### PR TITLE
feat(rstest): add prefer-equality-matcher rule

### DIFF
--- a/internal/plugins/jest/rules/prefer_equality_matcher/prefer_equality_matcher.go
+++ b/internal/plugins/jest/rules/prefer_equality_matcher/prefer_equality_matcher.go
@@ -3,7 +3,6 @@ package prefer_equality_matcher
 import (
 	"github.com/microsoft/TypeScript/tsc/shim/ast"
 	"github.com/microsoft/TypeScript/tsc/shim/core"
-	"github.com/microsoft/TypeScript/tsc/shim/scanner"
 	jestUtils "github.com/web-infra-dev/rslint/internal/plugins/jest/utils"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	testFramework "github.com/web-infra-dev/rslint/internal/utils/test_framework"
@@ -43,15 +42,13 @@ var PreferEqualityMatcherRule = shared.NewRule(shared.Config{
 			return nil
 		}
 
-		leftText := scanner.GetSourceTextOfNodeFromSourceFile(ctx.SourceFile, ast.SkipParentheses(match.Left), false)
-		rightText := scanner.GetSourceTextOfNodeFromSourceFile(ctx.SourceFile, ast.SkipParentheses(match.Right), false)
 		return []rule.RuleFix{
-			rule.RuleFixReplace(ctx.SourceFile, match.Comparison, leftText),
+			rule.RuleFixReplace(ctx.SourceFile, match.Comparison, match.LeftText),
 			rule.RuleFixReplaceRange(
 				core.NewTextRange(match.Expect.HeadCall.End(), matcherAccessor.End()),
 				match.ModifierText+"."+equalityMatcher,
 			),
-			rule.RuleFixReplace(ctx.SourceFile, match.MatcherArgument, rightText),
+			rule.RuleFixReplace(ctx.SourceFile, match.MatcherArgument, match.RightText),
 		}
 	},
 })

--- a/internal/plugins/jest/rules/prefer_equality_matcher/prefer_equality_matcher.go
+++ b/internal/plugins/jest/rules/prefer_equality_matcher/prefer_equality_matcher.go
@@ -1,136 +1,57 @@
 package prefer_equality_matcher
 
 import (
-	"maps"
-	"slices"
-
 	"github.com/microsoft/TypeScript/tsc/shim/ast"
 	"github.com/microsoft/TypeScript/tsc/shim/core"
 	"github.com/microsoft/TypeScript/tsc/shim/scanner"
-	"github.com/web-infra-dev/rslint/internal/plugins/jest/utils"
+	jestUtils "github.com/web-infra-dev/rslint/internal/plugins/jest/utils"
 	"github.com/web-infra-dev/rslint/internal/rule"
+	testFramework "github.com/web-infra-dev/rslint/internal/utils/test_framework"
+	shared "github.com/web-infra-dev/rslint/internal/utils/test_framework/rules/prefer_equality_matcher"
 )
 
-var suggestedEqualityMatchers = slices.Sorted(maps.Keys(utils.EQUALITY_METHOD_NAMES))
-
-func buildUseEqualityMatcherErrorMessage() rule.RuleMessage {
-	return rule.RuleMessage{
-		Id:          "useEqualityMatcher",
-		Description: "Prefer using one of the equality matchers instead",
-	}
-}
-
-func buildSuggestEqualityMatcherMessage(equalityMatcher string) rule.RuleMessage {
-	return rule.RuleMessage{
-		Id:          "suggestEqualityMatcher",
-		Description: "Use `" + equalityMatcher + "`",
-	}
-}
-
-func parseStrictEqualityComparison(node *ast.Node) (left, right *ast.Node, negated bool, ok bool) {
-	if node == nil || node.Kind != ast.KindBinaryExpression {
-		return nil, nil, false, false
-	}
-
-	bin := node.AsBinaryExpression()
-	switch bin.OperatorToken.Kind {
-	case ast.KindEqualsEqualsEqualsToken:
-		return bin.Left, bin.Right, false, true
-	case ast.KindExclamationEqualsEqualsToken:
-		return bin.Left, bin.Right, true, true
-	default:
-		return nil, nil, false, false
-	}
-}
-
-func buildModifierText(jestFnCall *utils.ParsedJestFnCall, addNotModifier bool) string {
-	modifierText := ""
-	if len(jestFnCall.ModifierEntries) > 0 && jestFnCall.ModifierEntries[0].Name != "not" {
-		modifierText = "." + jestFnCall.ModifierEntries[0].Name
-	}
-	if addNotModifier {
-		modifierText += ".not"
-	}
-	return modifierText
-}
-
-var PreferEqualityMatcherRule = rule.Rule{
-	Name:   "jest/prefer-equality-matcher",
-	Schema: rule.EmptyArraySchema,
-	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
-		return rule.RuleListeners{
-			ast.KindCallExpression: func(node *ast.Node) {
-				jestFnCall := utils.ParseJestFnCall(node, ctx)
-				if jestFnCall == nil ||
-					jestFnCall.Kind != utils.JestFnTypeExpect ||
-					jestFnCall.MatcherEntry == nil ||
-					!utils.EQUALITY_METHOD_NAMES[jestFnCall.Matcher] {
-					return
+var PreferEqualityMatcherRule = shared.NewRule(shared.Config{
+	Name: "jest/prefer-equality-matcher",
+	Prepare: func(ctx rule.RuleContext) shared.Runtime {
+		return shared.Runtime{
+			Parse: func(node *ast.Node) *shared.ExpectCall {
+				parsed := jestUtils.ParseJestFnCall(node, ctx)
+				if parsed == nil ||
+					parsed.Kind != jestUtils.JestFnTypeExpect ||
+					parsed.MatcherEntry == nil {
+					return nil
 				}
 
-				expectCall := jestFnCall.Head.Local.Node.Parent
-				if expectCall == nil || expectCall.Kind != ast.KindCallExpression {
-					return
+				headCall := parsed.Head.Local.Node.Parent
+				if headCall == nil || headCall.Kind != ast.KindCallExpression {
+					return nil
 				}
 
-				expectArgs := expectCall.Arguments()
-				if len(expectArgs) == 0 {
-					return
+				return &shared.ExpectCall{
+					HeadCall:     headCall,
+					MatcherCall:  node,
+					MatcherEntry: *parsed.MatcherEntry,
+					Matcher:      parsed.Matcher,
+					Modifiers:    parsed.ModifierEntries,
 				}
-
-				comparison := ast.SkipParentheses(expectArgs[0])
-				left, right, negated, ok := parseStrictEqualityComparison(comparison)
-				if !ok {
-					return
-				}
-
-				matcherArgs := node.AsCallExpression().Arguments.Nodes
-				if len(matcherArgs) == 0 {
-					return
-				}
-
-				matcherArg := matcherArgs[0]
-				matcherValue, ok := utils.IsBooleanLiteral(matcherArg)
-				if !ok {
-					return
-				}
-
-				matcherEntry := jestFnCall.MatcherEntry
-				// The accessor, not the entry's direct parent, ends the modifier
-				// range: a parenthesized key such as `[("toBe")]` parents the
-				// literal to the parentheses rather than the element access.
-				_, matcherAccessor := utils.GetAccessorReceiverAndParent(matcherEntry)
-				if matcherAccessor == nil {
-					return
-				}
-
-				hasNot := slices.Contains(jestFnCall.Modifiers, "not")
-				modifierText := buildModifierText(jestFnCall, (negated != matcherValue) == hasNot)
-
-				leftText := scanner.GetSourceTextOfNodeFromSourceFile(ctx.SourceFile, ast.SkipParentheses(left), false)
-				rightText := scanner.GetSourceTextOfNodeFromSourceFile(ctx.SourceFile, ast.SkipParentheses(right), false)
-				replaceComparison := rule.RuleFixReplace(ctx.SourceFile, comparison, leftText)
-				replaceMatcherArg := rule.RuleFixReplace(ctx.SourceFile, utils.UnwrapBasicTypeAssertions(matcherArg), rightText)
-				modifierRange := core.NewTextRange(expectCall.End(), matcherAccessor.End())
-
-				suggestions := make([]rule.RuleSuggestion, len(suggestedEqualityMatchers))
-				for i, equalityMatcher := range suggestedEqualityMatchers {
-					suggestions[i] = rule.RuleSuggestion{
-						Message: buildSuggestEqualityMatcherMessage(equalityMatcher),
-						FixesArr: []rule.RuleFix{
-							replaceComparison,
-							rule.RuleFixReplaceRange(modifierRange, modifierText+"."+equalityMatcher),
-							replaceMatcherArg,
-						},
-					}
-				}
-
-				ctx.ReportNodeWithSuggestions(
-					matcherEntry.Node,
-					buildUseEqualityMatcherErrorMessage(),
-					suggestions...,
-				)
 			},
 		}
 	},
-}
+	BuildFixes: func(ctx rule.RuleContext, match shared.Match, equalityMatcher string) []rule.RuleFix {
+		_, matcherAccessor := testFramework.AccessorReceiverAndParent(&match.Expect.MatcherEntry)
+		if matcherAccessor == nil {
+			return nil
+		}
+
+		leftText := scanner.GetSourceTextOfNodeFromSourceFile(ctx.SourceFile, ast.SkipParentheses(match.Left), false)
+		rightText := scanner.GetSourceTextOfNodeFromSourceFile(ctx.SourceFile, ast.SkipParentheses(match.Right), false)
+		return []rule.RuleFix{
+			rule.RuleFixReplace(ctx.SourceFile, match.Comparison, leftText),
+			rule.RuleFixReplaceRange(
+				core.NewTextRange(match.Expect.HeadCall.End(), matcherAccessor.End()),
+				match.ModifierText+"."+equalityMatcher,
+			),
+			rule.RuleFixReplace(ctx.SourceFile, match.MatcherArgument, rightText),
+		}
+	},
+})

--- a/internal/plugins/jest/rules/prefer_equality_matcher/prefer_equality_matcher_test.go
+++ b/internal/plugins/jest/rules/prefer_equality_matcher/prefer_equality_matcher_test.go
@@ -130,7 +130,46 @@ func TestPreferEqualityMatcherRule(t *testing.T) {
 						Line:      1,
 						Column:    17,
 						Suggestions: expectSuggestions(func(equalityMatcher string) string {
-							return `expect(a).` + equalityMatcher + `(b as boolean);`
+							return `expect(a).` + equalityMatcher + `(b);`
+						}),
+					},
+				},
+			},
+			{
+				Code: `expect(a === b).toBe(true as const);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "useEqualityMatcher",
+						Line:      1,
+						Column:    17,
+						Suggestions: expectSuggestions(func(equalityMatcher string) string {
+							return `expect(a).` + equalityMatcher + `(b);`
+						}),
+					},
+				},
+			},
+			{
+				Code: `expect((f(), a) === b).toBe(true);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "useEqualityMatcher",
+						Line:      1,
+						Column:    24,
+						Suggestions: expectSuggestions(func(equalityMatcher string) string {
+							return `expect((f(), a)).` + equalityMatcher + `(b);`
+						}),
+					},
+				},
+			},
+			{
+				Code: `expect(a === (f(), b)).toBe(true);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "useEqualityMatcher",
+						Line:      1,
+						Column:    24,
+						Suggestions: expectSuggestions(func(equalityMatcher string) string {
+							return `expect(a).` + equalityMatcher + `((f(), b));`
 						}),
 					},
 				},

--- a/internal/plugins/jest/rules/prefer_equality_matcher/prefer_equality_matcher_test.go
+++ b/internal/plugins/jest/rules/prefer_equality_matcher/prefer_equality_matcher_test.go
@@ -31,6 +31,7 @@ func TestPreferEqualityMatcherRule(t *testing.T) {
 			{Code: `expect.hasAssertions`},
 			{Code: `expect.hasAssertions()`},
 			{Code: `expect.assertions(1)`},
+			{Code: `expect(true).toBe(...true)`},
 			{Code: `expect(a == 1).toBe(true)`},
 			{Code: `expect(1 == a).toBe(true)`},
 			{Code: `expect(a == b).toBe(true)`},

--- a/internal/plugins/jest/utils/accessor.go
+++ b/internal/plugins/jest/utils/accessor.go
@@ -72,27 +72,11 @@ func InsertMemberBeforeAccessorFix(
 	entry *ParsedJestFnMemberEntry,
 	name string,
 ) (rule.RuleFix, bool) {
-	receiver, accessor := GetAccessorReceiverAndParent(entry)
-	if receiver == nil || accessor == nil {
+	textRange, text, ok := testFramework.InsertMemberBeforeAccessor(entry, name)
+	if !ok {
 		return rule.RuleFix{}, false
 	}
-
-	questionDot := AccessorQuestionDotToken(accessor)
-	if questionDot == nil {
-		return rule.RuleFixReplaceRange(
-			core.NewTextRange(receiver.End(), receiver.End()),
-			"."+name,
-		), true
-	}
-
-	suffix := name
-	if accessor.Kind == ast.KindPropertyAccessExpression {
-		suffix += "."
-	}
-	return rule.RuleFixReplaceRange(
-		core.NewTextRange(questionDot.End(), questionDot.End()),
-		suffix,
-	), true
+	return rule.RuleFixReplaceRange(textRange, text), true
 }
 
 // ReplaceCallSuffixFix replaces a call's type arguments and arguments while

--- a/internal/plugins/rstest/all.go
+++ b/internal/plugins/rstest/all.go
@@ -26,6 +26,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/prefer_called_once"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/prefer_called_times"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/prefer_each"
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/prefer_equality_matcher"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/prefer_expect_type_of"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/prefer_hooks_in_order"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/prefer_import_in_mock"
@@ -73,6 +74,7 @@ func GetAllRules() []rule.Rule {
 		prefer_called_once.PreferCalledOnceRule,
 		prefer_called_times.PreferCalledTimesRule,
 		prefer_each.PreferEachRule,
+		prefer_equality_matcher.PreferEqualityMatcherRule,
 		prefer_expect_type_of.PreferExpectTypeOfRule,
 		prefer_hooks_in_order.PreferHooksInOrderRule,
 		prefer_import_in_mock.PreferImportInMockRule,

--- a/internal/plugins/rstest/rules/prefer_equality_matcher/prefer_equality_matcher.go
+++ b/internal/plugins/rstest/rules/prefer_equality_matcher/prefer_equality_matcher.go
@@ -1,0 +1,114 @@
+package prefer_equality_matcher
+
+import (
+	"github.com/microsoft/TypeScript/tsc/shim/ast"
+	"github.com/microsoft/TypeScript/tsc/shim/scanner"
+	rstestUtils "github.com/web-infra-dev/rslint/internal/plugins/rstest/utils"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+	testFramework "github.com/web-infra-dev/rslint/internal/utils/test_framework"
+	shared "github.com/web-infra-dev/rslint/internal/utils/test_framework/rules/prefer_equality_matcher"
+)
+
+var PreferEqualityMatcherRule = shared.NewRule(shared.Config{
+	Name: "rstest/prefer-equality-matcher",
+	Prepare: func(ctx rule.RuleContext) shared.Runtime {
+		analysis := rstestUtils.GetRstestCallAnalysis(ctx)
+		return shared.Runtime{
+			Parse: func(node *ast.Node) *shared.ExpectCall {
+				parsed := analysis.ParseExpectCall(node)
+				if parsed == nil ||
+					parsed.Reason != rstestUtils.RstestExpectParseReasonNone ||
+					parsed.Head == nil ||
+					parsed.MatcherEntry == nil ||
+					len(parsed.Matchers) == 0 ||
+					parsed.Matchers[0].Kind != rstestUtils.RstestExpectMatcherCall ||
+					testFramework.IsComputedIdentifierAccessor(parsed.MatcherEntry.Node) {
+					return nil
+				}
+
+				matcherCall := rstestUtils.MatcherCall(parsed.MatcherEntry)
+				if matcherCall == nil {
+					return nil
+				}
+
+				return &shared.ExpectCall{
+					HeadCall:     parsed.Head,
+					MatcherCall:  matcherCall,
+					MatcherEntry: *parsed.MatcherEntry,
+					Matcher:      parsed.Matcher,
+					Modifiers:    parsed.ModifierEntries,
+				}
+			},
+		}
+	},
+	BuildFixes: buildSuggestionFixes,
+})
+
+func buildSuggestionFixes(ctx rule.RuleContext, match shared.Match, equalityMatcher string) []rule.RuleFix {
+	comparisonRange := utils.TrimNodeTextRange(ctx.SourceFile, match.Comparison)
+	if ctx.Comments != nil && utils.HasCommentInSpan(
+		ctx.Comments.All(),
+		comparisonRange.Pos(),
+		comparisonRange.End(),
+	) {
+		return nil
+	}
+
+	matcherRange, matcherText, ok := testFramework.AccessorReplacement(
+		ctx.SourceFile,
+		match.Expect.MatcherEntry.Node,
+		equalityMatcher,
+	)
+	if !ok {
+		return nil
+	}
+
+	fixes := []rule.RuleFix{
+		rule.RuleFixReplace(
+			ctx.SourceFile,
+			match.Comparison,
+			scanner.GetSourceTextOfNodeFromSourceFile(ctx.SourceFile, ast.SkipParentheses(match.Left), false),
+		),
+		rule.RuleFixReplaceRange(matcherRange, matcherText),
+		rule.RuleFixReplace(
+			ctx.SourceFile,
+			match.MatcherArgument,
+			scanner.GetSourceTextOfNodeFromSourceFile(ctx.SourceFile, ast.SkipParentheses(match.Right), false),
+		),
+	}
+
+	var notModifier *testFramework.MemberEntry
+	for index := range match.Expect.Modifiers {
+		if match.Expect.Modifiers[index].Name == "not" {
+			notModifier = &match.Expect.Modifiers[index]
+			break
+		}
+	}
+
+	switch {
+	case match.ShouldHaveNot && notModifier == nil:
+		textRange, text, ok := testFramework.InsertMemberBeforeAccessor(
+			&match.Expect.MatcherEntry,
+			"not",
+		)
+		if !ok {
+			return nil
+		}
+		fixes = append(fixes, rule.RuleFixReplaceRange(textRange, text))
+	case !match.ShouldHaveNot && notModifier != nil:
+		ranges, ok := testFramework.RemoveAccessorEntryRanges(
+			ctx.SourceFile,
+			ctx.Comments.All(),
+			notModifier,
+		)
+		if !ok {
+			return nil
+		}
+		for _, textRange := range ranges {
+			fixes = append(fixes, rule.RuleFixRemoveRange(textRange))
+		}
+	}
+
+	return fixes
+}

--- a/internal/plugins/rstest/rules/prefer_equality_matcher/prefer_equality_matcher.go
+++ b/internal/plugins/rstest/rules/prefer_equality_matcher/prefer_equality_matcher.go
@@ -2,7 +2,6 @@ package prefer_equality_matcher
 
 import (
 	"github.com/microsoft/TypeScript/tsc/shim/ast"
-	"github.com/microsoft/TypeScript/tsc/shim/scanner"
 	rstestUtils "github.com/web-infra-dev/rslint/internal/plugins/rstest/utils"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
@@ -46,12 +45,10 @@ var PreferEqualityMatcherRule = shared.NewRule(shared.Config{
 })
 
 func buildSuggestionFixes(ctx rule.RuleContext, match shared.Match, equalityMatcher string) []rule.RuleFix {
-	comparisonRange := utils.TrimNodeTextRange(ctx.SourceFile, match.Comparison)
-	if ctx.Comments != nil && utils.HasCommentInSpan(
-		ctx.Comments.All(),
-		comparisonRange.Pos(),
-		comparisonRange.End(),
-	) {
+	// Both replaced spans are rewritten wholesale, so a comment inside either
+	// one would be dropped. The rule keeps the diagnostic and drops the
+	// suggestions instead.
+	if hasComment(ctx, match.Comparison) || hasComment(ctx, match.MatcherArgument) {
 		return nil
 	}
 
@@ -65,17 +62,9 @@ func buildSuggestionFixes(ctx rule.RuleContext, match shared.Match, equalityMatc
 	}
 
 	fixes := []rule.RuleFix{
-		rule.RuleFixReplace(
-			ctx.SourceFile,
-			match.Comparison,
-			scanner.GetSourceTextOfNodeFromSourceFile(ctx.SourceFile, ast.SkipParentheses(match.Left), false),
-		),
+		rule.RuleFixReplace(ctx.SourceFile, match.Comparison, match.LeftText),
 		rule.RuleFixReplaceRange(matcherRange, matcherText),
-		rule.RuleFixReplace(
-			ctx.SourceFile,
-			match.MatcherArgument,
-			scanner.GetSourceTextOfNodeFromSourceFile(ctx.SourceFile, ast.SkipParentheses(match.Right), false),
-		),
+		rule.RuleFixReplace(ctx.SourceFile, match.MatcherArgument, match.RightText),
 	}
 
 	var notModifier *testFramework.MemberEntry
@@ -111,4 +100,12 @@ func buildSuggestionFixes(ctx rule.RuleContext, match shared.Match, equalityMatc
 	}
 
 	return fixes
+}
+
+func hasComment(ctx rule.RuleContext, node *ast.Node) bool {
+	if ctx.Comments == nil || node == nil {
+		return false
+	}
+	textRange := utils.TrimNodeTextRange(ctx.SourceFile, node)
+	return utils.HasCommentInSpan(ctx.Comments.All(), textRange.Pos(), textRange.End())
 }

--- a/internal/plugins/rstest/rules/prefer_equality_matcher/prefer_equality_matcher.md
+++ b/internal/plugins/rstest/rules/prefer_equality_matcher/prefer_equality_matcher.md
@@ -1,0 +1,33 @@
+# prefer-equality-matcher
+
+## Rule Details
+
+Requires strict equality checks inside `expect` to use an equality matcher directly. `expect(actual === expected).toBe(true)` is harder to read and produces less useful failures than `expect(actual).toBe(expected)`. The rule handles both `===` and `!==`, boolean expectations, an existing `.not`, and the `resolves` and `rejects` modifiers.
+
+The rule recognizes `toBe`, `toEqual`, and `toStrictEqual` when they are the first called matcher in an assertion. It recognizes Rstest globals, imports and aliases, namespace access, `import.meta.rstest`, and the `expect` supplied by a test's [TestContext](https://rstest.rs/api/runtime-api/test-api/test#testcontext). It also preserves assertion factories such as `expect.soft`, the second message argument of `expect(actual, message)`, matcher argument trivia, and trailing commas.
+
+Loose comparisons (`==` and `!=`), Chai property matchers, later matchers in a Chai chain, dynamic computed matcher names, locally shadowed names, and `expect` imported from another test framework are not reported. `expect.poll(fn)` and `expect.element(locator)` are only reported when the value passed to that factory is itself a strict equality comparison.
+
+## Incorrect
+
+```ts
+test('matches the saved profile', () => {
+  expect(savedProfile === expectedProfile).toBe(true);
+  expect(savedStatus !== 'archived').not.toEqual(false);
+});
+```
+
+## Correct
+
+```ts
+test('matches the saved profile', () => {
+  expect(savedProfile).toBe(expectedProfile);
+  expect(savedStatus).not.toEqual('archived');
+});
+```
+
+## Suggestions
+
+Each report offers three alternatives using `toBe`, `toEqual`, and `toStrictEqual`. The suggestion moves the left side of the comparison into `expect`, moves the right side into the matcher, and adjusts `.not` so the assertion keeps the same meaning. `resolves` or `rejects`, the written expect root, a second message argument, accessor quoting, surrounding trivia, and a trailing matcher-argument comma remain unchanged.
+
+If comments or unusual accessor syntax inside an edited span cannot be preserved safely, the rule reports the assertion without suggestions.

--- a/internal/plugins/rstest/rules/prefer_equality_matcher/prefer_equality_matcher_extras_test.go
+++ b/internal/plugins/rstest/rules/prefer_equality_matcher/prefer_equality_matcher_extras_test.go
@@ -102,7 +102,15 @@ func TestPreferEqualityMatcherExtras(t *testing.T) {
 			// ---- Dimension 4: parentheses and type assertions ----
 			{Code: `expect(((a === b))).toBe(true);`, Errors: []rule_tester.InvalidTestCaseError{equalityExtrasError(21, func(m string) string { return `expect(((a))).` + m + `(b);` })}},
 			{Code: `expect((a as number) === (b as number)).toBe(true);`, Errors: []rule_tester.InvalidTestCaseError{equalityExtrasError(41, func(m string) string { return `expect(a as number).` + m + `(b as number);` })}},
-			{Code: `expect(a === b).toBe((true as boolean));`, Errors: []rule_tester.InvalidTestCaseError{equalityExtrasError(17, func(m string) string { return `expect(a).` + m + `((b as boolean));` })}},
+			{Code: `expect(a === b).toBe((true as boolean));`, Errors: []rule_tester.InvalidTestCaseError{equalityExtrasError(17, func(m string) string { return `expect(a).` + m + `((b));` })}},
+			// A type assertion written for the boolean literal cannot survive on
+			// the operand that replaces it: `b as const` does not compile.
+			{Code: `expect(a === b).toBe(true as const);`, Errors: []rule_tester.InvalidTestCaseError{equalityExtrasError(17, func(m string) string { return `expect(a).` + m + `(b);` })}},
+			{Code: `expect(a === b).toBe(<const>true);`, Errors: []rule_tester.InvalidTestCaseError{equalityExtrasError(17, func(m string) string { return `expect(a).` + m + `(b);` })}},
+			// Parentheses around a comma expression are load-bearing: dropping
+			// them would splice a second argument into the rewritten call.
+			{Code: `expect((f(), a) === b).toBe(true);`, Errors: []rule_tester.InvalidTestCaseError{equalityExtrasError(24, func(m string) string { return `expect((f(), a)).` + m + `(b);` })}},
+			{Code: `expect(a === (f(), b)).toBe(true);`, Errors: []rule_tester.InvalidTestCaseError{equalityExtrasError(24, func(m string) string { return `expect(a).` + m + `((f(), b));` })}},
 
 			// ---- Accessor syntax and modifier preservation ----
 			{Code: `expect(a === b)['toBe'](true);`, Errors: []rule_tester.InvalidTestCaseError{equalityExtrasError(17, func(m string) string { return `expect(a)['` + m + `'](b);` })}},
@@ -165,6 +173,9 @@ api.expect(a).` + m + `(b);`
 			{Code: `expect(a === b).resolves /* keep */ .toBe(false,);`, Errors: []rule_tester.InvalidTestCaseError{equalityExtrasError(38, func(m string) string { return `expect(a).resolves.not /* keep */ .` + m + `(b,);` })}},
 			{Code: `expect(a === b).not /* keep */ .toBe(false);`, Errors: []rule_tester.InvalidTestCaseError{equalityExtrasError(33, func(m string) string { return `expect(a) /* keep */ .` + m + `(b);` })}},
 			{Code: `expect(a === b).toBe(/* expected */ true,);`, Errors: []rule_tester.InvalidTestCaseError{equalityExtrasError(17, func(m string) string { return `expect(a).` + m + `(/* expected */ b,);` })}},
+			// The whole type-asserted argument is replaced, so a comment inside
+			// it would be lost; the diagnostic is kept without suggestions.
+			{Code: `expect(a === b).toBe(true /* keep */ as const);`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useEqualityMatcher", Line: 1, Column: 17}}},
 		},
 	)
 }

--- a/internal/plugins/rstest/rules/prefer_equality_matcher/prefer_equality_matcher_extras_test.go
+++ b/internal/plugins/rstest/rules/prefer_equality_matcher/prefer_equality_matcher_extras_test.go
@@ -1,0 +1,250 @@
+// TestPreferEqualityMatcherExtras locks in branches and edge shapes that the
+// upstream test suite does not exercise: the full truth table, Rstest expect
+// sources, factory and matcher boundaries, safe source edits, and edit-demand
+// behavior. The upstream mirror lives in prefer_equality_matcher_upstream_test.go.
+package prefer_equality_matcher
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/microsoft/TypeScript/tsc/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/linter"
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/fixtures"
+	lintprogram "github.com/web-infra-dev/rslint/internal/program"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func equalityExtrasError(column int, output func(string) string) rule_tester.InvalidTestCaseError {
+	return rule_tester.InvalidTestCaseError{
+		MessageId:   "useEqualityMatcher",
+		Line:        1,
+		Column:      column,
+		Suggestions: equalitySuggestions(output),
+	}
+}
+
+func TestPreferEqualityMatcherExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&PreferEqualityMatcherRule,
+		[]rule_tester.ValidTestCase{
+			// Locks in upstream comparison gate: loose and non-equality operators.
+			{Code: `expect(a == b).toBe(true);`},
+			{Code: `expect(a != b).toEqual(false);`},
+			{Code: `expect(a > b).toStrictEqual(true);`},
+			// Locks in upstream matcher gate and first-argument boolean gate.
+			{Code: `expect(a === b).toContain(true);`},
+			{Code: `expect(a === b).toBe();`},
+			{Code: `expect(a === b).toBe(flag);`},
+			{Code: `expect(a === b).toBe(...flags);`},
+			{Code: `expect(a === b).toBe(true satisfies boolean);`},
+			{Code: `expect(a === b).toBe(true!);`},
+
+			// ---- Dimension 4: matcher shape and access forms ----
+			{Code: `expect(a === b).toBe;`},
+			{Code: `expect(a === b).to.be.equal(true);`},
+			{Code: `expect(a === b)[matcherName](true);`},
+			{Code: `expect(a === b)[0](true);`},
+
+			// ---- Dimension 4: receiver wrappers are parser boundaries ----
+			{Code: `expect(a === b)!.toBe(true);`},
+			{Code: `(expect(a === b) as any).toBe(true);`},
+			{Code: `(expect(a === b) satisfies Assertion).toBe(true);`},
+
+			// ---- Rstest source and shadowing boundaries ----
+			{Code: `import { expect } from 'vitest'; expect(a === b).toBe(true);`},
+			{Code: `import { expect } from '@jest/globals'; expect(a === b).toBe(true);`},
+			{Code: `import { expect } from 'chai'; expect(a === b).toBe(true);`},
+			{Code: `const expect = makeExpect(); expect(a === b).toBe(true);`},
+			{Code: `import { expect } from '@rstest/core'; function f(expect: any) { expect(a === b).toBe(true); }`},
+
+			// No Entry gate: poll is rejected because its subject is a function,
+			// while element naturally remains outside the strict-comparison shape.
+			{Code: `expect.poll(() => a === b).toBe(true);`},
+			{Code: `expect.element(locator).toBe(true);`},
+
+			// N/A: declaration/container and function-kind rows do not apply to
+			// this rule's call-expression listener. Spread/rest and empty-body
+			// forms cannot be the strict binary subject selected by the rule.
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Complete 2 x 2 x 2 truth table ----
+			{Code: `expect(a === b).toEqual(true);`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useEqualityMatcher", Message: "Prefer using one of the equality matchers instead", Line: 1, Column: 17, EndLine: 1, EndColumn: 24, Suggestions: equalitySuggestions(func(m string) string { return `expect(a).` + m + `(b);` })}}},
+			{Code: `expect(a === b).toEqual(false);`, Errors: []rule_tester.InvalidTestCaseError{equalityExtrasError(17, func(m string) string { return `expect(a).not.` + m + `(b);` })}},
+			{Code: `expect(a !== b).toEqual(true);`, Errors: []rule_tester.InvalidTestCaseError{equalityExtrasError(17, func(m string) string { return `expect(a).not.` + m + `(b);` })}},
+			{Code: `expect(a !== b).toEqual(false);`, Errors: []rule_tester.InvalidTestCaseError{equalityExtrasError(17, func(m string) string { return `expect(a).` + m + `(b);` })}},
+			{Code: `expect(a === b).not.toEqual(true);`, Errors: []rule_tester.InvalidTestCaseError{equalityExtrasError(21, func(m string) string { return `expect(a).not.` + m + `(b);` })}},
+			{Code: `expect(a === b).not.toEqual(false);`, Errors: []rule_tester.InvalidTestCaseError{equalityExtrasError(21, func(m string) string { return `expect(a).` + m + `(b);` })}},
+			{Code: `expect(a !== b).not.toEqual(true);`, Errors: []rule_tester.InvalidTestCaseError{equalityExtrasError(21, func(m string) string { return `expect(a).` + m + `(b);` })}},
+			{Code: `expect(a !== b).not.toEqual(false);`, Errors: []rule_tester.InvalidTestCaseError{equalityExtrasError(21, func(m string) string { return `expect(a).not.` + m + `(b);` })}},
+			{
+				Code: `expect(a === b)
+  .resolves
+  .toStrictEqual(true);`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "useEqualityMatcher",
+					Line:      3,
+					Column:    4,
+					EndLine:   3,
+					EndColumn: 17,
+					Suggestions: equalitySuggestions(func(m string) string {
+						return `expect(a)
+  .resolves
+  .` + m + `(b);`
+					}),
+				}},
+			},
+
+			// ---- Dimension 4: parentheses and type assertions ----
+			{Code: `expect(((a === b))).toBe(true);`, Errors: []rule_tester.InvalidTestCaseError{equalityExtrasError(21, func(m string) string { return `expect(((a))).` + m + `(b);` })}},
+			{Code: `expect((a as number) === (b as number)).toBe(true);`, Errors: []rule_tester.InvalidTestCaseError{equalityExtrasError(41, func(m string) string { return `expect(a as number).` + m + `(b as number);` })}},
+			{Code: `expect(a === b).toBe((true as boolean));`, Errors: []rule_tester.InvalidTestCaseError{equalityExtrasError(17, func(m string) string { return `expect(a).` + m + `((b as boolean));` })}},
+
+			// ---- Accessor syntax and modifier preservation ----
+			{Code: `expect(a === b)['toBe'](true);`, Errors: []rule_tester.InvalidTestCaseError{equalityExtrasError(17, func(m string) string { return `expect(a)['` + m + `'](b);` })}},
+			{Code: "expect(a === b)[`toBe`](true);", Errors: []rule_tester.InvalidTestCaseError{equalityExtrasError(17, func(m string) string { return "expect(a)[`" + m + "`](b);" })}},
+			{Code: `expect(a === b)?.toBe(false);`, Errors: []rule_tester.InvalidTestCaseError{equalityExtrasError(18, func(m string) string { return `expect(a)?.not.` + m + `(b);` })}},
+			{Code: `expect(a === b).toBe?.(true);`, Errors: []rule_tester.InvalidTestCaseError{equalityExtrasError(17, func(m string) string { return `expect(a).` + m + `?.(b);` })}},
+			{Code: `expect(a !== b).rejects.not.toStrictEqual(true);`, Errors: []rule_tester.InvalidTestCaseError{equalityExtrasError(29, func(m string) string { return `expect(a).rejects.` + m + `(b);` })}},
+			{Code: `expect(a === b).not.resolves.toBe(false);`, Errors: []rule_tester.InvalidTestCaseError{equalityExtrasError(30, func(m string) string { return `expect(a).resolves.` + m + `(b);` })}},
+			// ---- UTF-16 report and edit ranges ----
+			{Code: `expect("😀" === value).toBe(true);`, Errors: []rule_tester.InvalidTestCaseError{equalityExtrasError(24, func(m string) string { return `expect("😀").` + m + `(value);` })}},
+
+			// ---- Rstest factories and expect roots ----
+			{Code: `expect.soft(a === b).toBe(true);`, Errors: []rule_tester.InvalidTestCaseError{equalityExtrasError(22, func(m string) string { return `expect.soft(a).` + m + `(b);` })}},
+			// No factory-specific gate: a binary argument is handled uniformly,
+			// even for factories whose ordinary argument has another shape.
+			{Code: `expect.poll(a === b).toBe(true);`, Errors: []rule_tester.InvalidTestCaseError{equalityExtrasError(22, func(m string) string { return `expect.poll(a).` + m + `(b);` })}},
+			{Code: `expect.element(a !== b).toEqual(false);`, Errors: []rule_tester.InvalidTestCaseError{equalityExtrasError(25, func(m string) string { return `expect.element(a).` + m + `(b);` })}},
+			{Code: `expect(a === b, 'values should match').toBe(true);`, Errors: []rule_tester.InvalidTestCaseError{equalityExtrasError(40, func(m string) string { return `expect(a, 'values should match').` + m + `(b);` })}},
+			{Code: `import { expect as check } from '@rstest/core';
+check(a === b, 'message').toBe(false);`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useEqualityMatcher", Line: 2, Column: 27, Suggestions: equalitySuggestions(func(m string) string {
+				return `import { expect as check } from '@rstest/core';
+check(a, 'message').not.` + m + `(b);`
+			})}}},
+			{Code: `const { expect } = require('@rstest/core');
+expect(a === b).toBe(true);`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useEqualityMatcher", Line: 2, Column: 17, Suggestions: equalitySuggestions(func(m string) string {
+				return `const { expect } = require('@rstest/core');
+expect(a).` + m + `(b);`
+			})}}},
+			{Code: `import * as core from '@rstest/core';
+core.expect(a === b).toBe(true);`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useEqualityMatcher", Line: 2, Column: 22, Suggestions: equalitySuggestions(func(m string) string {
+				return `import * as core from '@rstest/core';
+core.expect(a).` + m + `(b);`
+			})}}},
+			{Code: `import { expect } from '@rstest/playwright';
+expect(a === b).toBe(true);`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useEqualityMatcher", Line: 2, Column: 17, Suggestions: equalitySuggestions(func(m string) string {
+				return `import { expect } from '@rstest/playwright';
+expect(a).` + m + `(b);`
+			})}}},
+			{Code: `import.meta.rstest.expect(a === b).toBe(true);`, Errors: []rule_tester.InvalidTestCaseError{equalityExtrasError(36, func(m string) string { return `import.meta.rstest.expect(a).` + m + `(b);` })}},
+			{Code: `const api = import.meta.rstest;
+api.expect(a === b).toBe(true);`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useEqualityMatcher", Line: 2, Column: 21, Suggestions: equalitySuggestions(func(m string) string {
+				return `const api = import.meta.rstest;
+api.expect(a).` + m + `(b);`
+			})}}},
+			{Code: `test('compares values', ({ expect }) => expect(a !== b).toBe(false));`, Errors: []rule_tester.InvalidTestCaseError{equalityExtrasError(57, func(m string) string { return `test('compares values', ({ expect }) => expect(a).` + m + `(b));` })}},
+			{Code: `test('compares values', ctx => ctx.expect(a === b).toBe(true));`, Errors: []rule_tester.InvalidTestCaseError{equalityExtrasError(52, func(m string) string { return `test('compares values', ctx => ctx.expect(a).` + m + `(b));` })}},
+
+			// ---- Chai multi-matcher boundary ----
+			// Only the first call-style matcher is inspected. A later matcher is
+			// left outside the three edits.
+			{Code: `expect(a === b).toBe(true).toEqual(false);`, Errors: []rule_tester.InvalidTestCaseError{equalityExtrasError(17, func(m string) string { return `expect(a).` + m + `(b).toEqual(false);` })}},
+
+			// ---- Real-user: issue #2006 empty expect argument regression ----
+			// The parser sees a real matcher, but the shared subject gate leaves
+			// `expect()` alone without indexing a missing argument.
+			// (The invalid companion proves a later valid assertion still runs.)
+			{Code: `expect(); expect(a === b).toBe(true);`, Errors: []rule_tester.InvalidTestCaseError{equalityExtrasError(27, func(m string) string { return `expect(); expect(a).` + m + `(b);` })}},
+			// ---- Real-user: preserve comments and trailing commas ----
+			{Code: `expect(a /* left */ === b /* right */, 'message').toBe(true,);`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useEqualityMatcher", Line: 1, Column: 51}}},
+			{Code: `expect(a === b).resolves /* keep */ .toBe(false,);`, Errors: []rule_tester.InvalidTestCaseError{equalityExtrasError(38, func(m string) string { return `expect(a).resolves.not /* keep */ .` + m + `(b,);` })}},
+			{Code: `expect(a === b).not /* keep */ .toBe(false);`, Errors: []rule_tester.InvalidTestCaseError{equalityExtrasError(33, func(m string) string { return `expect(a) /* keep */ .` + m + `(b);` })}},
+			{Code: `expect(a === b).toBe(/* expected */ true,);`, Errors: []rule_tester.InvalidTestCaseError{equalityExtrasError(17, func(m string) string { return `expect(a).` + m + `(/* expected */ b,);` })}},
+		},
+	)
+}
+
+// TestPreferEqualityMatcherEditDemand locks in that the diagnostic is stable
+// and the three suggestions are constructed only when requested.
+func TestPreferEqualityMatcherEditDemand(t *testing.T) {
+	t.Parallel()
+
+	helper := rule_tester.NewProgramHelper(fixtures.GetRootDir())
+	program, sourceFile, err := helper.CreateTestProgram(
+		`expect(a === b, 'message').resolves.not['toBe'](false,);`,
+		"edit-demand.ts",
+		"tsconfig.json",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	run := func(demand rule.EditDemand) rule.RuleDiagnostic {
+		t.Helper()
+		var diagnostics []rule.RuleDiagnostic
+		linter.LintSingleFile(linter.LintSingleFileOptions{
+			Program:     lintprogram.NewFromCompiler(program),
+			File:        sourceFile.FileName(),
+			HasTypeInfo: true,
+			GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+				return []rule.ConfiguredRule{{
+					Name:     PreferEqualityMatcherRule.Name,
+					Severity: rule.SeverityError,
+					Run: func(ctx rule.RuleContext) rule.RuleListeners {
+						return PreferEqualityMatcherRule.Run(ctx, nil)
+					},
+				}}
+			},
+			Consumer: rule.DiagnosticConsumer{Demand: demand, Report: func(diagnostic rule.RuleDiagnostic) {
+				diagnostics = append(diagnostics, diagnostic)
+			}},
+		})
+		if len(diagnostics) != 1 {
+			t.Fatalf("demand %d: diagnostics = %d, want 1", demand, len(diagnostics))
+		}
+		return diagnostics[0]
+	}
+
+	diagnostics := map[rule.EditDemand]rule.RuleDiagnostic{
+		rule.EditDemandNone:       run(rule.EditDemandNone),
+		rule.EditDemandAutofix:    run(rule.EditDemandAutofix),
+		rule.EditDemandSuggestion: run(rule.EditDemandSuggestion),
+		rule.EditDemandAll:        run(rule.EditDemandAll),
+	}
+
+	withoutEdits := func(diagnostic rule.RuleDiagnostic) rule.RuleDiagnostic {
+		diagnostic.FixesPtr = nil
+		diagnostic.Suggestions = nil
+		return diagnostic
+	}
+	want := withoutEdits(diagnostics[rule.EditDemandAll])
+	for demand, diagnostic := range diagnostics {
+		if got := withoutEdits(diagnostic); !reflect.DeepEqual(got, want) {
+			t.Errorf("demand %d changed diagnostic identity:\ngot  %#v\nwant %#v", demand, got, want)
+		}
+		if diagnostic.FixesPtr != nil {
+			t.Errorf("demand %d unexpectedly materialized autofixes", demand)
+		}
+	}
+	for _, demand := range []rule.EditDemand{rule.EditDemandNone, rule.EditDemandAutofix} {
+		if diagnostics[demand].Suggestions != nil {
+			t.Errorf("demand %d unexpectedly materialized suggestions", demand)
+		}
+	}
+	for _, demand := range []rule.EditDemand{rule.EditDemandSuggestion, rule.EditDemandAll} {
+		suggestions := diagnostics[demand].Suggestions
+		if suggestions == nil || len(*suggestions) != 3 {
+			t.Fatalf("demand %d suggestions = %#v, want three", demand, suggestions)
+		}
+		for index, suggestion := range *suggestions {
+			if len(suggestion.FixesArr) < 3 {
+				t.Errorf("demand %d suggestion %d has %d fixes, want at least 3", demand, index, len(suggestion.FixesArr))
+			}
+		}
+	}
+}

--- a/internal/plugins/rstest/rules/prefer_equality_matcher/prefer_equality_matcher_upstream_test.go
+++ b/internal/plugins/rstest/rules/prefer_equality_matcher/prefer_equality_matcher_upstream_test.go
@@ -1,0 +1,182 @@
+// TestPreferEqualityMatcherUpstream migrates the complete
+// @vitest/eslint-plugin@v1.6.27 prefer-equality-matcher suite
+// (tests/prefer-equality-matcher.test.ts) 1:1. Position assertions cover
+// line/column for every invalid case. Rstest-specific sources, edge shapes,
+// branch lock-ins and edit-demand coverage live in
+// prefer_equality_matcher_extras_test.go.
+package prefer_equality_matcher
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func equalitySuggestions(output func(string) string) []rule_tester.InvalidTestCaseSuggestion {
+	matchers := []string{"toBe", "toEqual", "toStrictEqual"}
+	suggestions := make([]rule_tester.InvalidTestCaseSuggestion, len(matchers))
+	for index, matcher := range matchers {
+		suggestions[index] = rule_tester.InvalidTestCaseSuggestion{
+			MessageId: "suggestEqualityMatcher",
+			Output:    output(matcher),
+		}
+	}
+	return suggestions
+}
+
+func equalityError(column int, output func(string) string) rule_tester.InvalidTestCaseError {
+	return rule_tester.InvalidTestCaseError{
+		MessageId:   "useEqualityMatcher",
+		Message:     "Prefer using one of the equality matchers instead",
+		Line:        1,
+		Column:      column,
+		Suggestions: equalitySuggestions(output),
+	}
+}
+
+func TestPreferEqualityMatcherUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&PreferEqualityMatcherRule,
+		[]rule_tester.ValidTestCase{
+			// ---- === ----
+			{Code: `expect.hasAssertions`},
+			{Code: `expect.hasAssertions()`},
+			{Code: `expect.assertions(1)`},
+			{Code: `expect(true).toBe(...true)`},
+			{Code: `expect(a).to.be.a("string");`},
+			{Code: `expect(a == 1).toBe(true)`},
+			{Code: `expect(1 == a).toBe(true)`},
+			{Code: `expect(a == b).toBe(true)`},
+			// ---- !== ----
+			{Code: `expect.hasAssertions`},
+			{Code: `expect.hasAssertions()`},
+			{Code: `expect.assertions(1)`},
+			{Code: `expect(true).toBe(...true)`},
+			{Code: `expect(a != 1).toBe(true)`},
+			{Code: `expect(1 != a).toBe(true)`},
+			{Code: `expect(a != b).toBe(true)`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- === ----
+			{
+				Code: `expect(a === b).toBe(true);`,
+				Errors: []rule_tester.InvalidTestCaseError{equalityError(17, func(matcher string) string {
+					return `expect(a).` + matcher + `(b);`
+				})},
+			},
+			{
+				Code: `expect(a === b,).toBe(true,);`,
+				Errors: []rule_tester.InvalidTestCaseError{equalityError(18, func(matcher string) string {
+					return `expect(a,).` + matcher + `(b,);`
+				})},
+			},
+			{
+				Code: `expect(a === b).toBe(false);`,
+				Errors: []rule_tester.InvalidTestCaseError{equalityError(17, func(matcher string) string {
+					return `expect(a).not.` + matcher + `(b);`
+				})},
+			},
+			{
+				Code: `expect(a === b).resolves.toBe(true);`,
+				Errors: []rule_tester.InvalidTestCaseError{equalityError(26, func(matcher string) string {
+					return `expect(a).resolves.` + matcher + `(b);`
+				})},
+			},
+			{
+				Code: `expect(a === b).resolves.toBe(false);`,
+				Errors: []rule_tester.InvalidTestCaseError{equalityError(26, func(matcher string) string {
+					return `expect(a).resolves.not.` + matcher + `(b);`
+				})},
+			},
+			{
+				Code: `expect(a === b).not.toBe(true);`,
+				Errors: []rule_tester.InvalidTestCaseError{equalityError(21, func(matcher string) string {
+					return `expect(a).not.` + matcher + `(b);`
+				})},
+			},
+			{
+				Code: `expect(a === b).not.toBe(false);`,
+				Errors: []rule_tester.InvalidTestCaseError{equalityError(21, func(matcher string) string {
+					return `expect(a).` + matcher + `(b);`
+				})},
+			},
+			{
+				Code: `expect(a === b).resolves.not.toBe(true);`,
+				Errors: []rule_tester.InvalidTestCaseError{equalityError(30, func(matcher string) string {
+					return `expect(a).resolves.not.` + matcher + `(b);`
+				})},
+			},
+			{
+				Code: `expect(a === b).resolves.not.toBe(false);`,
+				Errors: []rule_tester.InvalidTestCaseError{equalityError(30, func(matcher string) string {
+					return `expect(a).resolves.` + matcher + `(b);`
+				})},
+			},
+			{
+				Code: `expect(a === b)["resolves"].not.toBe(false);`,
+				Errors: []rule_tester.InvalidTestCaseError{equalityError(33, func(matcher string) string {
+					return `expect(a)["resolves"].` + matcher + `(b);`
+				})},
+			},
+			{
+				Code: `expect(a === b)["resolves"]["not"]["toBe"](false);`,
+				Errors: []rule_tester.InvalidTestCaseError{equalityError(36, func(matcher string) string {
+					return `expect(a)["resolves"]` + `["` + matcher + `"](b);`
+				})},
+			},
+			// ---- !== ----
+			{
+				Code: `expect(a !== b).toBe(true);`,
+				Errors: []rule_tester.InvalidTestCaseError{equalityError(17, func(matcher string) string {
+					return `expect(a).not.` + matcher + `(b);`
+				})},
+			},
+			{
+				Code: `expect(a !== b).toBe(false);`,
+				Errors: []rule_tester.InvalidTestCaseError{equalityError(17, func(matcher string) string {
+					return `expect(a).` + matcher + `(b);`
+				})},
+			},
+			{
+				Code: `expect(a !== b).resolves.toBe(true);`,
+				Errors: []rule_tester.InvalidTestCaseError{equalityError(26, func(matcher string) string {
+					return `expect(a).resolves.not.` + matcher + `(b);`
+				})},
+			},
+			{
+				Code: `expect(a !== b).resolves.toBe(false);`,
+				Errors: []rule_tester.InvalidTestCaseError{equalityError(26, func(matcher string) string {
+					return `expect(a).resolves.` + matcher + `(b);`
+				})},
+			},
+			{
+				Code: `expect(a !== b).not.toBe(true);`,
+				Errors: []rule_tester.InvalidTestCaseError{equalityError(21, func(matcher string) string {
+					return `expect(a).` + matcher + `(b);`
+				})},
+			},
+			{
+				Code: `expect(a !== b).not.toBe(false);`,
+				Errors: []rule_tester.InvalidTestCaseError{equalityError(21, func(matcher string) string {
+					return `expect(a).not.` + matcher + `(b);`
+				})},
+			},
+			{
+				Code: `expect(a !== b).resolves.not.toBe(true);`,
+				Errors: []rule_tester.InvalidTestCaseError{equalityError(30, func(matcher string) string {
+					return `expect(a).resolves.` + matcher + `(b);`
+				})},
+			},
+			{
+				Code: `expect(a !== b).resolves.not.toBe(false);`,
+				Errors: []rule_tester.InvalidTestCaseError{equalityError(30, func(matcher string) string {
+					return `expect(a).resolves.not.` + matcher + `(b);`
+				})},
+			},
+		},
+	)
+}

--- a/internal/utils/test_framework/accessor.go
+++ b/internal/utils/test_framework/accessor.go
@@ -279,3 +279,24 @@ func AccessorReplacement(sourceFile *ast.SourceFile, node *ast.Node, name string
 		return core.TextRange{}, "", false
 	}
 }
+
+// InsertMemberBeforeAccessor returns the insertion edit for a dotted member
+// immediately before entry while keeping an optional boundary on the original
+// receiver. The caller decides whether the edit is an autofix or suggestion.
+func InsertMemberBeforeAccessor(entry *MemberEntry, name string) (core.TextRange, string, bool) {
+	receiver, accessor := AccessorReceiverAndParent(entry)
+	if receiver == nil || accessor == nil {
+		return core.TextRange{}, "", false
+	}
+
+	questionDot := AccessorQuestionDotToken(accessor)
+	if questionDot == nil {
+		return core.NewTextRange(receiver.End(), receiver.End()), "." + name, true
+	}
+
+	suffix := name
+	if accessor.Kind == ast.KindPropertyAccessExpression {
+		suffix += "."
+	}
+	return core.NewTextRange(questionDot.End(), questionDot.End()), suffix, true
+}

--- a/internal/utils/test_framework/accessor_test.go
+++ b/internal/utils/test_framework/accessor_test.go
@@ -248,6 +248,37 @@ func TestRemoveAccessorEntryRanges(t *testing.T) {
 	}
 }
 
+func TestInsertMemberBeforeAccessor(t *testing.T) {
+	tests := []struct {
+		name string
+		code string
+		want string
+	}{
+		{name: "property", code: `a.b()`, want: `a.x.b()`},
+		{name: "element", code: `a['b']()`, want: `a.x['b']()`},
+		{name: "optional property", code: `a?.b()`, want: `a?.x.b()`},
+		{name: "optional element", code: `a?.['b']()`, want: `a?.x['b']()`},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, call := parseFirstCall(t, test.code)
+			entries := GetMemberEntries(call)
+			if len(entries) < 2 {
+				t.Fatalf("no member accessor in %q", test.code)
+			}
+			textRange, text, ok := InsertMemberBeforeAccessor(&entries[1], "x")
+			if !ok {
+				t.Fatalf("InsertMemberBeforeAccessor returned false for %q", test.code)
+			}
+			got := test.code[:textRange.Pos()] + text + test.code[textRange.End():]
+			if got != test.want {
+				t.Errorf("output = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
 func TestAccessorRejectsUnsupportedNodes(t *testing.T) {
 	t.Run("nil node", func(t *testing.T) {
 		if _, ok := AccessorRange(nil, nil); ok {
@@ -261,6 +292,9 @@ func TestAccessorRejectsUnsupportedNodes(t *testing.T) {
 		}
 		if IsAccessorNode(nil) {
 			t.Error("IsAccessorNode(nil) = true, want false")
+		}
+		if _, _, ok := InsertMemberBeforeAccessor(nil, "x"); ok {
+			t.Error("InsertMemberBeforeAccessor(nil) = true, want false")
 		}
 	})
 

--- a/internal/utils/test_framework/rules/prefer_equality_matcher/prefer_equality_matcher.go
+++ b/internal/utils/test_framework/rules/prefer_equality_matcher/prefer_equality_matcher.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 
 	"github.com/microsoft/TypeScript/tsc/shim/ast"
+	"github.com/microsoft/TypeScript/tsc/shim/scanner"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	testFramework "github.com/web-infra-dev/rslint/internal/utils/test_framework"
 )
@@ -33,10 +34,18 @@ type Runtime struct {
 // Match contains the source nodes and normalized modifier decision needed by
 // a framework-specific suggestion builder.
 type Match struct {
-	Expect          *ExpectCall
-	Comparison      *ast.Node
-	Left            *ast.Node
-	Right           *ast.Node
+	Expect     *ExpectCall
+	Comparison *ast.Node
+	Left       *ast.Node
+	Right      *ast.Node
+	// LeftText and RightText are the operands as they must be written at
+	// their new positions, which is not always their authored source text.
+	LeftText  string
+	RightText string
+	// MatcherArgument is the span the right operand replaces. It is the
+	// boolean literal, widened to the outermost type assertion around it so
+	// that an assertion written for the literal is not re-applied to an
+	// unrelated operand.
 	MatcherArgument *ast.Node
 	ShouldHaveNot   bool
 	ModifierText    string
@@ -79,23 +88,64 @@ func parseStrictEqualityComparison(node *ast.Node) (left, right *ast.Node, negat
 	}
 }
 
-func unwrapBooleanLiteral(node *ast.Node) (literal *ast.Node, value bool, ok bool) {
+// unwrapBooleanLiteral reads the boolean a matcher argument asserts through
+// parentheses and type assertions, and returns the span a replacement operand
+// has to take over. The span stops at the outermost type assertion rather than
+// at the literal: `toBe(true as const)` asserts a type that only holds for the
+// literal, so leaving `as const` behind would produce uncompilable code.
+func unwrapBooleanLiteral(node *ast.Node) (target *ast.Node, value bool, ok bool) {
 	for node != nil {
 		node = ast.SkipParentheses(node)
+		if node == nil {
+			break
+		}
 		switch node.Kind {
 		case ast.KindAsExpression:
+			if target == nil {
+				target = node
+			}
 			node = node.AsAsExpression().Expression
 		case ast.KindTypeAssertionExpression:
+			if target == nil {
+				target = node
+			}
 			node = node.AsTypeAssertion().Expression
 		case ast.KindTrueKeyword:
-			return node, true, true
+			if target == nil {
+				target = node
+			}
+			return target, true, true
 		case ast.KindFalseKeyword:
-			return node, false, true
+			if target == nil {
+				target = node
+			}
+			return target, false, true
 		default:
 			return nil, false, false
 		}
 	}
 	return nil, false, false
+}
+
+// operandText renders an operand for its new position. Redundant parentheses
+// are dropped, except around a comma expression: `expect((f(), a) === b)`
+// would otherwise become `expect(f(), a)`, which passes two arguments and
+// asserts on the wrong value.
+func operandText(sourceFile *ast.SourceFile, node *ast.Node) string {
+	inner := ast.SkipParentheses(node)
+	text := scanner.GetSourceTextOfNodeFromSourceFile(sourceFile, inner, false)
+	if isCommaExpression(inner) {
+		return "(" + text + ")"
+	}
+	return text
+}
+
+func isCommaExpression(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	return node.Kind == ast.KindBinaryExpression &&
+		node.AsBinaryExpression().OperatorToken.Kind == ast.KindCommaToken
 }
 
 func modifierText(modifiers []testFramework.MemberEntry, addNot bool) string {
@@ -173,6 +223,8 @@ func NewRule(config Config) rule.Rule {
 						expectCall.MatcherEntry.Node,
 						buildUseEqualityMatcherMessage(),
 						func() []rule.RuleSuggestion {
+							match.LeftText = operandText(ctx.SourceFile, match.Left)
+							match.RightText = operandText(ctx.SourceFile, match.Right)
 							suggestions := make([]rule.RuleSuggestion, 0, len(equalityMatchers))
 							for _, equalityMatcher := range equalityMatchers {
 								fixes := config.BuildFixes(ctx, match, equalityMatcher)

--- a/internal/utils/test_framework/rules/prefer_equality_matcher/prefer_equality_matcher.go
+++ b/internal/utils/test_framework/rules/prefer_equality_matcher/prefer_equality_matcher.go
@@ -1,0 +1,194 @@
+// Package prefer_equality_matcher holds the framework-neutral matching and
+// suggestion planning shared by jest/prefer-equality-matcher and
+// rstest/prefer-equality-matcher. Framework adapters own expect parsing and
+// source edits; this package owns the strict-comparison contract and truth
+// table.
+package prefer_equality_matcher
+
+import (
+	"slices"
+
+	"github.com/microsoft/TypeScript/tsc/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	testFramework "github.com/web-infra-dev/rslint/internal/utils/test_framework"
+)
+
+var equalityMatchers = []string{"toBe", "toEqual", "toStrictEqual"}
+
+// ExpectCall is the framework-neutral projection of one parsed expect
+// assertion. Adapters deliberately project only the matcher shape their
+// framework wants this rule to inspect.
+type ExpectCall struct {
+	HeadCall     *ast.Node
+	MatcherCall  *ast.Node
+	MatcherEntry testFramework.MemberEntry
+	Matcher      string
+	Modifiers    []testFramework.MemberEntry
+}
+
+type Runtime struct {
+	Parse func(*ast.Node) *ExpectCall
+}
+
+// Match contains the source nodes and normalized modifier decision needed by
+// a framework-specific suggestion builder.
+type Match struct {
+	Expect          *ExpectCall
+	Comparison      *ast.Node
+	Left            *ast.Node
+	Right           *ast.Node
+	MatcherArgument *ast.Node
+	ShouldHaveNot   bool
+	ModifierText    string
+}
+
+type Config struct {
+	Name       string
+	Prepare    func(rule.RuleContext) Runtime
+	BuildFixes func(rule.RuleContext, Match, string) []rule.RuleFix
+}
+
+func buildUseEqualityMatcherMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "useEqualityMatcher",
+		Description: "Prefer using one of the equality matchers instead",
+	}
+}
+
+func buildSuggestEqualityMatcherMessage(equalityMatcher string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "suggestEqualityMatcher",
+		Description: "Use `" + equalityMatcher + "`",
+	}
+}
+
+func parseStrictEqualityComparison(node *ast.Node) (left, right *ast.Node, negated bool, ok bool) {
+	node = ast.SkipParentheses(node)
+	if node == nil || node.Kind != ast.KindBinaryExpression {
+		return nil, nil, false, false
+	}
+
+	binary := node.AsBinaryExpression()
+	switch binary.OperatorToken.Kind {
+	case ast.KindEqualsEqualsEqualsToken:
+		return binary.Left, binary.Right, false, true
+	case ast.KindExclamationEqualsEqualsToken:
+		return binary.Left, binary.Right, true, true
+	default:
+		return nil, nil, false, false
+	}
+}
+
+func unwrapBooleanLiteral(node *ast.Node) (literal *ast.Node, value bool, ok bool) {
+	for node != nil {
+		node = ast.SkipParentheses(node)
+		switch node.Kind {
+		case ast.KindAsExpression:
+			node = node.AsAsExpression().Expression
+		case ast.KindTypeAssertionExpression:
+			node = node.AsTypeAssertion().Expression
+		case ast.KindTrueKeyword:
+			return node, true, true
+		case ast.KindFalseKeyword:
+			return node, false, true
+		default:
+			return nil, false, false
+		}
+	}
+	return nil, false, false
+}
+
+func modifierText(modifiers []testFramework.MemberEntry, addNot bool) string {
+	text := ""
+	for _, modifier := range modifiers {
+		if modifier.Name != "not" {
+			text = "." + modifier.Name
+			break
+		}
+	}
+	if addNot {
+		text += ".not"
+	}
+	return text
+}
+
+func shouldAddNot(comparisonNegated, matcherValue, hasNot bool) bool {
+	return (comparisonNegated != matcherValue) == hasNot
+}
+
+func NewRule(config Config) rule.Rule {
+	return rule.Rule{
+		Name:   config.Name,
+		Schema: rule.EmptyArraySchema,
+		Run: func(ctx rule.RuleContext, _ []any) rule.RuleListeners {
+			runtime := config.Prepare(ctx)
+			return rule.RuleListeners{
+				ast.KindCallExpression: func(node *ast.Node) {
+					if runtime.Parse == nil || config.BuildFixes == nil {
+						return
+					}
+					expectCall := runtime.Parse(node)
+					if expectCall == nil ||
+						expectCall.HeadCall == nil ||
+						expectCall.MatcherCall == nil ||
+						expectCall.MatcherEntry.Node == nil ||
+						!slices.Contains(equalityMatchers, expectCall.Matcher) {
+						return
+					}
+
+					expectArguments := expectCall.HeadCall.Arguments()
+					if len(expectArguments) == 0 {
+						return
+					}
+					comparison := ast.SkipParentheses(expectArguments[0])
+					left, right, comparisonNegated, ok := parseStrictEqualityComparison(comparison)
+					if !ok {
+						return
+					}
+
+					matcherArguments := expectCall.MatcherCall.Arguments()
+					if len(matcherArguments) == 0 {
+						return
+					}
+					matcherArgument, matcherValue, ok := unwrapBooleanLiteral(matcherArguments[0])
+					if !ok {
+						return
+					}
+
+					hasNot := slices.ContainsFunc(expectCall.Modifiers, func(entry testFramework.MemberEntry) bool {
+						return entry.Name == "not"
+					})
+					shouldHaveNot := shouldAddNot(comparisonNegated, matcherValue, hasNot)
+					match := Match{
+						Expect:          expectCall,
+						Comparison:      comparison,
+						Left:            left,
+						Right:           right,
+						MatcherArgument: matcherArgument,
+						ShouldHaveNot:   shouldHaveNot,
+						ModifierText:    modifierText(expectCall.Modifiers, shouldHaveNot),
+					}
+
+					ctx.ReportNodeWithDeferredSuggestions(
+						expectCall.MatcherEntry.Node,
+						buildUseEqualityMatcherMessage(),
+						func() []rule.RuleSuggestion {
+							suggestions := make([]rule.RuleSuggestion, 0, len(equalityMatchers))
+							for _, equalityMatcher := range equalityMatchers {
+								fixes := config.BuildFixes(ctx, match, equalityMatcher)
+								if len(fixes) == 0 {
+									return nil
+								}
+								suggestions = append(suggestions, rule.RuleSuggestion{
+									Message:  buildSuggestEqualityMatcherMessage(equalityMatcher),
+									FixesArr: fixes,
+								})
+							}
+							return suggestions
+						},
+					)
+				},
+			}
+		},
+	}
+}

--- a/internal/utils/test_framework/rules/prefer_equality_matcher/prefer_equality_matcher.go
+++ b/internal/utils/test_framework/rules/prefer_equality_matcher/prefer_equality_matcher.go
@@ -92,7 +92,7 @@ func parseStrictEqualityComparison(node *ast.Node) (left, right *ast.Node, negat
 // parentheses and type assertions, and returns the span a replacement operand
 // has to take over. The span stops at the outermost type assertion rather than
 // at the literal: `toBe(true as const)` asserts a type that only holds for the
-// literal, so leaving `as const` behind would produce uncompilable code.
+// literal, so code that leaves `as const` behind no longer compiles.
 func unwrapBooleanLiteral(node *ast.Node) (target *ast.Node, value bool, ok bool) {
 	for node != nil {
 		node = ast.SkipParentheses(node)

--- a/internal/utils/test_framework/rules/prefer_equality_matcher/prefer_equality_matcher_test.go
+++ b/internal/utils/test_framework/rules/prefer_equality_matcher/prefer_equality_matcher_test.go
@@ -1,0 +1,171 @@
+package prefer_equality_matcher
+
+import (
+	"testing"
+
+	"github.com/microsoft/TypeScript/tsc/shim/ast"
+	"github.com/microsoft/TypeScript/tsc/shim/core"
+	"github.com/microsoft/TypeScript/tsc/shim/parser"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	testFramework "github.com/web-infra-dev/rslint/internal/utils/test_framework"
+)
+
+func TestShouldAddNotTruthTable(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		comparisonNegated bool
+		matcherValue      bool
+		hasNot            bool
+		want              bool
+	}{
+		{comparisonNegated: false, matcherValue: true, hasNot: false, want: false},
+		{comparisonNegated: false, matcherValue: false, hasNot: false, want: true},
+		{comparisonNegated: true, matcherValue: true, hasNot: false, want: true},
+		{comparisonNegated: true, matcherValue: false, hasNot: false, want: false},
+		{comparisonNegated: false, matcherValue: true, hasNot: true, want: true},
+		{comparisonNegated: false, matcherValue: false, hasNot: true, want: false},
+		{comparisonNegated: true, matcherValue: true, hasNot: true, want: false},
+		{comparisonNegated: true, matcherValue: false, hasNot: true, want: true},
+	}
+
+	for _, test := range tests {
+		if got := shouldAddNot(test.comparisonNegated, test.matcherValue, test.hasNot); got != test.want {
+			t.Errorf("shouldAddNot(%t, %t, %t) = %t, want %t", test.comparisonNegated, test.matcherValue, test.hasNot, got, test.want)
+		}
+	}
+}
+
+func TestEqualityMatcherSuggestionOrder(t *testing.T) {
+	t.Parallel()
+
+	want := []string{"toBe", "toEqual", "toStrictEqual"}
+	if len(equalityMatchers) != len(want) {
+		t.Fatalf("equalityMatchers has %d entries, want %d", len(equalityMatchers), len(want))
+	}
+	for index := range want {
+		if equalityMatchers[index] != want[index] {
+			t.Errorf("equalityMatchers[%d] = %q, want %q", index, equalityMatchers[index], want[index])
+		}
+	}
+}
+
+func TestNewRuleBuildsThreeNonOverlappingSuggestions(t *testing.T) {
+	t.Parallel()
+
+	sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: "/test.ts",
+		Path:     "/test.ts",
+	}, `expect(a === b).not.toBe(false);`, core.ScriptKindTS)
+
+	var calls []*ast.Node
+	var visit func(*ast.Node) bool
+	visit = func(node *ast.Node) bool {
+		if node.Kind == ast.KindCallExpression {
+			calls = append(calls, node)
+		}
+		return node.ForEachChild(visit)
+	}
+	sourceFile.AsNode().ForEachChild(visit)
+	if len(calls) != 2 {
+		t.Fatalf("call count = %d, want 2", len(calls))
+	}
+
+	outer, head := calls[0], calls[1]
+	entries := testFramework.GetMemberEntries(outer)
+	if len(entries) != 3 {
+		t.Fatalf("member count = %d, want 3", len(entries))
+	}
+
+	buildCount := 0
+	r := NewRule(Config{
+		Name: "test/prefer-equality-matcher",
+		Prepare: func(rule.RuleContext) Runtime {
+			return Runtime{Parse: func(node *ast.Node) *ExpectCall {
+				if node != outer {
+					return nil
+				}
+				return &ExpectCall{
+					HeadCall:     head,
+					MatcherCall:  outer,
+					MatcherEntry: entries[2],
+					Matcher:      entries[2].Name,
+					Modifiers:    entries[1:2],
+				}
+			}}
+		},
+		BuildFixes: func(_ rule.RuleContext, match Match, equalityMatcher string) []rule.RuleFix {
+			buildCount++
+			if match.ShouldHaveNot {
+				t.Fatal("existing not should be removed for !== false")
+			}
+			if match.ModifierText != "" {
+				t.Fatalf("modifier text = %q, want empty", match.ModifierText)
+			}
+			return []rule.RuleFix{
+				rule.RuleFixReplaceRange(core.NewTextRange(0, 1), "left"),
+				rule.RuleFixReplaceRange(core.NewTextRange(2, 3), equalityMatcher),
+				rule.RuleFixReplaceRange(core.NewTextRange(4, 5), "right"),
+			}
+		},
+	})
+
+	run := func(demand rule.EditDemand) []rule.RuleDiagnostic {
+		t.Helper()
+		var diagnostics []rule.RuleDiagnostic
+		ctx := rule.RuleContext{SourceFile: sourceFile}.WithDiagnosticConsumer(
+			r.Name,
+			rule.SeverityError,
+			rule.DiagnosticConsumer{
+				Demand: demand,
+				Report: func(diagnostic rule.RuleDiagnostic) {
+					diagnostics = append(diagnostics, diagnostic)
+				},
+			},
+		)
+		r.Run(ctx, nil)[ast.KindCallExpression](outer)
+		return diagnostics
+	}
+
+	diagnosticsOnly := run(rule.EditDemandNone)
+	if len(diagnosticsOnly) != 1 || diagnosticsOnly[0].Suggestions != nil || buildCount != 0 {
+		t.Fatalf("diagnostics-only run = %#v, build count = %d", diagnosticsOnly, buildCount)
+	}
+	autofixOnly := run(rule.EditDemandAutofix)
+	if len(autofixOnly) != 1 || autofixOnly[0].Suggestions != nil || autofixOnly[0].FixesPtr != nil || buildCount != 0 {
+		t.Fatalf("autofix-only run = %#v, build count = %d", autofixOnly, buildCount)
+	}
+	diagnostics := run(rule.EditDemandSuggestion)
+
+	if len(diagnostics) != 1 || diagnostics[0].Suggestions == nil {
+		t.Fatalf("diagnostics = %#v, want one diagnostic with suggestions", diagnostics)
+	}
+	suggestions := *diagnostics[0].Suggestions
+	if len(suggestions) != 3 {
+		t.Fatalf("suggestions = %d, want 3", len(suggestions))
+	}
+	for index, matcher := range []string{"toBe", "toEqual", "toStrictEqual"} {
+		if suggestions[index].Message.Description != "Use `"+matcher+"`" {
+			t.Errorf("suggestion %d description = %q", index, suggestions[index].Message.Description)
+		}
+		fixes := suggestions[index].FixesArr
+		if len(fixes) != 3 || fixes[1].Text != matcher {
+			t.Errorf("suggestion %d fixes = %#v", index, fixes)
+		}
+		for fixIndex := 1; fixIndex < len(fixes); fixIndex++ {
+			if fixes[fixIndex-1].Range.End() > fixes[fixIndex].Range.Pos() {
+				t.Errorf("suggestion %d fixes %d and %d overlap: %#v", index, fixIndex-1, fixIndex, fixes)
+			}
+		}
+	}
+	if buildCount != 3 {
+		t.Errorf("suggestion build count = %d, want 3", buildCount)
+	}
+	allEdits := run(rule.EditDemandAll)
+	if len(allEdits) != 1 || allEdits[0].Suggestions == nil || len(*allEdits[0].Suggestions) != 3 || allEdits[0].FixesPtr != nil {
+		t.Fatalf("all-edits run = %#v, want suggestions only", allEdits)
+	}
+	if buildCount != 6 {
+		t.Errorf("all-edits build count = %d, want 6 total", buildCount)
+	}
+}

--- a/packages/rslint-test-tools/rstack.config.mts
+++ b/packages/rslint-test-tools/rstack.config.mts
@@ -647,6 +647,7 @@ define.test({
     './tests/rstest/rules/prefer-called-once.test.ts',
     './tests/rstest/rules/prefer-called-times.test.ts',
     './tests/rstest/rules/prefer-each.test.ts',
+    './tests/rstest/rules/prefer-equality-matcher.test.ts',
     './tests/rstest/rules/prefer-expect-type-of.test.ts',
     './tests/rstest/rules/prefer-hooks-in-order.test.ts',
     './tests/rstest/rules/prefer-import-in-mock.test.ts',

--- a/packages/rslint-test-tools/tests/rstest/rules/prefer-equality-matcher.test.ts
+++ b/packages/rslint-test-tools/tests/rstest/rules/prefer-equality-matcher.test.ts
@@ -11,21 +11,19 @@ const expectSuggestions = (output: (equalityMatcher: string) => string) =>
 
 ruleTester.run('prefer-equality-matcher', {} as never, {
   valid: [
-    // ===
     { code: 'expect.hasAssertions' },
     { code: 'expect.hasAssertions()' },
     { code: 'expect.assertions(1)' },
     { code: 'expect(true).toBe(...true)' },
+    { code: 'expect(a).to.be.a("string");' },
     { code: 'expect(a == 1).toBe(true)' },
     { code: 'expect(1 == a).toBe(true)' },
     { code: 'expect(a == b).toBe(true)' },
-    // !==
     { code: 'expect(a != 1).toBe(true)' },
     { code: 'expect(1 != a).toBe(true)' },
     { code: 'expect(a != b).toBe(true)' },
   ],
   invalid: [
-    // ===
     {
       code: 'expect(a === b).toBe(true);',
       errors: [
@@ -151,7 +149,7 @@ ruleTester.run('prefer-equality-matcher', {} as never, {
         {
           messageId: 'useEqualityMatcher',
           suggestions: expectSuggestions(
-            (equalityMatcher) => `expect(a).resolves.${equalityMatcher}(b);`,
+            (equalityMatcher) => `expect(a)["resolves"].${equalityMatcher}(b);`,
           ),
           column: 33,
           line: 1,
@@ -164,14 +162,14 @@ ruleTester.run('prefer-equality-matcher', {} as never, {
         {
           messageId: 'useEqualityMatcher',
           suggestions: expectSuggestions(
-            (equalityMatcher) => `expect(a).resolves.${equalityMatcher}(b);`,
+            (equalityMatcher) =>
+              `expect(a)["resolves"]["${equalityMatcher}"](b);`,
           ),
           column: 36,
           line: 1,
         },
       ],
     },
-    // !==
     {
       code: 'expect(a !== b).toBe(true);',
       errors: [


### PR DESCRIPTION
## Summary

Add `rstest/prefer-equality-matcher` to replace boolean assertions over strict comparisons with direct equality assertions. For example, `expect(actual === expected).toBe(true)` can be changed to `expect(actual).toBe(expected)`. The rule handles `===`, `!==`, boolean expectations, existing `not`, and promise modifiers, and offers three suggestions using `toBe`, `toEqual`, and `toStrictEqual`. It is registered in the Rstest plugin but stays out of the `recommended` preset, matching upstream.

Assertions resolve through the shared Rstest call analysis, covering globals, imports and aliases, namespace and `require` forms, `import.meta.rstest`, Playwright, TestContext `expect`, and assertion factories. Only the first called equality matcher is considered; loose comparisons, Chai assertions, dynamic matcher names, foreign expect functions, and local shadows are ignored. The suggestions retain the assertion root, a second expect message, promise modifiers, accessor spelling, surrounding trivia, and trailing commas, and they are built only when requested.

The strict-comparison predicate, boolean truth table, and suggestion planning now live under `internal/utils/test_framework/rules/prefer_equality_matcher` and are shared with the existing Jest rule. A framework-neutral accessor insertion helper is also extracted for placing `not` safely across dot, element, and optional access.

## Credits

Port from [`@vitest/eslint-plugin`](https://github.com/vitest-dev/eslint-plugin-vitest)'s `prefer-equality-matcher`.

## Intentional differences from upstream

- **Rstest suggestions preserve authored accessors and comments.** String and template accessors retain their delimiters, existing `not` members are removed in place, and comments outside the strict-comparison span survive. If rewriting the comparison would delete a comment or an accessor cannot be edited safely, the diagnostic is retained without suggestions.

- **TypeScript-wrapped boolean literals are recognized.** Parentheses and basic type assertions around `true` or `false` do not change the value being asserted, so these forms participate in the same equality truth table.

## Related Links

Related #935

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
