### PR TITLE
feat: port rule promise/no-native

### DIFF
--- a/internal/plugins/promise/all.go
+++ b/internal/plugins/promise/all.go
@@ -6,6 +6,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/catch_or_return"
 	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/no_callback_in_promise"
 	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/no_multiple_resolved"
+	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/no_native"
 	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/no_nesting"
 	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/no_new_statics"
 	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/no_promise_in_callback"
@@ -25,6 +26,7 @@ func GetAllRules() []rule.Rule {
 		catch_or_return.CatchOrReturnRule,
 		no_callback_in_promise.NoCallbackInPromiseRule,
 		no_multiple_resolved.NoMultipleResolvedRule,
+		no_native.NoNativeRule,
 		no_nesting.NoNestingRule,
 		no_new_statics.NoNewStaticsRule,
 		no_promise_in_callback.NoPromiseInCallbackRule,

--- a/internal/plugins/promise/rules/no_native/no_native.go
+++ b/internal/plugins/promise/rules/no_native/no_native.go
@@ -1,0 +1,42 @@
+package no_native
+
+import (
+	"github.com/microsoft/TypeScript/tsc/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils/scope"
+)
+
+var NoNativeRule = rule.Rule{
+	Name:   "promise/no-native",
+	Schema: rule.EmptyArraySchema,
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		// Upstream accepts any authored definition in the global scope, even
+		// one in a different TypeScript namespace. Module and CommonJS wrapper
+		// bindings instead have to resolve the individual reference.
+		sourceType := ctx.LanguageOptions.EffectiveSourceType()
+		globalScope := sourceType == "script" ||
+			(sourceType == "commonjs" && !ast.IsInJSFile(ctx.SourceFile.AsNode()))
+		if globalScope && ctx.Refs.IsNameDefinedInFileWithMeaning(ctx.SourceFile.AsNode(), "Promise",
+			ast.SymbolFlagsValue|ast.SymbolFlagsType|ast.SymbolFlagsNamespace|ast.SymbolFlagsAlias) {
+			return nil
+		}
+
+		return rule.RuleListeners{
+			ast.KindIdentifier: func(node *ast.Node) {
+				if node.Text() != "Promise" || !scope.IsReferenceIdentifier(node) {
+					return
+				}
+				meaning := scope.ESLintReferenceSpace(node).DeclarationMeaning()
+				if ctx.Refs.ResolveInFileWithMeaning(node, meaning) != nil {
+					return
+				}
+				// Configured globals, inline globals and TypeScript's libraries
+				// do not supply the file-local definition required by this rule.
+				ctx.ReportNode(node, rule.RuleMessage{
+					Id:          "name",
+					Description: `"Promise" is not defined.`,
+				})
+			},
+		}
+	},
+}

--- a/internal/plugins/promise/rules/no_native/no_native.go
+++ b/internal/plugins/promise/rules/no_native/no_native.go
@@ -2,6 +2,7 @@ package no_native
 
 import (
 	"github.com/microsoft/TypeScript/tsc/shim/ast"
+	"github.com/microsoft/TypeScript/tsc/shim/scanner"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils/scope"
 )
@@ -13,11 +14,8 @@ var NoNativeRule = rule.Rule{
 		// Upstream accepts any authored definition in the global scope, even
 		// one in a different TypeScript namespace. Module and CommonJS wrapper
 		// bindings instead have to resolve the individual reference.
-		sourceType := ctx.LanguageOptions.EffectiveSourceType()
-		globalScope := sourceType == "script" ||
-			(sourceType == "commonjs" && !ast.IsInJSFile(ctx.SourceFile.AsNode()))
-		if globalScope && ctx.Refs.IsNameDefinedInFileWithMeaning(ctx.SourceFile.AsNode(), "Promise",
-			ast.SymbolFlagsValue|ast.SymbolFlagsType|ast.SymbolFlagsNamespace|ast.SymbolFlagsAlias) {
+		if !ctx.Refs.HasNonGlobalProgramScope() && ctx.Refs.IsNameDefinedInFileWithMeaning(
+			ctx.SourceFile.AsNode(), "Promise", scope.ReferenceDual.DeclarationMeaning()) {
 			return nil
 		}
 
@@ -32,7 +30,10 @@ var NoNativeRule = rule.Rule{
 				}
 				// Configured globals, inline globals and TypeScript's libraries
 				// do not supply the file-local definition required by this rule.
-				ctx.ReportNode(node, rule.RuleMessage{
+				// Identifiers already have their exact token end. Reuse tsgo's
+				// trivia handling without allocating a scanner per diagnostic.
+				start := scanner.GetTokenPosOfNode(node, ctx.SourceFile, false)
+				ctx.ReportRange(node.Loc.WithPos(start), rule.RuleMessage{
 					Id:          "name",
 					Description: `"Promise" is not defined.`,
 				})

--- a/internal/plugins/promise/rules/no_native/no_native.md
+++ b/internal/plugins/promise/rules/no_native/no_native.md
@@ -1,0 +1,39 @@
+# no-native
+
+Require declaring or importing `Promise` before using it.
+
+## Rule Details
+
+This rule helps projects that use a Promise library such as Bluebird or target an environment without native promises. Each file must provide its own `Promise` binding instead of relying on a global implementation.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+const x = Promise.resolve('bad');
+new Promise((resolve) => resolve());
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+const Promise = require('bluebird');
+const x = Promise.resolve('good');
+```
+
+```javascript
+import Promise from 'bluebird';
+const x = Promise.resolve('good');
+```
+
+Parameters and other local declarations named `Promise` also satisfy the rule. Accessing a property such as `window.Promise` does not reference the bare `Promise` binding and is allowed.
+
+Configuring `Promise` in `languageOptions.globals`, adding a `/* global Promise */` comment, or selecting an ECMAScript version with native promises does not satisfy this rule.
+
+## Options
+
+This rule has no options.
+
+## Original Documentation
+
+- [eslint-plugin-promise: no-native](https://github.com/eslint-community/eslint-plugin-promise/blob/v7.3.0/docs/rules/no-native.md)
+- [Source code](https://github.com/eslint-community/eslint-plugin-promise/blob/v7.3.0/rules/no-native.js)

--- a/internal/plugins/promise/rules/no_native/no_native_extras_test.go
+++ b/internal/plugins/promise/rules/no_native/no_native_extras_test.go
@@ -5,9 +5,13 @@ package no_native_test
 import (
 	"testing"
 
+	"github.com/microsoft/TypeScript/tsc/shim/ast"
+	"github.com/microsoft/TypeScript/tsc/shim/core"
+	"github.com/microsoft/TypeScript/tsc/shim/tspath"
 	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/no_native"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
+	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
 // N/A: no fixes, suggestions or options; literal values are never compared.
@@ -119,6 +123,32 @@ func TestNoNativeExtras(t *testing.T) {
 			// Default parameters preserve their outer binding
 			{
 				Code: `const Promise = polyfill; function f(value = Promise) { const Promise = local; }`,
+			},
+			// Type exports skip a value shadow and find the outer type
+			{
+				Code: "type Promise = {}; namespace N { const Promise = lib; export type { Promise }; }",
+			},
+			// Namespace re-exports preserve an outer lexical binding
+			{
+				Code: "const Promise = lib; namespace N { export { Promise } from \"x\"; Promise; }",
+			},
+			// ESTree erases parentheses around a bare type export
+			{
+				Code: "interface Promise {} export default (((Promise)));",
+			},
+			// A class expression decorator can use an outer binding
+			{
+				Code: "const Promise = lib; const C = @Promise class Promise {};",
+			},
+			// A synthesized JSDoc import cannot hide an authored import
+			{
+				Code:     "/** @import { Promise } from \"x\" */\nimport { Promise } from \"y\";\nPromise;",
+				FileName: "file.js",
+			},
+			// Espree treats a namespaced JSX tag as a label
+			{
+				Code:     "const v = <Promise:part />;",
+				FileName: "file.jsx",
 			},
 		},
 		[]rule_tester.InvalidTestCase{
@@ -353,6 +383,160 @@ Promise.resolve();`,
 				Code:   `for (const Promise of implementations) { Promise.resolve(); } Promise;`,
 				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 63, EndLine: 1, EndColumn: 70}},
 			},
+			// A type export cannot resolve its own value-only alias
+			{
+				Code: "namespace N { const Promise = lib; export type { Promise }; }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 50, EndLine: 1, EndColumn: 57},
+				},
+			},
+			// A namespace re-export does not bind a lexical reference
+			{
+				Code: "namespace N { export { Promise } from \"x\"; Promise; }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 44, EndLine: 1, EndColumn: 51},
+				},
+			},
+			// Dotted namespace segments are not global scope definitions
+			{
+				Code:            "namespace Promise.Inner {} Promise;",
+				LanguageOptions: rule.LanguageOptions{SourceType: "script"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 28, EndLine: 1, EndColumn: 35},
+				},
+			},
+			// Import type qualifiers are labels but type arguments are references
+			{
+				Code: "type P = import(\"x\").Promise; type Q = import(\"x\").Box<Promise<void>>;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 56, EndLine: 1, EndColumn: 63},
+				},
+			},
+			// A type predicate subject is a value reference
+			{
+				Code: "type Promise = {}; function test(value: unknown): Promise is string { return true; }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 51, EndLine: 1, EndColumn: 58},
+				},
+			},
+			// An inferred type parameter is unavailable in the false branch
+			{
+				Code: "type P<T> = T extends infer Promise ? Promise : Promise;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 49, EndLine: 1, EndColumn: 56},
+				},
+			},
+			// A mapped type parameter stays inside its mapped type
+			{
+				Code: "type P = { [Promise in string as Promise]: Promise }; Promise;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 55, EndLine: 1, EndColumn: 62},
+				},
+			},
+			// A class expression name is unavailable in its own decorator
+			{
+				Code: "const C = @Promise class Promise { method() { return Promise; } };",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 12, EndLine: 1, EndColumn: 19},
+				},
+			},
+			// TypeScript treats a namespaced JSX tag as a reference
+			{
+				Code:     "const v = <Promise:part />;",
+				FileName: "file.tsx",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 12, EndLine: 1, EndColumn: 19},
+				},
+			},
+			// A closure in a parameter initializer cannot see body bindings
+			{
+				Code: "function f(value = () => Promise) { var Promise; return value(); }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 26, EndLine: 1, EndColumn: 33},
+				},
+			},
+			// Token ranges skip JavaScript Unicode trivia and preserve CRLF positions
+			{
+				Code: "/* 😀 */\u00a0\ufeffPromise; // trailing\r\n/* lead */\tPromise;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 11, EndLine: 1, EndColumn: 18},
+					{MessageId: "name", Message: noNativeMessage, Line: 2, Column: 12, EndLine: 2, EndColumn: 19},
+				},
+			},
+			// Token ranges exclude hashbang and leading JSDoc comments
+			{
+				Code:     "#!/usr/bin/env node\n/** leading */ Promise;",
+				FileName: "file.js",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "name", Message: noNativeMessage, Line: 2, Column: 16, EndLine: 2, EndColumn: 23},
+				},
+			},
 		},
 	)
+}
+
+func TestNoNativeCheckerInvariant(t *testing.T) {
+	root := noNativeTestRoot()
+	filePath := tspath.ResolvePath(root.Dir, "no-native-checker.ts")
+	crossFilePath := tspath.ResolvePath(root.Dir, "no-native-cross-file.ts")
+	ambientPath := tspath.ResolvePath(root.Dir, "no-native-ambient.d.ts")
+	fs := utils.NewOverlayVFS(root.FS, map[string]string{
+		filePath:      "Promise.resolve();\nlet value: Promise<void>;",
+		crossFilePath: "var Promise = implementation;",
+		ambientPath:   "interface Promise<T> {}",
+	})
+	program, err := utils.CreateProgram(true, fs, root.Dir, "tsconfig.allowJs.json", utils.CreateCompilerHost(root.Dir, fs))
+	if err != nil {
+		t.Fatal(err)
+	}
+	file := program.GetSourceFile(filePath)
+	if file == nil || program.GetSourceFile(crossFilePath) == nil || program.GetSourceFile(ambientPath) == nil {
+		t.Fatal("checker fixture must include the linted file and both external declarations")
+	}
+	checker, done := program.GetTypeChecker(t.Context())
+	t.Cleanup(done)
+	_, refsInit, language := rule.ResolveLanguageDefaults(filePath, rule.LanguageOptions{})
+	for _, withChecker := range []bool{false, true} {
+		name := "without checker"
+		if withChecker {
+			name = "with checker"
+		}
+		t.Run(name, func(t *testing.T) {
+			tc := checker
+			if !withChecker {
+				tc = nil
+			}
+			var diagnostics []rule.RuleDiagnostic
+			ctx := (rule.RuleContext{
+				SourceFile: file, TypeChecker: tc, LanguageOptions: language,
+				Refs: rule.NewRefStore(file, program.Options(), tc, refsInit),
+			}).WithReporter(no_native.NoNativeRule.Name, rule.SeverityError, func(d rule.RuleDiagnostic) {
+				diagnostics = append(diagnostics, d)
+			})
+			listeners := no_native.NoNativeRule.Run(ctx, nil)
+			var visit func(*ast.Node) bool
+			visit = func(node *ast.Node) bool {
+				if node.Kind == ast.KindIdentifier && node.Text() == "Promise" && checker.GetSymbolAtLocation(node) == nil {
+					t.Fatal("checker must resolve Promise from outside the linted file")
+				}
+				if callback := listeners[node.Kind]; callback != nil {
+					callback(node)
+				}
+				node.ForEachChild(visit)
+				return false
+			}
+			visit(file.AsNode())
+			want := []core.TextRange{core.NewTextRange(0, 7), core.NewTextRange(30, 37)}
+			if len(diagnostics) != len(want) {
+				t.Fatalf("got %d diagnostics, want %d", len(diagnostics), len(want))
+			}
+			for i, d := range diagnostics {
+				if d.Range != want[i] || d.Message.Id != "name" || d.Message.Description != noNativeMessage ||
+					d.RuleName != no_native.NoNativeRule.Name || d.Severity != rule.SeverityError ||
+					d.FixesPtr != nil || d.Suggestions != nil {
+					t.Errorf("diagnostic %d: got %+v, want no-native at %v without edits", i, d, want[i])
+				}
+			}
+		})
+	}
 }

--- a/internal/plugins/promise/rules/no_native/no_native_extras_test.go
+++ b/internal/plugins/promise/rules/no_native/no_native_extras_test.go
@@ -1,0 +1,358 @@
+// Additional AST, scope and regression coverage for no-native.
+// The pinned upstream migration lives in no_native_upstream_test.go.
+package no_native_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/no_native"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// N/A: no fixes, suggestions or options; literal values are never compared.
+func TestNoNativeExtras(t *testing.T) {
+	rule_tester.RunRuleTester(noNativeTestRoot(), "tsconfig.allowJs.json", t, &no_native.NoNativeRule,
+		[]rule_tester.ValidTestCase{
+			// Locks in upstream isDeclared() arm 1: unrelated names do not declare Promise
+			{
+				Code: `const OtherPromise = library; OtherPromise.resolve();`,
+			},
+			// Locks in upstream isDeclared() arm 3: a script definition allows references
+			{
+				Code:            `Promise.resolve(); var Promise = polyfill;`,
+				LanguageOptions: rule.LanguageOptions{SourceType: "script"},
+			},
+			// Locks in upstream Program:exit: non-Promise globals and unresolved names are ignored
+			{
+				Code: `Map; Unknown; window.Promise; globalThis.Promise;`,
+			},
+			// Dimension 4: member names, keys and private names are not references
+			{
+				Code: `const object = { Promise: 1, "Promise": 2, 0: 3, Promise() {} }; object.Promise; object["Promise"]; class C { #Promise; Promise() {} }`,
+			},
+			// Dimension 4: JSX attributes are not references
+			{
+				Code:     `const x = <div Promise="yes" />;`,
+				FileName: "file.tsx",
+			},
+			// Dimension 4: local class declaration
+			{
+				Code: `class Promise {} new Promise();`,
+			},
+			// Dimension 4: function forms and async/generator variants
+			{
+				Code: `function Promise() {} Promise(); (function f(Promise) { return Promise; }); ((Promise) => Promise); (async function* f(Promise) { yield Promise; });`,
+			},
+			// Dimension 4: parameter defaults can reference a parameter binding
+			{
+				Code: `function f(Promise, value = Promise.resolve()) { return value; }`,
+			},
+			// Dimension 4: destructuring and rest bindings
+			{
+				Code: `const { Promise } = library; function f(...Promise) { return Promise; } Promise.resolve();`,
+			},
+			// Script global definitions suppress references across namespaces
+			{
+				Code:            `interface Promise<T> {} Promise.resolve();`,
+				LanguageOptions: rule.LanguageOptions{SourceType: "script"},
+			},
+			// Script value definition also permits type references
+			{
+				Code:            `const Promise = polyfill; let p: Promise<void>;`,
+				LanguageOptions: rule.LanguageOptions{SourceType: "script"},
+			},
+			// CommonJS TypeScript retains the parser global scope
+			{
+				Code:            `type Promise = {}; Promise.resolve();`,
+				LanguageOptions: rule.LanguageOptions{SourceType: "commonjs"},
+			},
+			// CommonJS local declarations
+			{
+				Code:            `const Promise = require("bluebird"); module.exports = Promise;`,
+				FileName:        "file.cjs",
+				LanguageOptions: rule.LanguageOptions{SourceType: "commonjs"},
+			},
+			// Type-only imports follow the upstream scope manager
+			{
+				Code: `import type Promise from "bluebird"; Promise.resolve();`,
+			},
+			// Named and namespace imports bind locally
+			{
+				Code: `import { Promise } from "library"; Promise.resolve();`,
+			},
+			// Namespace import
+			{
+				Code: `import * as Promise from "library"; Promise.resolve();`,
+			},
+			// Re-export labels are not references
+			{
+				Code: `export { Promise } from "library"; export * as Promise from "library";`,
+			},
+			// Ambient declarations authored in this file
+			{
+				Code: `declare const Promise: any; Promise.resolve();`,
+			},
+			// Real-user: issue #2 explicit Bluebird import
+			{
+				Code: `import Promise from "bluebird"; export default Promise.resolve(null);`,
+			},
+			// Disabled globals still permit local declarations
+			{
+				Code:    `const Promise = polyfill; Promise.resolve();`,
+				Globals: map[string]any{"Promise": "off"},
+			},
+			// ES5 script var binding
+			{
+				Code:            `var Promise = polyfill; Promise.resolve();`,
+				FileName:        "file.js",
+				LanguageOptions: rule.LanguageOptions{SourceType: "script", ECMAVersion: 5},
+			},
+			// Declaration hoisting
+			{
+				Code: `Promise.resolve(); const Promise = polyfill;`,
+			},
+			// Labels are not references
+			{
+				Code: `Promise: for (;;) { break Promise; }`,
+			},
+			// Default parameters preserve their outer binding
+			{
+				Code: `const Promise = polyfill; function f(value = Promise) { const Promise = local; }`,
+			},
+		},
+		[]rule_tester.InvalidTestCase{
+			// Locks in upstream isDeclared() arm 2: an implicit global has no definition
+			{
+				Code:    `Promise;`,
+				Globals: map[string]any{"Promise": "readonly"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 1, EndLine: 1, EndColumn: 8}},
+			},
+			// Locks in upstream validatePromiseReference(): unresolved reads and writes report
+			{
+				Code: `Promise; typeof Promise; Promise = polyfill;`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 1, EndLine: 1, EndColumn: 8},
+					{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 17, EndLine: 1, EndColumn: 24},
+					{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 26, EndLine: 1, EndColumn: 33}},
+			},
+			// Dimension 4: parenthesized receivers and constructor
+			{
+				Code: `(Promise).resolve(); ((Promise)).reject(); new ((Promise))();`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 2, EndLine: 1, EndColumn: 9},
+					{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 24, EndLine: 1, EndColumn: 31},
+					{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 50, EndLine: 1, EndColumn: 57}},
+			},
+			// Dimension 4: TS wrappers still reference the identifier
+			{
+				Code: `Promise!.resolve(); (Promise as any).resolve(); (Promise satisfies object).resolve();`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 1, EndLine: 1, EndColumn: 8},
+					{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 22, EndLine: 1, EndColumn: 29},
+					{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 50, EndLine: 1, EndColumn: 57}},
+			},
+			// Dimension 4: optional property access and calls
+			{
+				Code: `Promise?.resolve(); Promise?.(); Promise.resolve?.();`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 1, EndLine: 1, EndColumn: 8},
+					{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 21, EndLine: 1, EndColumn: 28},
+					{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 34, EndLine: 1, EndColumn: 41}},
+			},
+			// Dimension 4: computed member access
+			{
+				Code: "Promise[\"resolve\"](); Promise[`resolve`](); Promise[0]; Promise[Symbol.iterator];",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 1, EndLine: 1, EndColumn: 8},
+					{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 23, EndLine: 1, EndColumn: 30},
+					{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 45, EndLine: 1, EndColumn: 52},
+					{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 57, EndLine: 1, EndColumn: 64}},
+			},
+			// Dimension 4: shorthand and computed keys reference Promise
+			{
+				Code: `const object = { Promise, [Promise]: 1 };`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 18, EndLine: 1, EndColumn: 25},
+					{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 28, EndLine: 1, EndColumn: 35}},
+			},
+			// Dimension 4: JSX references its opening tag
+			{
+				Code:     `const x = <Promise></Promise>;`,
+				FileName: "file.jsx",
+				Errors:   []rule_tester.InvalidTestCaseError{{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 12, EndLine: 1, EndColumn: 19}},
+			},
+			// Dimension 4: TypeScript JSX references both tags
+			{
+				Code:     `const x = <Promise></Promise>;`,
+				FileName: "file.tsx",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 12, EndLine: 1, EndColumn: 19},
+					{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 22, EndLine: 1, EndColumn: 29}},
+			},
+			// Dimension 4: dotted JSX tags
+			{
+				Code:     `const x = <Promise.Component value={Promise} />;`,
+				FileName: "file.tsx",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 12, EndLine: 1, EndColumn: 19},
+					{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 37, EndLine: 1, EndColumn: 44}},
+			},
+			// Dimension 4: class expressions do not leak their name
+			{
+				Code:   `const C = class Promise { method() { return Promise; } }; Promise;`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 59, EndLine: 1, EndColumn: 66}},
+			},
+			// Dimension 4: function expressions do not leak their name
+			{
+				Code:   `const f = function Promise() { return Promise; }; Promise;`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 51, EndLine: 1, EndColumn: 58}},
+			},
+			// Dimension 4: method, field arrow and static block boundaries
+			{
+				Code: `class C { method(Promise) { return Promise; } field = () => Promise; static { const Promise = polyfill; Promise.resolve(); } } Promise;`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 61, EndLine: 1, EndColumn: 68},
+					{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 128, EndLine: 1, EndColumn: 135}},
+			},
+			// Dimension 4: nested parameter and block scopes
+			{
+				Code:   `function outer(Promise) { return () => Promise.resolve(); } { let Promise = polyfill; Promise.resolve(); } Promise.resolve();`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 108, EndLine: 1, EndColumn: 115}},
+			},
+			// Dimension 4: body bindings cannot reach a parameter initializer
+			{
+				Code:   `function f(value = Promise.resolve()) { var Promise = polyfill; return Promise; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 20, EndLine: 1, EndColumn: 27}},
+			},
+			// Dimension 4: catch scope
+			{
+				Code:   `try {} catch (Promise) { Promise.resolve(); } Promise;`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 47, EndLine: 1, EndColumn: 54}},
+			},
+			// Dimension 4: object spread and destructuring defaults
+			{
+				Code: `const object = { ...Promise, value: Promise }; const { value = Promise } = object;`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 21, EndLine: 1, EndColumn: 28},
+					{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 37, EndLine: 1, EndColumn: 44},
+					{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 64, EndLine: 1, EndColumn: 71}},
+			},
+			// Dimension 4: destructuring writes do not declare Promise
+			{
+				Code: `({ Promise } = library); [Promise] = values;`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 4, EndLine: 1, EndColumn: 11},
+					{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 27, EndLine: 1, EndColumn: 34}},
+			},
+			// Dimension 4: empty containers and no arguments
+			{
+				Code:   `class C {} function f() {} const {} = {}; new Promise();`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 47, EndLine: 1, EndColumn: 54}},
+			},
+			// Dimension 4: heritage references
+			{
+				Code: `class Child extends Promise {} class Other implements Promise<void> {}`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 21, EndLine: 1, EndColumn: 28},
+					{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 55, EndLine: 1, EndColumn: 62}},
+			},
+			// Dimension 4: type references also require an import or declaration
+			{
+				Code: `let value: Promise<void>; type Constructor = typeof Promise;`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 12, EndLine: 1, EndColumn: 19},
+					{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 53, EndLine: 1, EndColumn: 60}},
+			},
+			// Dimension 4: type parameters resolve only in type space
+			{
+				Code:   `function f<Promise>(value: Promise) { return Promise.resolve(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 46, EndLine: 1, EndColumn: 53}},
+			},
+			// Dimension 4: type declarations do not define a module value
+			{
+				Code:   `interface Promise<T> {} let p: Promise<void>; Promise.resolve();`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 47, EndLine: 1, EndColumn: 54}},
+			},
+			// Dimension 4: type alias does not define a module value
+			{
+				Code:   `type Promise = {}; Promise.resolve();`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 20, EndLine: 1, EndColumn: 27}},
+			},
+			// Dimension 4: value declaration does not define a module type
+			{
+				Code:   `const Promise = polyfill; let p: Promise<void>;`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 34, EndLine: 1, EndColumn: 41}},
+			},
+			// CommonJS native references
+			{
+				Code:            `module.exports = Promise.resolve();`,
+				FileName:        "file.cjs",
+				LanguageOptions: rule.LanguageOptions{SourceType: "commonjs"},
+				Errors:          []rule_tester.InvalidTestCaseError{{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 18, EndLine: 1, EndColumn: 25}},
+			},
+			// Aliased import does not bind Promise
+			{
+				Code:   `import { Promise as Other } from "library"; Promise.resolve();`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 45, EndLine: 1, EndColumn: 52}},
+			},
+			// Local export and type export reference the binding
+			{
+				Code: `export { Promise }; export type { Promise as P };`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 10, EndLine: 1, EndColumn: 17},
+					{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 35, EndLine: 1, EndColumn: 42}},
+			},
+			// Global augmentation does not supply a local definition
+			{
+				Code:   `export {}; declare global { var Promise: any; } Promise.resolve();`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 49, EndLine: 1, EndColumn: 56}},
+			},
+			// JSDoc type declarations do not bind runtime references
+			{
+				Code: `/** @typedef {object} Promise */
+Promise.resolve();`,
+				FileName: "file.js",
+				Errors:   []rule_tester.InvalidTestCaseError{{MessageId: "name", Message: noNativeMessage, Line: 2, Column: 1, EndLine: 2, EndColumn: 8}},
+			},
+			// JSDoc cast wrappers preserve runtime references
+			{
+				Code:     `(/** @type {any} */ (Promise)).resolve();`,
+				FileName: "file.js",
+				Errors:   []rule_tester.InvalidTestCaseError{{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 22, EndLine: 1, EndColumn: 29}},
+			},
+			// Dimension 4: multiline and UTF-16 diagnostic ranges
+			{
+				Code: `const label = "😀"; Promise.resolve();
+function f() {
+  return (
+    Promise
+  );
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 21, EndLine: 1, EndColumn: 28},
+					{MessageId: "name", Message: noNativeMessage, Line: 4, Column: 5, EndLine: 4, EndColumn: 12}},
+			},
+			// Escaped identifier spelling uses the original range
+			{
+				Code:   `\u0050\u0072\u006f\u006d\u0069\u0073\u0065.resolve();`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 1, EndLine: 1, EndColumn: 43}},
+			},
+			// Real-user: issue #2 missing a Promise import
+			{
+				Code:   `export default Promise.resolve(null);`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 16, EndLine: 1, EndColumn: 23}},
+			},
+			// Real-user: issue #611 native globals must still report
+			{
+				Code:    `const ready = Promise.resolve(); ready.then(() => Promise.resolve());`,
+				Globals: map[string]any{"Promise": "readonly"},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 15, EndLine: 1, EndColumn: 22},
+					{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 51, EndLine: 1, EndColumn: 58}},
+			},
+			// Inline globals cannot replace an authored binding
+			{
+				Code: `/* global Promise */
+Promise.resolve();`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "name", Message: noNativeMessage, Line: 2, Column: 1, EndLine: 2, EndColumn: 8}},
+			},
+			// ES5 unresolved references
+			{
+				Code:            `new Promise(function () {});`,
+				FileName:        "file.js",
+				LanguageOptions: rule.LanguageOptions{SourceType: "script", ECMAVersion: 5},
+				Errors:          []rule_tester.InvalidTestCaseError{{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 5, EndLine: 1, EndColumn: 12}},
+			},
+			// Loop binding is limited to its loop
+			{
+				Code:   `for (const Promise of implementations) { Promise.resolve(); } Promise;`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 63, EndLine: 1, EndColumn: 70}},
+			},
+		},
+	)
+}

--- a/internal/plugins/promise/rules/no_native/no_native_upstream_test.go
+++ b/internal/plugins/promise/rules/no_native/no_native_upstream_test.go
@@ -1,0 +1,114 @@
+// Tests migrated from eslint-plugin-promise v7.3.0 __tests__/no-native.js
+// and docs/rules/no-native.md. Additional coverage lives in no_native_extras_test.go.
+package no_native_test
+
+import (
+	"testing"
+
+	"github.com/microsoft/TypeScript/tsc/shim/tspath"
+	"github.com/web-infra-dev/rslint/internal/plugins/promise/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/no_native"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+const noNativeMessage = `"Promise" is not defined.`
+
+func noNativeTestRoot() rule_tester.Root {
+	root := fixtures.GetRootDir()
+	root.FS = utils.NewOverlayVFS(root.FS, map[string]string{
+		tspath.ResolvePath(root.Dir, "tsconfig.allowJs.json"): `{
+			"extends": "./tsconfig.json",
+			"compilerOptions": { "allowJs": true }
+		}`,
+	})
+	return root
+}
+
+func TestNoNativeUpstream(t *testing.T) {
+	for _, filename := range []string{"file.js", "file.ts"} {
+		t.Run(filename, func(t *testing.T) {
+			rule_tester.RunRuleTester(noNativeTestRoot(), "tsconfig.allowJs.json", t, &no_native.NoNativeRule,
+				[]rule_tester.ValidTestCase{
+					// local variable
+					{
+						Code:     `var Promise = null; function x() { return Promise.resolve("hi"); }`,
+						FileName: filename,
+					},
+					// polyfill fallback
+					{
+						Code:     `var Promise = window.Promise || require("bluebird"); var x = Promise.reject();`,
+						FileName: filename,
+					},
+					// import
+					{
+						Code:     `import Promise from "bluebird"; var x = Promise.reject();`,
+						FileName: filename,
+					},
+					// documentation valid
+					{
+						Code: `const Promise = require('bluebird')
+const x = Promise.resolve('good')`,
+						FileName: filename,
+					},
+				},
+				[]rule_tester.InvalidTestCase{
+					// constructor
+					{
+						Code:     `new Promise(function(reject, resolve) { })`,
+						FileName: filename,
+						Errors:   []rule_tester.InvalidTestCaseError{{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 5, EndLine: 1, EndColumn: 12}},
+					},
+					// static method
+					{
+						Code:     `Promise.resolve()`,
+						FileName: filename,
+						Errors:   []rule_tester.InvalidTestCaseError{{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 1, EndLine: 1, EndColumn: 8}},
+					},
+					// browser environment
+					{
+						Code:     `new Promise(function(reject, resolve) { })`,
+						FileName: filename,
+						Globals:  map[string]any{"Promise": false, "window": false},
+						Errors:   []rule_tester.InvalidTestCaseError{{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 5, EndLine: 1, EndColumn: 12}},
+					},
+					// node environment
+					{
+						Code:     `new Promise(function(reject, resolve) { })`,
+						FileName: filename,
+						Globals:  map[string]any{"Promise": false, "global": false},
+						Errors:   []rule_tester.InvalidTestCaseError{{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 5, EndLine: 1, EndColumn: 12}},
+					},
+					// es6 environment
+					{
+						Code:            `Promise.resolve()`,
+						FileName:        filename,
+						LanguageOptions: rule.LanguageOptions{ECMAVersion: 2015},
+						Errors:          []rule_tester.InvalidTestCaseError{{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 1, EndLine: 1, EndColumn: 8}},
+					},
+					// writable global
+					{
+						Code:     `Promise.resolve()`,
+						FileName: filename,
+						Globals:  map[string]any{"Promise": true},
+						Errors:   []rule_tester.InvalidTestCaseError{{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 1, EndLine: 1, EndColumn: 8}},
+					},
+					// disabled global
+					{
+						Code:     `Promise.resolve()`,
+						FileName: filename,
+						Globals:  map[string]any{"Promise": "off"},
+						Errors:   []rule_tester.InvalidTestCaseError{{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 1, EndLine: 1, EndColumn: 8}},
+					},
+					// documentation invalid
+					{
+						Code:     `const x = Promise.resolve('bad')`,
+						FileName: filename,
+						Errors:   []rule_tester.InvalidTestCaseError{{MessageId: "name", Message: noNativeMessage, Line: 1, Column: 11, EndLine: 1, EndColumn: 18}},
+					},
+				},
+			)
+		})
+	}
+}

--- a/packages/rslint-test-tools/rstack.config.mts
+++ b/packages/rslint-test-tools/rstack.config.mts
@@ -688,6 +688,7 @@ define.test({
     './tests/eslint-plugin-promise/rules/catch-or-return.test.ts',
     './tests/eslint-plugin-promise/rules/no-callback-in-promise.test.ts',
     './tests/eslint-plugin-promise/rules/no-multiple-resolved.test.ts',
+    './tests/eslint-plugin-promise/rules/no-native.test.ts',
     './tests/eslint-plugin-promise/rules/no-nesting.test.ts',
     './tests/eslint-plugin-promise/rules/no-new-statics.test.ts',
     './tests/eslint-plugin-promise/rules/no-promise-in-callback.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-promise/rules/no-native.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-promise/rules/no-native.test.ts
@@ -1,0 +1,134 @@
+// Upstream: eslint-plugin-promise v7.3.0 __tests__/no-native.js and rule docs.
+import path from 'node:path';
+
+import { lint } from '@rslint/core/internal';
+
+interface TestCase {
+  name: string;
+  code: string;
+  globals?: Record<string, boolean | 'off'>;
+  column?: number;
+}
+
+// The suite's shared wrapper does not assert ranges or accept globals.
+// Use IPC directly so the upstream global-configuration cases are exercised.
+const cases: TestCase[] = [
+  {
+    name: 'local variable',
+    code: 'var Promise = null; function x() { return Promise.resolve("hi"); }',
+  },
+  {
+    name: 'polyfill fallback',
+    code: 'var Promise = window.Promise || require("bluebird"); var x = Promise.reject();',
+  },
+  {
+    name: 'import',
+    code: 'import Promise from "bluebird"; var x = Promise.reject();',
+  },
+  {
+    name: 'constructor',
+    code: 'new Promise(function(reject, resolve) { })',
+    column: 5,
+  },
+  {
+    name: 'static method',
+    code: 'Promise.resolve()',
+    column: 1,
+  },
+  // Relevant globals from the upstream browser/node environments.
+  {
+    name: 'browser environment',
+    code: 'new Promise(function(reject, resolve) { })',
+    globals: { Promise: false, window: false },
+    column: 5,
+  },
+  {
+    name: 'node environment',
+    code: 'new Promise(function(reject, resolve) { })',
+    globals: { Promise: false, global: false },
+    column: 5,
+  },
+  {
+    name: 'es6 environment',
+    code: 'Promise.resolve()',
+    column: 1,
+  },
+  {
+    name: 'writable global',
+    code: 'Promise.resolve()',
+    globals: { Promise: true },
+    column: 1,
+  },
+  {
+    name: 'disabled global',
+    code: 'Promise.resolve()',
+    globals: { Promise: 'off' },
+    column: 1,
+  },
+  {
+    name: 'documentation valid',
+    code: "const Promise = require('bluebird')\nconst x = Promise.resolve('good')",
+  },
+  {
+    name: 'documentation invalid',
+    code: "const x = Promise.resolve('bad')",
+    column: 11,
+  },
+];
+
+describe.each(['js', 'ts'])('promise/no-native (%s)', (extension) => {
+  for (const testCase of cases) {
+    test(testCase.name, async () => {
+      const filename = path.resolve(
+        import.meta.dirname,
+        `virtual.${extension}`,
+      );
+      const result = await lint({
+        workingDirectory: import.meta.dirname,
+        configDirectory: import.meta.dirname,
+        config: [
+          {
+            plugins: ['promise'],
+            languageOptions: {
+              ecmaVersion: 2015,
+              sourceType: 'module',
+              globals: testCase.globals,
+            },
+            rules: { 'promise/no-native': 'error' },
+          },
+        ],
+        fileContents: { [filename]: testCase.code },
+      });
+
+      expect(result.fileCount).toBe(1);
+      expect(result.ruleCount).toBe(1);
+      const expected = testCase.column
+        ? [
+            {
+              ruleName: 'promise/no-native',
+              messageId: 'name',
+              message: '"Promise" is not defined.',
+              severity: 'error',
+              range: {
+                start: { line: 1, column: testCase.column },
+                end: { line: 1, column: testCase.column + 7 },
+              },
+              fixes: [],
+              suggestions: [],
+            },
+          ]
+        : [];
+      expect(
+        result.diagnostics.map((diagnostic) => ({
+          ruleName: diagnostic.ruleName,
+          messageId: diagnostic.messageId,
+          message: diagnostic.message,
+          severity: diagnostic.severity,
+          range: diagnostic.range,
+          fixes: diagnostic.fixes ?? [],
+          suggestions: diagnostic.suggestions ?? [],
+        })),
+      ).toEqual(expected);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Port `promise/no-native` from eslint-plugin-promise v7.3.0. Global or undefined `Promise` references now report `"Promise" is not defined.`; declarations and imports in the file satisfy the rule. Register the native rule and add documentation and the complete upstream test mirror.

Reuse rslint's reference classification, declaration-space resolution and program-scope facts, together with tsgo's binder and token-position API. Preserve JavaScript and TypeScript behavior for configured globals, shadowing, type references, exports, decorators, JSDoc and JSX. Library, ambient and cross-file declarations do not suppress reports, even when a type checker is available.

Profiling found that trimming each diagnostic range allocated a scanner. Use `GetTokenPosOfNode` and the identifier's existing end position to avoid that allocation while preserving comments, Unicode trivia, escaped identifiers and UTF-16 ranges.

Validation:

- 104 Go RuleTester cases plus checker-on/off regressions pass; the native catalog registration check also passes.
- Rebuilt the native binary and passed all 24 JS/TS IPC cases with `CI=true`, with no skips.
- Differential checks against ESLint 10.9.0, eslint-plugin-promise 7.3.0 and typescript-eslint 8.65.0 match 186 diagnostics across 269 additional syntax/scope inputs and 133 diagnostics across 16 real source files. Checks include message IDs, text, severity, full ranges and absence of edits.
- Scoped Go lint, TypeScript typecheck, JS lint, spell checking and formatting pass.

Temporary Go benchmarks compare the original and final implementations in the same test executable, with a fresh reference store per file and diagnostic-count assertions. On Apple M5 Max, ten samples with `-cpu=1 -benchtime=200ms` give the following medians for 512-reference inputs. These measurements include rule initialization and callbacks, excluding parsing, binding and traversal.

| Input | Before | After | Change |
| --- | ---: | ---: | ---: |
| Native Promise | 53.2 μs | 29.5 μs | -44.5% |
| Mixed type/value spaces | 107.4 μs | 82.2 μs | -23.4% |
| Nested scopes | 71.2 μs | 45.8 μs | -35.7% |

Reporting inputs drop from 82,576 B / 517 allocations to 656 B / 5 allocations per file. Local/imported bindings remain effectively unchanged. Benchmark sources and profiles are not included in this PR.

## Related Links

- [ESLint rule documentation](https://github.com/eslint-community/eslint-plugin-promise/blob/v7.3.0/docs/rules/no-native.md)
- [Source code](https://github.com/eslint-community/eslint-plugin-promise/blob/v7.3.0/rules/no-native.js)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
