### PR TITLE
refactor: move shared accessor helpers into utils

### DIFF
--- a/internal/rules/accessor_pairs/accessor_pairs.go
+++ b/internal/rules/accessor_pairs/accessor_pairs.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/microsoft/TypeScript/tsc/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
-	"github.com/web-infra-dev/rslint/internal/rules/accessorutil"
 	"github.com/web-infra-dev/rslint/internal/utils"
+	"github.com/web-infra-dev/rslint/internal/utils/accessor"
 )
 
 //go:embed accessor_pairs.schema.json
@@ -57,7 +57,7 @@ const (
 // accessorGroup keeps the accessors belonging to one shared key. The key
 // helper preserves ESLint's distinct static, private, and dynamic classes.
 type accessorGroup struct {
-	key      accessorutil.Key
+	key      accessor.Key
 	isStatic bool
 	getters  []*ast.Node
 	setters  []*ast.Node
@@ -76,11 +76,11 @@ func checkList(ctx rule.RuleContext, members []*ast.Node, opts Options, kind con
 		if !isGetter && !isSetter {
 			continue
 		}
-		key := accessorutil.MakeKey(m)
+		key := accessor.MakeKey(m)
 		isStatic := distinguishStatic && ast.IsStatic(m)
 		var group *accessorGroup
 		for _, g := range groups {
-			if g.isStatic == isStatic && accessorutil.KeysEqual(ctx.SourceFile, g.key, key) {
+			if g.isStatic == isStatic && accessor.KeysEqual(ctx.SourceFile, g.key, key) {
 				group = g
 				break
 			}

--- a/internal/rules/grouped_accessor_pairs/grouped_accessor_pairs.go
+++ b/internal/rules/grouped_accessor_pairs/grouped_accessor_pairs.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/microsoft/TypeScript/tsc/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
-	"github.com/web-infra-dev/rslint/internal/rules/accessorutil"
 	"github.com/web-infra-dev/rslint/internal/utils"
+	"github.com/web-infra-dev/rslint/internal/utils/accessor"
 )
 
 //go:embed grouped_accessor_pairs.schema.json
@@ -36,7 +36,7 @@ func parseOptions(options []any) Options {
 }
 
 type accessorGroup struct {
-	key         accessorutil.Key
+	key         accessor.Key
 	getterIndex int
 	setterIndex int
 	getterCount int
@@ -78,10 +78,10 @@ func checkList(ctx rule.RuleContext, headLocator *utils.FunctionHeadRangeLocator
 		if !include(member) || (member.Kind != ast.KindGetAccessor && member.Kind != ast.KindSetAccessor) {
 			continue
 		}
-		key := accessorutil.MakeKey(member)
+		key := accessor.MakeKey(member)
 		groupIndex := -1
 		for index := range groups {
-			if accessorutil.KeysEqual(ctx.SourceFile, groups[index].key, key) {
+			if accessor.KeysEqual(ctx.SourceFile, groups[index].key, key) {
 				groupIndex = index
 				break
 			}

--- a/internal/utils/accessor/accessor_key.go
+++ b/internal/utils/accessor/accessor_key.go
@@ -1,4 +1,4 @@
-package accessorutil
+package accessor
 
 import (
 	"github.com/microsoft/TypeScript/tsc/shim/ast"


### PR DESCRIPTION
Move the shared accessor-key helpers from `internal/rules/accessorutil` to `internal/utils/accessor`, and update `accessor-pairs` and `grouped-accessor-pairs` to use the `accessor` package. Keeping the helper outside the rule implementation directory prevents the website rule manifest from listing it as an ESLint rule. The helper implementation is unchanged apart from its package name.

Validation:
- `go test ./internal/utils/accessor ./internal/rules/accessor_pairs ./internal/rules/grouped_accessor_pairs` passed: the helper package compiles and both existing rule suites pass.
- `golangci-lint run --new-from-merge-base=origin/main ./internal/utils/accessor ./internal/rules/accessor_pairs ./internal/rules/grouped_accessor_pairs` passed.
- Ran `node scripts/gen-rule-manifest.js` before and after the move: the manifest changes from 639 entries to 638, removing only `eslint:accessorutil`; every other entry is identical.
- Explicit-file spell checks and `pnpm run format:check` passed.

Historical release metadata is corrected separately in #2078.
