### PR TITLE
fix(react): honor JSX pragma in display-name

### DIFF
--- a/internal/plugins/react/rules/display_name/display_name.go
+++ b/internal/plugins/react/rules/display_name/display_name.go
@@ -1471,7 +1471,7 @@ var DisplayNameRule = rule.Rule{
 	Schema: rule.NewSchema(schemaJSON),
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		opts := parseOptions(options)
-		pragma := reactutil.GetReactPragma(ctx.Settings)
+		pragma := reactutil.GetReactPragmaFromContext(ctx)
 		createClass := reactutil.GetReactCreateClass(ctx.Settings)
 		wrappers := reactutil.GetComponentWrapperFunctions(ctx.Settings, pragma)
 

--- a/internal/plugins/react/rules/display_name/display_name.md
+++ b/internal/plugins/react/rules/display_name/display_name.md
@@ -6,6 +6,8 @@ Disallow missing `displayName` in a React component definition.
 
 `displayName` allows you to name your component. This name is used by React in debugging messages.
 
+Component detection uses the first `@jsx` comment in the file, then `settings.react.pragma`, and defaults to `React`. For example, `/** @jsx Foo */` makes the rule recognize `Foo.createClass` when `settings.react.createClass` is `"createClass"`, even if a different pragma is configured in settings.
+
 Examples of **incorrect** code for this rule:
 
 ```jsx

--- a/internal/plugins/react/rules/display_name/display_name_extras_test.go
+++ b/internal/plugins/react/rules/display_name/display_name_extras_test.go
@@ -3,11 +3,11 @@ package display_name
 // These regressions cover effective pragma resolution against eslint-plugin-react
 // v7.37.5. The existing rule suite lives in display_name_test.go.
 import (
-	"path/filepath"
 	"testing"
 
 	"github.com/microsoft/TypeScript/tsc/shim/ast"
 	"github.com/microsoft/TypeScript/tsc/shim/core"
+	"github.com/microsoft/TypeScript/tsc/shim/tspath"
 	"github.com/web-infra-dev/rslint/internal/linter"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
 	lintprogram "github.com/web-infra-dev/rslint/internal/program"
@@ -110,7 +110,7 @@ func TestDisplayNameExtrasPragma(t *testing.T) {
 			})
 			t.Run("source", func(t *testing.T) {
 				root := fixtures.GetRootDir()
-				fileName := filepath.Join(root.Dir, "pragma.tsx")
+				fileName := tspath.ResolvePath(root.Dir, "pragma.tsx")
 				fs := utils.NewOverlayVFS(root.FS, map[string]string{fileName: test.code})
 				program, err := lintprogram.NewFromRoots(lintprogram.RootOptions{
 					RootFileNames: []string{fileName}, Host: utils.CreateCompilerHost(root.Dir, fs),

--- a/internal/plugins/react/rules/display_name/display_name_extras_test.go
+++ b/internal/plugins/react/rules/display_name/display_name_extras_test.go
@@ -1,0 +1,169 @@
+package display_name
+
+// These regressions cover effective pragma resolution against eslint-plugin-react
+// v7.37.5. The existing rule suite lives in display_name_test.go.
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/microsoft/TypeScript/tsc/shim/ast"
+	"github.com/microsoft/TypeScript/tsc/shim/core"
+	"github.com/web-infra-dev/rslint/internal/linter"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	lintprogram "github.com/web-infra-dev/rslint/internal/program"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+func TestDisplayNameExtrasPragma(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		code     string
+		settings map[string]interface{}
+		errors   []rule_tester.InvalidTestCaseError
+	}{
+		{
+			name:     "block",
+			code:     "/** @jsx Foo */\nvar Hello = Foo.createClass({ render() { return <div />; } });",
+			settings: map[string]interface{}{"react": map[string]interface{}{"createClass": "createClass", "version": "16.14.0"}},
+			errors:   []rule_tester.InvalidTestCaseError{{MessageId: "noDisplayName", Message: "Component definition is missing display name", Line: 2, Column: 29, EndLine: 2, EndColumn: 61}},
+		},
+		{
+			name:     "line",
+			code:     "// @jsx Foo\nvar Hello = Foo.createClass({ render() { return <div />; } });",
+			settings: map[string]interface{}{"react": map[string]interface{}{"createClass": "createClass", "version": "16.14.0"}},
+			errors:   []rule_tester.InvalidTestCaseError{{MessageId: "noDisplayName", Message: "Component definition is missing display name", Line: 2, Column: 29, EndLine: 2, EndColumn: 61}},
+		},
+		{
+			name:     "source overrides settings",
+			code:     "/** @jsx Foo */\nvar Hello = Foo.createClass({ render() { return <div />; } });",
+			settings: map[string]interface{}{"react": map[string]interface{}{"createClass": "createClass", "version": "16.14.0", "pragma": "Bar"}},
+			errors:   []rule_tester.InvalidTestCaseError{{MessageId: "noDisplayName", Message: "Component definition is missing display name", Line: 2, Column: 29, EndLine: 2, EndColumn: 61}},
+		},
+		{
+			name:     "settings fallback",
+			code:     "// no annotation\nvar Hello = Foo.createClass({ render() { return <div />; } });",
+			settings: map[string]interface{}{"react": map[string]interface{}{"createClass": "createClass", "version": "16.14.0", "pragma": "Foo"}},
+			errors:   []rule_tester.InvalidTestCaseError{{MessageId: "noDisplayName", Message: "Component definition is missing display name", Line: 2, Column: 29, EndLine: 2, EndColumn: 61}},
+		},
+		{
+			name:     "default fallback",
+			code:     "// no annotation\nvar Hello = React.createClass({ render() { return <div />; } });",
+			settings: map[string]interface{}{"react": map[string]interface{}{"createClass": "createClass", "version": "16.14.0"}},
+			errors:   []rule_tester.InvalidTestCaseError{{MessageId: "noDisplayName", Message: "Component definition is missing display name", Line: 2, Column: 31, EndLine: 2, EndColumn: 63}},
+		},
+		{
+			name:     "dotted source",
+			code:     "/** @jsx Foo.h */\nvar Hello = Foo.createClass({ render() { return <div />; } });",
+			settings: map[string]interface{}{"react": map[string]interface{}{"createClass": "createClass", "version": "16.14.0", "pragma": "Bar"}},
+			errors:   []rule_tester.InvalidTestCaseError{{MessageId: "noDisplayName", Message: "Component definition is missing display name", Line: 2, Column: 29, EndLine: 2, EndColumn: 61}},
+		},
+		{
+			name:     "invalid source",
+			code:     "/** @jsx 123 */\nvar Hello = React.createClass({ render() { return <div />; } });",
+			settings: map[string]interface{}{"react": map[string]interface{}{"createClass": "createClass", "version": "16.14.0", "pragma": "Bar"}},
+			errors:   []rule_tester.InvalidTestCaseError{{MessageId: "noDisplayName", Message: "Component definition is missing display name", Line: 2, Column: 31, EndLine: 2, EndColumn: 63}},
+		},
+		{
+			name:     "first annotation",
+			code:     "/** @jsx Foo */ /* @jsx Bar */\nvar Hello = Foo.createClass({ render() { return <div />; } });",
+			settings: map[string]interface{}{"react": map[string]interface{}{"createClass": "createClass", "version": "16.14.0", "pragma": "Bar"}},
+			errors:   []rule_tester.InvalidTestCaseError{{MessageId: "noDisplayName", Message: "Component definition is missing display name", Line: 2, Column: 29, EndLine: 2, EndColumn: 61}},
+		},
+		{
+			name:     "overridden settings ignored",
+			code:     "/** @jsx Foo */\nvar Hello = Bar.createClass({ render() { return <div />; } });",
+			settings: map[string]interface{}{"react": map[string]interface{}{"createClass": "createClass", "version": "16.14.0", "pragma": "Bar"}},
+			errors:   []rule_tester.InvalidTestCaseError{},
+		},
+		{
+			name:     "overridden default ignored",
+			code:     "/** @jsx Foo */\nvar Hello = React.createClass({ render() { return <div />; } });",
+			settings: map[string]interface{}{"react": map[string]interface{}{"createClass": "createClass", "version": "16.14.0"}},
+			errors:   []rule_tester.InvalidTestCaseError{},
+		},
+		{
+			name:     "explicit display name",
+			code:     "/** @jsx Foo */\nvar Hello = Foo.createClass({ displayName: 'Hello', render() { return <div />; } });",
+			settings: map[string]interface{}{"react": map[string]interface{}{"createClass": "createClass", "version": "16.14.0"}},
+			errors:   []rule_tester.InvalidTestCaseError{},
+		},
+		{
+			name:     "wrapper substitution",
+			code:     "/** @jsx Foo */\nconst Hello = Foo.wrap(() => <div />);",
+			settings: map[string]interface{}{"react": map[string]interface{}{"createClass": "createClass", "version": "16.14.0", "pragma": "Bar"}, "componentWrapperFunctions": []any{map[string]interface{}{"object": "<pragma>", "property": "wrap"}}},
+			errors:   []rule_tester.InvalidTestCaseError{{MessageId: "noDisplayName", Message: "Component definition is missing display name", Line: 2, Column: 15, EndLine: 2, EndColumn: 38}},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			options := map[string]interface{}{"ignoreTranspilerName": true}
+			t.Run("checker", func(t *testing.T) {
+				var valid []rule_tester.ValidTestCase
+				var invalid []rule_tester.InvalidTestCase
+				if len(test.errors) == 0 {
+					valid = append(valid, rule_tester.ValidTestCase{Code: test.code, Tsx: true, Settings: test.settings, Options: options})
+				} else {
+					invalid = append(invalid, rule_tester.InvalidTestCase{Code: test.code, Tsx: true, Settings: test.settings, Options: options, Errors: test.errors})
+				}
+				rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &DisplayNameRule, valid, invalid)
+			})
+			t.Run("source", func(t *testing.T) {
+				root := fixtures.GetRootDir()
+				fileName := filepath.Join(root.Dir, "pragma.tsx")
+				fs := utils.NewOverlayVFS(root.FS, map[string]string{fileName: test.code})
+				program, err := lintprogram.NewFromRoots(lintprogram.RootOptions{
+					RootFileNames: []string{fileName}, Host: utils.CreateCompilerHost(root.Dir, fs),
+					CompilerOptions: &core.CompilerOptions{Target: core.ScriptTargetESNext}, SingleThreaded: true,
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				var diagnostics []rule.RuleDiagnostic
+				plan, err := linter.PrepareLintPlan(linter.PrepareLintPlanOptions{
+					Programs: []*lintprogram.Program{program}, TargetsByProgram: [][]string{{fileName}}, SingleThreaded: true,
+					GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+						return []rule.ConfiguredRule{{Name: DisplayNameRule.Name, Severity: rule.SeverityError,
+							Environment: &rule.RuleEnvironment{Settings: test.settings},
+							Run: func(ctx rule.RuleContext) rule.RuleListeners {
+								if ctx.TypeChecker != nil {
+									t.Fatal("source program unexpectedly has a checker")
+								}
+								return DisplayNameRule.Run(ctx, []any{options})
+							}}}
+					},
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				_, err = linter.RunLinter(linter.RunLinterOptions{SingleThreaded: true, LintPlan: plan,
+					Consumer: rule.DiagnosticConsumer{Report: func(d rule.RuleDiagnostic) { diagnostics = append(diagnostics, d) }},
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				if len(diagnostics) != len(test.errors) {
+					t.Fatalf("got %d diagnostics, want %d: %#v", len(diagnostics), len(test.errors), diagnostics)
+				}
+				for i, diagnostic := range diagnostics {
+					want := test.errors[i]
+					if diagnostic.Message.Id != want.MessageId || diagnostic.Message.Description != want.Message {
+						t.Fatalf("unexpected message: %#v", diagnostic.Message)
+					}
+					// All oracle cases report on the second line; use raw offsets to also
+					// validate the source-only Program's complete diagnostic range.
+					lineStart := 0
+					for j, ch := range test.code {
+						if ch == '\n' {
+							lineStart = j + 1
+							break
+						}
+					}
+					if diagnostic.Range.Pos() != lineStart+want.Column-1 || diagnostic.Range.End() != lineStart+want.EndColumn-1 {
+						t.Fatalf("range = %v, want columns %d-%d on line 2", diagnostic.Range, want.Column, want.EndColumn)
+					}
+				}
+			})
+		})
+	}
+}

--- a/internal/plugins/react/rules/display_name/display_name_test.go
+++ b/internal/plugins/react/rules/display_name/display_name_test.go
@@ -1748,9 +1748,6 @@ func TestDisplayNameRule(t *testing.T) {
 			Settings: map[string]interface{}{
 				"react": map[string]interface{}{"createClass": "createClass"},
 			},
-			// SKIP: rslint does not support ESLint's `/** @jsx ... */` directive
-			// comments. The pragma is read solely from settings.react.pragma.
-			Skip:   true,
 			Errors: []rule_tester.InvalidTestCaseError{{MessageId: noDisplayName}},
 		},
 

--- a/packages/rslint-test-tools/tests/eslint-plugin-react/rules/display-name.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react/rules/display-name.test.ts
@@ -372,6 +372,22 @@ ruleTester.run('display-name', {} as never, {
   ],
 
   invalid: [
+    {
+      code: `
+        /** @jsx Foo */
+        var Hello = Foo.createClass({
+          _renderHello: function() {
+            return <span>Hello {this.props.name}</span>;
+          },
+          render: function() {
+            return <div>{this._renderHello()}</div>;
+          }
+        });
+      `,
+      options: [{ ignoreTranspilerName: true }],
+      settings: { react: { createClass: 'createClass' } },
+      errors: [{ messageId: 'noDisplayName' }],
+    },
     // ---- Shadowed-but-only-some-paths shadowed ----
     {
       code: `


### PR DESCRIPTION
## Summary

Make `react/display-name` resolve the React pragma from source `@jsx` comments before falling back to settings, matching eslint-plugin-react v7.37.5.

Restore the skipped upstream case and add 12 regression scenarios covering pragma precedence, fallback, and wrapper substitution in both source-only and checker-backed Programs.

## Validation

- Compared all 12 scenarios with eslint-plugin-react v7.37.5.
- Go tests passed for `display_name` and `reactutil`.
- Rebuilt the CLI; `display-name` JS integration tests passed.
- Scoped Go lint, spell check, and format check passed.

## Checklist

- [x] Tests updated.
- [x] Documentation updated.
