### PR TITLE
feat: add promise/spec-only rule

### DIFF
--- a/internal/plugins/promise/all.go
+++ b/internal/plugins/promise/all.go
@@ -14,6 +14,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/param_names"
 	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/prefer_await_to_then"
 	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/prefer_catch"
+	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/spec_only"
 	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/valid_params"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
@@ -33,6 +34,7 @@ func GetAllRules() []rule.Rule {
 		param_names.ParamNamesRule,
 		prefer_await_to_then.PreferAwaitToThenRule,
 		prefer_catch.PreferCatchRule,
+		spec_only.SpecOnlyRule,
 		valid_params.ValidParamsRule,
 	}
 }

--- a/internal/plugins/promise/rules/spec_only/spec_only.go
+++ b/internal/plugins/promise/rules/spec_only/spec_only.go
@@ -1,0 +1,131 @@
+package spec_only
+
+import (
+	_ "embed"
+	"strings"
+
+	"github.com/microsoft/TypeScript/tsc/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/promise/promiseutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+//go:embed spec_only.schema.json
+var schemaJSON []byte
+
+// identifierName mirrors ESTree's property.name, including private names.
+func identifierName(property *ast.Node) string {
+	switch property.Kind {
+	case ast.KindIdentifier:
+		return property.AsIdentifier().Text
+	case ast.KindPrivateIdentifier:
+		return strings.TrimPrefix(property.AsPrivateIdentifier().Text, "#")
+	default:
+		return ""
+	}
+}
+
+func propertyName(property *ast.Node) string {
+	if ast.IsMemberName(property) {
+		return identifierName(property)
+	}
+	// ESTree templates have neither .name nor .value, even without substitutions.
+	if property.Kind != ast.KindNoSubstitutionTemplateLiteral {
+		if value, ok := utils.GetStaticExpressionValue(property); ok {
+			return value
+		}
+	}
+	return "undefined"
+}
+
+func isPermittedProperty(node, property *ast.Node, instance bool, allowedMethods map[string]bool) bool {
+	var name string
+	switch property.Kind {
+	case ast.KindStringLiteral:
+		name = property.AsStringLiteral().Text
+	case ast.KindIdentifier:
+		if node.Kind == ast.KindElementAccessExpression {
+			return true
+		}
+		name = property.AsIdentifier().Text
+	default:
+		// Literal values are compared without coercion upstream, so numbers,
+		// booleans, null, bigints and regexps cannot match an allowed string.
+		return false
+	}
+	if allowedMethods[name] {
+		return true
+	}
+	if instance {
+		return name == "then" || name == "catch" || name == "finally"
+	}
+	return promiseutil.IsPromiseStatic(name) || name == "withResolvers"
+}
+
+// https://github.com/eslint-community/eslint-plugin-promise/blob/v7.3.0/rules/spec-only.js
+var SpecOnlyRule = rule.Rule{
+	Name:   "promise/spec-only",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		var allowedMethods map[string]bool
+		if len(options) > 0 {
+			if opts, ok := options[0].(map[string]any); ok {
+				if methods, ok := opts["allowedMethods"].([]any); ok {
+					allowedMethods = make(map[string]bool, len(methods))
+					for _, method := range methods {
+						if name, ok := method.(string); ok {
+							allowedMethods[name] = true
+						}
+					}
+				}
+			}
+		}
+
+		checkMember := func(node *ast.Node) {
+			object, property := utils.MemberExpressionParts(node)
+			object = utils.ESTreeRuntimeExpression(object)
+			if object == nil || !ast.IsIdentifier(object) || object.AsIdentifier().Text != "Promise" {
+				return
+			}
+			// Only a Promise receiver needs the parent walk that excludes JSX tags.
+			if utils.IsInJsxTagName(node) {
+				return
+			}
+			property = utils.ESTreeRuntimeExpression(property)
+			if property == nil {
+				return
+			}
+
+			if identifierName(property) == "prototype" {
+				parent := utils.ESTreeParent(node)
+				parentObject, parentProperty := utils.MemberExpressionParts(parent)
+				if parentProperty == nil {
+					return
+				}
+				// A terminated optional chain has an ESTree ChainExpression
+				// parent, even when tsgo exposes a member beyond parentheses.
+				if ast.IsOptionalChain(node) && (node.Parent != parent || !ast.IsOptionalChain(parent) || parentObject != node) {
+					return
+				}
+				if isPermittedProperty(parent, utils.ESTreeRuntimeExpression(parentProperty), true, allowedMethods) {
+					return
+				}
+			} else if isPermittedProperty(node, property, false, allowedMethods) {
+				return
+			}
+
+			name := propertyName(property)
+			ctx.ReportNode(node, rule.RuleMessage{
+				Id:          "avoidNonStandard",
+				Description: "Avoid using non-standard 'Promise." + name + "'",
+				Data:        map[string]string{"name": name},
+			})
+		}
+
+		return rule.RuleListeners{
+			ast.KindPropertyAccessExpression: checkMember,
+			ast.KindElementAccessExpression:  checkMember,
+			ast.KindQualifiedName:            checkMember,
+		}
+	},
+}

--- a/internal/plugins/promise/rules/spec_only/spec_only.md
+++ b/internal/plugins/promise/rules/spec_only/spec_only.md
@@ -1,0 +1,52 @@
+# spec-only
+
+Disallow non-standard Promise methods (`promise/spec-only`).
+
+Depending on Promise extensions can make it harder to migrate between implementations. This rule checks member access on `Promise`, including method references and calls, and checks members of `Promise.prototype`.
+
+## Rule Details
+
+The allowed static methods are `all`, `allSettled`, `any`, `race`, `reject`, `resolve`, and `withResolvers`. The allowed prototype methods are `then`, `catch`, and `finally`.
+
+Examples of incorrect code:
+
+```js
+const x = Promise.done('bad')
+const done = Promise['done']
+Promise.prototype.done
+```
+
+Examples of correct code:
+
+```js
+const x = Promise.resolve('good')
+Promise.allSettled(tasks)
+Promise.withResolvers()
+Promise.prototype.then
+Promise[method]
+```
+
+Computed identifiers such as `Promise[method]` are allowed. String keys are checked directly. Only members whose object is named `Promise` are checked; aliases and promise instances are not tracked.
+
+## Options
+
+### `allowedMethods`
+
+An array of additional method names to allow on both `Promise` and `Promise.prototype`. Defaults to an empty array.
+
+```js
+{
+  'promise/spec-only': ['error', { allowedMethods: ['done'] }]
+}
+```
+
+## Compatibility
+
+Optional access to a private member, such as `Promise?.#done` inside a class declaring `#done`, is rejected by the TypeScript parser before this rule runs.
+
+For computed regular-expression keys, rslint uses the literal's string representation. ESLint running on an older Node.js version can instead report `Promise.null` when that runtime cannot construct a regular expression using newer syntax, such as modifier groups in `Promise[/(?i:a)/]`.
+
+## Original Documentation
+
+- [eslint-plugin-promise: spec-only](https://github.com/eslint-community/eslint-plugin-promise/blob/v7.3.0/docs/rules/spec-only.md)
+- [Source code](https://github.com/eslint-community/eslint-plugin-promise/blob/v7.3.0/rules/spec-only.js)

--- a/internal/plugins/promise/rules/spec_only/spec_only.schema.json
+++ b/internal/plugins/promise/rules/spec_only/spec_only.schema.json
@@ -1,0 +1,19 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "properties": {
+        "allowedMethods": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/promise/rules/spec_only/spec_only_extras_test.go
+++ b/internal/plugins/promise/rules/spec_only/spec_only_extras_test.go
@@ -1,9 +1,9 @@
 package spec_only_test
 
 import (
-	"path/filepath"
 	"testing"
 
+	"github.com/microsoft/TypeScript/tsc/shim/tspath"
 	"github.com/web-infra-dev/rslint/internal/plugins/promise/fixtures"
 	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/spec_only"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
@@ -15,8 +15,9 @@ import (
 // Go assertions include complete diagnostic ranges.
 func TestSpecOnlyExtras(t *testing.T) {
 	root := fixtures.GetRootDir()
+	// Use tsgo paths for the in-memory filesystem on every platform.
 	root.FS = utils.NewOverlayVFS(root.FS, map[string]string{
-		filepath.Join(root.Dir, "tsconfig.allowJs.json"): `{"extends":"./tsconfig.json","compilerOptions":{"allowJs":true}}`,
+		tspath.ResolvePath(root.Dir, "tsconfig.allowJs.json"): `{"extends":"./tsconfig.json","compilerOptions":{"allowJs":true}}`,
 	})
 	rule_tester.RunRuleTester(root, "tsconfig.json", t, &spec_only.SpecOnlyRule,
 		[]rule_tester.ValidTestCase{

--- a/internal/plugins/promise/rules/spec_only/spec_only_extras_test.go
+++ b/internal/plugins/promise/rules/spec_only/spec_only_extras_test.go
@@ -1,0 +1,227 @@
+package spec_only_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/promise/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/spec_only"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// Additional cases checked against eslint-plugin-promise v7.3.0 with
+// @typescript-eslint/parser 8.65.0, or ESLint's default parser for JavaScript.
+// Go assertions include complete diagnostic ranges.
+func TestSpecOnlyExtras(t *testing.T) {
+	root := fixtures.GetRootDir()
+	root.FS = utils.NewOverlayVFS(root.FS, map[string]string{
+		filepath.Join(root.Dir, "tsconfig.allowJs.json"): `{"extends":"./tsconfig.json","compilerOptions":{"allowJs":true}}`,
+	})
+	rule_tester.RunRuleTester(root, "tsconfig.json", t, &spec_only.SpecOnlyRule,
+		[]rule_tester.ValidTestCase{
+			// Every standard method, including statics missing from upstream tests.
+			{Code: `Promise.allSettled([]); Promise.any([]); Promise["withResolvers"](); Promise.prototype.then; Promise.prototype.finally; Promise.prototype["catch"];`},
+			// Identifiers remain dynamic even when a variable has a known string value.
+			{Code: `const method = "done"; Promise[(method)]; Promise.prototype[(method)]; Promise[prototype]; Promise[prototype].then;`},
+			// Only direct Promise members are checked; promise instances and aliases are not tracked.
+			{Code: `const P = Promise; P.done(); globalThis.Promise.done(); Promise.resolve().done(); new Promise(fn).done(); Promise().done(); data.a.b.c.d.e.f.g.Promise.done;`},
+			// Static and instance allow lists share names and accept string keys.
+			{Code: `Promise.done(); Promise["done"]; Promise.prototype.done; Promise.prototype["done"]; Promise["prototype"].done;`,
+				Options: []any{map[string]any{"allowedMethods": []any{"done", "prototype", "done"}}}},
+			// String values are matched exactly, including empty and Unicode names.
+			{Code: `Promise[""]; Promise["完成"];`,
+				Options: []any{map[string]any{"allowedMethods": []any{"", "完成"}}}},
+			// Standard methods remain valid with an explicitly empty options object.
+			{Code: `Promise.resolve(); Promise.prototype.then;`,
+				Options: []any{map[string]any{}}},
+			// Parentheses terminating optional chains introduce ChainExpression parents.
+			{Code: `(Promise?.prototype).done; (Promise?.prototype)?.done; target[Promise?.prototype]; Promise?.prototype;`},
+			// TS assertions and non-null wrappers remain visible to ESTree.
+			{Code: `(Promise as any).done; Promise!.done; (Promise satisfies any).done; (Promise.prototype as any).done; Promise.prototype!.done; (Promise.prototype satisfies any).done;`},
+			// Dotted JSX tag names and ordinary type names are not member expressions.
+			{Code: `const node = <Promise.done />; const nested = <Other.Promise.done />; const deep = <Promise.foo.bar />; type T = Promise.done; type U = typeof Promise.done;`,
+				Tsx: true},
+			// A private prototype name takes the upstream prototype branch, but instance methods must still be permitted.
+			{Code: `class C { #prototype; m() { Promise.#prototype; Promise.#prototype.then; } }`},
+			// Allowed names are strings, including Object.prototype names and empty keys.
+			{Code: `Promise.__proto__; Promise.constructor; Promise.toString; Promise[""];`,
+				Options: []any{map[string]any{"allowedMethods": []any{"__proto__", "constructor", "toString", ""}}},
+			},
+			// A JSDoc cast does not remove the ChainExpression terminating optional access.
+			{Code: `(/** @type {any} */ (Promise?.prototype)).done;`,
+				FileName: "chain.js", TSConfig: "tsconfig.allowJs.json",
+			},
+		},
+		[]rule_tester.InvalidTestCase{
+			// Both explicit defaults reject a non-standard method.
+			{Code: `Promise.done;`,
+				Options: []any{map[string]any{}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.done'", Line: 1, Column: 1, EndLine: 1, EndColumn: 13},
+				}},
+			{Code: `Promise.done;`,
+				Options: []any{map[string]any{"allowedMethods": []any{}}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.done'", Line: 1, Column: 1, EndLine: 1, EndColumn: 13},
+				}},
+			// Static and prototype standard sets are distinct; prototype reports cover the receiver.
+			{Code: `Promise.then; Promise.catch; Promise.finally; Promise.prototype.resolve; Promise.prototype.withResolvers;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.then'", Line: 1, Column: 1, EndLine: 1, EndColumn: 13},
+					{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.catch'", Line: 1, Column: 15, EndLine: 1, EndColumn: 28},
+					{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.finally'", Line: 1, Column: 30, EndLine: 1, EndColumn: 45},
+					{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.prototype'", Line: 1, Column: 47, EndLine: 1, EndColumn: 64},
+					{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.prototype'", Line: 1, Column: 74, EndLine: 1, EndColumn: 91},
+				}},
+			// The special prototype branch uses property.name, including computed identifiers.
+			{Code: `Promise["prototype"]; Promise[prototype].done; Promise.prototype["done"]; target[Promise.prototype];`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.prototype'", Line: 1, Column: 1, EndLine: 1, EndColumn: 21},
+					{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.prototype'", Line: 1, Column: 23, EndLine: 1, EndColumn: 41},
+					{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.prototype'", Line: 1, Column: 48, EndLine: 1, EndColumn: 65},
+					{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.prototype'", Line: 1, Column: 82, EndLine: 1, EndColumn: 99},
+				}},
+			// Allowing prototype does not allow arbitrary prototype members.
+			{Code: `Promise.prototype.done;`,
+				Options: []any{map[string]any{"allowedMethods": []any{"prototype"}}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.prototype'", Line: 1, Column: 1, EndLine: 1, EndColumn: 18},
+				}},
+			// Parentheses are transparent around receivers, keys and prototype member expressions.
+			{Code: `((Promise)).done; (Promise.prototype).done; Promise[(("done"))]; Promise.prototype[("done")];`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.done'", Line: 1, Column: 1, EndLine: 1, EndColumn: 17},
+					{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.prototype'", Line: 1, Column: 20, EndLine: 1, EndColumn: 37},
+					{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.done'", Line: 1, Column: 45, EndLine: 1, EndColumn: 64},
+					{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.prototype'", Line: 1, Column: 66, EndLine: 1, EndColumn: 83},
+				}},
+			// Optional access reports members within a chain, including consecutive optional links.
+			{Code: `Promise?.done?.(); Promise?.["done"]; Promise?.prototype.done; Promise.prototype?.done; Promise?.prototype?.done;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.done'", Line: 1, Column: 1, EndLine: 1, EndColumn: 14},
+					{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.done'", Line: 1, Column: 20, EndLine: 1, EndColumn: 37},
+					{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.prototype'", Line: 1, Column: 39, EndLine: 1, EndColumn: 57},
+					{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.prototype'", Line: 1, Column: 64, EndLine: 1, EndColumn: 81},
+					{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.prototype'", Line: 1, Column: 89, EndLine: 1, EndColumn: 107},
+				}},
+			// Numeric, boolean, null, bigint and regexp keys are never coerced for allowedMethods.
+			{Code: `Promise[0x10]; Promise[1e21]; Promise[1_000]; Promise[true]; Promise[false]; Promise[null]; Promise[0x10n]; Promise[/done/mi];`,
+				Options: []any{map[string]any{"allowedMethods": []any{"16", "1e+21", "1000", "true", "false", "null", "/done/im"}}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.16'", Line: 1, Column: 1, EndLine: 1, EndColumn: 14},
+					{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.1e+21'", Line: 1, Column: 16, EndLine: 1, EndColumn: 29},
+					{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.1000'", Line: 1, Column: 31, EndLine: 1, EndColumn: 45},
+					{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.true'", Line: 1, Column: 47, EndLine: 1, EndColumn: 60},
+					{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.false'", Line: 1, Column: 62, EndLine: 1, EndColumn: 76},
+					{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.null'", Line: 1, Column: 78, EndLine: 1, EndColumn: 91},
+					{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.16'", Line: 1, Column: 93, EndLine: 1, EndColumn: 107},
+					{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise./done/im'", Line: 1, Column: 109, EndLine: 1, EndColumn: 126},
+				}},
+			// Expressions and templates have no ESTree name or literal value.
+			{Code: "Promise[`resolve`]; Promise[`done${suffix}`]; Promise[\"re\" + \"solve\"]; Promise[getMethod()]; Promise[-1]; Promise[{}]; Promise[[]];",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.undefined'", Line: 1, Column: 1, EndLine: 1, EndColumn: 19},
+					{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.undefined'", Line: 1, Column: 21, EndLine: 1, EndColumn: 45},
+					{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.undefined'", Line: 1, Column: 47, EndLine: 1, EndColumn: 70},
+					{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.undefined'", Line: 1, Column: 72, EndLine: 1, EndColumn: 92},
+					{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.undefined'", Line: 1, Column: 94, EndLine: 1, EndColumn: 105},
+					{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.undefined'", Line: 1, Column: 107, EndLine: 1, EndColumn: 118},
+					{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.undefined'", Line: 1, Column: 120, EndLine: 1, EndColumn: 131},
+				}},
+			// Private properties report their name without # and cannot be allowed by string.
+			{Code: `class C { #done; #prototype; m() { Promise.#done; Promise.#prototype.done; Promise.prototype.#done; } }`,
+				Options: []any{map[string]any{"allowedMethods": []any{"done"}}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.done'", Line: 1, Column: 36, EndLine: 1, EndColumn: 49},
+					{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.prototype'", Line: 1, Column: 76, EndLine: 1, EndColumn: 93},
+				}},
+			// The rule intentionally checks shadowed identifiers named Promise.
+			{Code: `function run(Promise) { return Promise.done(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.done'", Line: 1, Column: 32, EndLine: 1, EndColumn: 44},
+				}},
+			// TS wrappers around a property value have neither a name nor literal value.
+			{Code: `Promise["resolve" as string]; Promise[method!]; Promise.done<string>();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.undefined'", Line: 1, Column: 1, EndLine: 1, EndColumn: 29},
+					{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.undefined'", Line: 1, Column: 31, EndLine: 1, EndColumn: 47},
+					{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.done'", Line: 1, Column: 49, EndLine: 1, EndColumn: 61},
+				}},
+			// TS heritage names are ESTree members; heritage type arguments remain types.
+			{Code: `class C extends Promise.done {} interface I extends Promise.done {} class D implements Promise.prototype.done {} interface J extends Base<Promise.done> {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.done'", Line: 1, Column: 17, EndLine: 1, EndColumn: 29},
+					{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.done'", Line: 1, Column: 53, EndLine: 1, EndColumn: 65},
+					{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.prototype'", Line: 1, Column: 88, EndLine: 1, EndColumn: 105},
+				}},
+			// Runtime JSX expressions are checked while dotted tags are ignored.
+			{Code: `const node = <Promise.done value={Promise.done}>{Promise.prototype.done}</Promise.done>;`,
+				Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.done'", Line: 1, Column: 35, EndLine: 1, EndColumn: 47},
+					{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.prototype'", Line: 1, Column: 50, EndLine: 1, EndColumn: 67},
+				}},
+			// JSDoc casts in JavaScript are transparent to ESTree.
+			{Code: `/** @type {any} */ (Promise).done; (/** @type {any} */ (Promise.prototype)).done;`,
+				FileName: "cast.js",
+				TSConfig: "tsconfig.allowJs.json",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.done'", Line: 1, Column: 20, EndLine: 1, EndColumn: 34},
+					{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.prototype'", Line: 1, Column: 57, EndLine: 1, EndColumn: 74},
+				}},
+			// Unicode text and line breaks require complete UTF-16 diagnostic ranges.
+			{Code: `"😀"; Promise["完成"]
+Promise
+  .prototype
+  .done;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.完成'", Line: 1, Column: 7, EndLine: 1, EndColumn: 20},
+					{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.prototype'", Line: 2, Column: 1, EndLine: 3, EndColumn: 13},
+				}},
+			// Escaped names are decoded before matching and reporting.
+			// cspell:disable-next-line
+			{Code: `Pr\u006fmise.d\u006fne; Promise["d\u006fne"];`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.done'", Line: 1, Column: 1, EndLine: 1, EndColumn: 23},
+					{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.done'", Line: 1, Column: 25, EndLine: 1, EndColumn: 45},
+				}},
+			// A Bluebird-style migration has nested static references and prototype extensions.
+			{Code: `import Promise from "bluebird";
+export const load = files => Promise.map(files, readFile).tap(log);
+Promise.prototype.timeout = timeout;
+const join = Promise.join;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.map'", Line: 2, Column: 30, EndLine: 2, EndColumn: 41},
+					{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.prototype'", Line: 3, Column: 1, EndLine: 3, EndColumn: 18},
+					{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.join'", Line: 4, Column: 14, EndLine: 4, EndColumn: 26},
+				}},
+			// Numeric rounding and regexp stringification use the shared ECMAScript helpers.
+			// Regexp modifiers were checked against ESLint on Node 24.19.0.
+			{Code: `Promise[0x20000000000001]; Promise[1e309]; Promise[0x100000000000000000000n]; Promise[/a/yg]; Promise[/(?i:a)/];`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.9007199254740992'", Line: 1, Column: 1, EndLine: 1, EndColumn: 26}, {MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.Infinity'", Line: 1, Column: 28, EndLine: 1, EndColumn: 42}, {MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.1208925819614629174706176'", Line: 1, Column: 44, EndLine: 1, EndColumn: 77}, {MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise./a/gy'", Line: 1, Column: 79, EndLine: 1, EndColumn: 93}, {MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise./(?i:a)/'", Line: 1, Column: 95, EndLine: 1, EndColumn: 112}},
+			},
+			// BOM, CRLF and Unicode line separators preserve the full member range.
+			{Code: "\ufeff// before\r\nPromise\u2028 .prototype\u2029 .done;",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.prototype'", Line: 2, Column: 1, EndLine: 3, EndColumn: 12}},
+			},
+			// Line directives suppress diagnostics before and beside a statement.
+			{Code: `// eslint-disable-next-line
+Promise.done;
+Promise.done; // eslint-disable-line
+Promise.something;`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.something'", Line: 4, Column: 1, EndLine: 4, EndColumn: 18}},
+			},
+			// Block directives can re-enable reporting later on the same line.
+			{Code: `/* eslint-disable */ Promise.done; /* eslint-enable */ Promise.done;`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.done'", Line: 1, Column: 56, EndLine: 1, EndColumn: 68}},
+			},
+			// ESLint accepts optional private access, but tsgo reports TS18030 before rule execution.
+			{Code: `class C { #done; m() { Promise?.#done; } }`,
+				FileName: "private.js", TSConfig: "tsconfig.allowJs.json",
+				Skip:   true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.done'", Line: 1, Column: 24, EndLine: 1, EndColumn: 38}},
+			},
+		},
+	)
+}

--- a/internal/plugins/promise/rules/spec_only/spec_only_upstream_test.go
+++ b/internal/plugins/promise/rules/spec_only/spec_only_upstream_test.go
@@ -1,0 +1,84 @@
+package spec_only_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/promise/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/spec_only"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// All cases from eslint-plugin-promise v7.3.0, plus its documentation examples.
+// https://github.com/eslint-community/eslint-plugin-promise/blob/v7.3.0/__tests__/spec-only.js
+// https://github.com/eslint-community/eslint-plugin-promise/blob/v7.3.0/docs/rules/spec-only.md
+func TestSpecOnlyUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &spec_only.SpecOnlyRule,
+		[]rule_tester.ValidTestCase{
+			{Code: `Promise.resolve()`},
+			{Code: `Promise.reject()`},
+			{Code: `Promise.all()`},
+			{Code: `Promise["all"]`},
+			{Code: `Promise[method];`},
+			{Code: `Promise.prototype;`},
+			{Code: `Promise.prototype[method];`},
+			{Code: `Promise.prototype["then"];`},
+			{Code: `Promise.race()`},
+			// cspell:disable-next-line
+			{Code: `var ctch = Promise.prototype.catch`},
+			{Code: `Promise.withResolvers()`},
+			{Code: `new Promise(function (resolve, reject) {})`},
+			{Code: `SomeClass.resolve()`},
+			{Code: `doSomething(Promise.all)`},
+			{Code: `Promise.permittedMethod()`,
+				Options: []any{map[string]any{"allowedMethods": []any{"permittedMethod"}}}},
+			{Code: `Promise.prototype.permittedInstanceMethod`,
+				Options: []any{map[string]any{"allowedMethods": []any{"permittedInstanceMethod"}}}},
+			// Pinned documentation: valid example.
+			{Code: `const x = Promise.resolve('good')`},
+		},
+		[]rule_tester.InvalidTestCase{
+			{Code: `Promise.done()`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.done'", Line: 1, Column: 1, EndLine: 1, EndColumn: 13},
+				}},
+			{Code: `Promise.something()`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.something'", Line: 1, Column: 1, EndLine: 1, EndColumn: 18},
+				}},
+			{Code: `new Promise.done()`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.done'", Line: 1, Column: 5, EndLine: 1, EndColumn: 17},
+				}},
+			{Code: `
+        function foo() {
+          var a = getA()
+          return Promise.done(a)
+        }
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.done'", Line: 4, Column: 18, EndLine: 4, EndColumn: 30},
+				}},
+			{Code: `
+        function foo() {
+          getA(Promise.done)
+        }
+      `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.done'", Line: 3, Column: 16, EndLine: 3, EndColumn: 28},
+				}},
+			{Code: `var done = Promise.prototype.done`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.prototype'", Line: 1, Column: 12, EndLine: 1, EndColumn: 29},
+				}},
+			{Code: `Promise["done"];`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.done'", Line: 1, Column: 1, EndLine: 1, EndColumn: 16},
+				}},
+			// Pinned documentation: invalid example.
+			{Code: `const x = Promise.done('bad')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "avoidNonStandard", Message: "Avoid using non-standard 'Promise.done'", Line: 1, Column: 11, EndLine: 1, EndColumn: 23},
+				}},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstack.config.mts
+++ b/packages/rslint-test-tools/rstack.config.mts
@@ -696,6 +696,7 @@ define.test({
     './tests/eslint-plugin-promise/rules/param-names.test.ts',
     './tests/eslint-plugin-promise/rules/prefer-await-to-then.test.ts',
     './tests/eslint-plugin-promise/rules/prefer-catch.test.ts',
+    './tests/eslint-plugin-promise/rules/spec-only.test.ts',
     './tests/eslint-plugin-promise/rules/valid-params.test.ts',
 
     // eslint-plugin-unicorn

--- a/packages/rslint-test-tools/tests/eslint-plugin-promise/rules/spec-only.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-promise/rules/spec-only.test.ts
@@ -1,0 +1,78 @@
+// Upstream: eslint-plugin-promise v7.3.0 (__tests__/spec-only.js and docs/rules/spec-only.md).
+// Exact diagnostic IDs/ranges and absence of edits are asserted in the Go suite.
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('spec-only', {} as never, {
+  valid: [
+    { code: 'Promise.resolve()' },
+    { code: 'Promise.reject()' },
+    { code: 'Promise.all()' },
+    { code: 'Promise["all"]' },
+    { code: 'Promise[method];' },
+    { code: 'Promise.prototype;' },
+    { code: 'Promise.prototype[method];' },
+    { code: 'Promise.prototype["then"];' },
+    { code: 'Promise.race()' },
+    { code: 'var ctch = Promise.prototype.catch' },
+    { code: 'Promise.withResolvers()' },
+    { code: 'new Promise(function (resolve, reject) {})' },
+    { code: 'SomeClass.resolve()' },
+    { code: 'doSomething(Promise.all)' },
+    {
+      code: 'Promise.permittedMethod()',
+      options: [{ allowedMethods: ['permittedMethod'] }],
+    },
+    {
+      code: 'Promise.prototype.permittedInstanceMethod',
+      options: [{ allowedMethods: ['permittedInstanceMethod'] }],
+    },
+    // Pinned documentation: valid example.
+    { code: "const x = Promise.resolve('good')" },
+  ],
+  invalid: [
+    {
+      code: 'Promise.done()',
+      errors: [{ message: "Avoid using non-standard 'Promise.done'" }],
+    },
+    {
+      code: 'Promise.something()',
+      errors: [{ message: "Avoid using non-standard 'Promise.something'" }],
+    },
+    {
+      code: 'new Promise.done()',
+      errors: [{ message: "Avoid using non-standard 'Promise.done'" }],
+    },
+    {
+      code: `
+        function foo() {
+          var a = getA()
+          return Promise.done(a)
+        }
+      `,
+      errors: [{ message: "Avoid using non-standard 'Promise.done'" }],
+    },
+    {
+      code: `
+        function foo() {
+          getA(Promise.done)
+        }
+      `,
+      errors: [{ message: "Avoid using non-standard 'Promise.done'" }],
+    },
+    {
+      code: 'var done = Promise.prototype.done',
+      errors: [{ message: "Avoid using non-standard 'Promise.prototype'" }],
+    },
+    {
+      code: 'Promise["done"];',
+      errors: [{ message: "Avoid using non-standard 'Promise.done'" }],
+    },
+    {
+      // Pinned documentation: invalid example.
+      code: "const x = Promise.done('bad')",
+      errors: [{ message: "Avoid using non-standard 'Promise.done'" }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Add native `promise/spec-only` support matching eslint-plugin-promise v7.3.0, including standard static/prototype members, computed keys, method references, and the `allowedMethods` option. Register the rule and schema, add documentation, and mirror every upstream test and documentation example in Go and JS.

Reuse the existing member-expression, parentheses/JSDoc, literal-value, Promise-static and diagnostic helpers. Check the receiver before walking ancestors for JSX tags, and construct diagnostic text without `fmt.Sprintf`.

Validation:

- `go test ./internal/plugins/promise/rules/spec_only`: passed; 60 permanent cases including one explained parser skip.
- `go test ./internal/rules -run '^TestAllContainsEveryGoRuleExactlyOnce$'`: passed.
- `CI=true pnpm --dir packages/rslint-test-tools exec rs test run tests/eslint-plugin-promise/rules/spec-only.test.ts`: passed after rebuilding the native binary.
- Scoped Go lint and spelling checks, `pnpm run format:check`, and `git diff --check`: passed. Schema and public option types were regenerated through the normal build.
- Differential validation against ESLint 10.9.0 / eslint-plugin-promise 7.3.0: all diagnostic fields match for 8 real Bluebird/rslint files under two option sets (207 diagnostics), the original 53 test inputs, and 468 additional supported syntax/option combinations (276 diagnostics). Verified the actual file set and exactly one enabled rule on every API run, including named disable directives.

Compatibility is documented: tsgo rejects optional private access with TS18030, so that case remains an explained skip. ESLint's diagnostic text for newer regexp syntax can depend on its Node runtime; modifier groups match on Node 24.19.0, while Node 22.18.0 produces a null literal value upstream.

Go benchmark, initial port → final implementation (macOS arm64): fixtures are parsed once; each operation initializes the rule and runs its registered callbacks over 128 repetitions, including diagnostic reporting with `EditDemandNone`. Parsing and the complete lint pipeline are excluded. These are medians of six 300 ms samples per case, with CPU idle above 70% before each measurement. Temporary benchmark and generated-validation Go files were removed and are not part of this PR.

```sh
go test ./internal/plugins/promise/rules/spec_only -run '^$' -bench '^BenchmarkSpecOnly$' -benchmem -benchtime=300ms -count=6
```

| Case | ns/op before → after | Reduction | B/op before → after | allocs/op before → after |
| --- | ---: | ---: | ---: | ---: |
| UnrelatedMembers | 27,875.5 → 17,073.0 | 38.8% | 472.0 → 472.0 | 4 → 4 |
| StandardStatics | 5,587.5 → 5,207.5 | 6.8% | 472.0 → 472.0 | 4 → 4 |
| PrototypeAllowed | 7,648.5 → 6,472.5 | 15.4% | 472.0 → 472.0 | 4 → 4 |
| AllowedMethods | 8,251.5 → 7,642.0 | 7.4% | 728.0 → 728.0 | 6 → 6 |
| ManyAllowedMethods | 8,736.0 → 8,376.5 | 4.1% | 7,088.0 → 7,088.0 | 8 → 8 |
| StaticDiagnostics | 26,342.0 → 21,851.5 | 17.0% | 72,256.0 → 70,104.0 | 644 → 516 |
| PrototypeDiagnostics | 30,037.0 → 24,703.0 | 17.8% | 72,257.5 → 70,104.0 | 644 → 516 |
| IgnoredTSAndJSX | 7,265.0 → 6,238.5 | 14.1% | 472.0 → 472.0 | 4 → 4 |

## Related Links

- [Upstream rule](https://github.com/eslint-community/eslint-plugin-promise/blob/v7.3.0/rules/spec-only.js)
- [Upstream tests](https://github.com/eslint-community/eslint-plugin-promise/blob/v7.3.0/__tests__/spec-only.js)
- [Upstream documentation](https://github.com/eslint-community/eslint-plugin-promise/blob/v7.3.0/docs/rules/spec-only.md)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
