### PR TITLE
feat: add promise/prefer-await-to-callbacks

### DIFF
--- a/internal/plugins/promise/all.go
+++ b/internal/plugins/promise/all.go
@@ -12,6 +12,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/no_return_in_finally"
 	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/no_return_wrap"
 	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/param_names"
+	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/prefer_await_to_callbacks"
 	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/prefer_await_to_then"
 	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/prefer_catch"
 	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/valid_params"
@@ -31,6 +32,7 @@ func GetAllRules() []rule.Rule {
 		no_return_in_finally.NoReturnInFinallyRule,
 		no_return_wrap.NoReturnWrapRule,
 		param_names.ParamNamesRule,
+		prefer_await_to_callbacks.PreferAwaitToCallbacksRule,
 		prefer_await_to_then.PreferAwaitToThenRule,
 		prefer_catch.PreferCatchRule,
 		valid_params.ValidParamsRule,

--- a/internal/plugins/promise/rules/prefer_await_to_callbacks/prefer_await_to_callbacks.go
+++ b/internal/plugins/promise/rules/prefer_await_to_callbacks/prefer_await_to_callbacks.go
@@ -1,0 +1,139 @@
+package prefer_await_to_callbacks
+
+import (
+	"slices"
+	"strings"
+
+	"github.com/microsoft/TypeScript/tsc/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+var callbackMessage = rule.RuleMessage{
+	Id:          "error",
+	Description: "Avoid callbacks. Prefer Async/Await.",
+}
+
+// parameterName mirrors ESTree's parameter.name: defaults, rest parameters,
+// destructuring and TypeScript parameter properties are separate node kinds.
+func parameterName(node *ast.Node) string {
+	param := node.AsParameterDeclaration()
+	if param.Initializer != nil || param.DotDotDotToken != nil ||
+		ast.IsParameterPropertyDeclaration(node, node.Parent) {
+		return ""
+	}
+	return propertyName(param.Name())
+}
+
+// Upstream reads property.name even for computed and private properties.
+// String literals have no name, while PrivateIdentifier names omit the '#'.
+func propertyName(node *ast.Node) string {
+	if node == nil {
+		return ""
+	}
+	switch node.Kind {
+	case ast.KindIdentifier:
+		return node.AsIdentifier().Text
+	case ast.KindPrivateIdentifier:
+		return strings.TrimPrefix(node.AsPrivateIdentifier().Text, "#")
+	default:
+		return ""
+	}
+}
+
+func isCallbackName(name string) bool {
+	return name == "cb" || name == "callback"
+}
+
+func isArrayMethod(name string) bool {
+	switch name {
+	case "map", "every", "forEach", "some", "find", "filter":
+		return true
+	default:
+		return false
+	}
+}
+
+func isInsideYieldOrAwait(node *ast.Node) bool {
+	return ast.FindAncestor(node.Parent, func(parent *ast.Node) bool {
+		return parent.Kind == ast.KindAwaitExpression || parent.Kind == ast.KindYieldExpression
+	}) != nil
+}
+
+var PreferAwaitToCallbacksRule = rule.Rule{
+	Name:   "promise/prefer-await-to-callbacks",
+	Schema: rule.EmptyArraySchema,
+	Run: func(ctx rule.RuleContext, _ []any) rule.RuleListeners {
+		checkLastParameter := func(node *ast.Node) {
+			// Body-absent TypeScript declarations are TSDeclareFunction or
+			// TSEmptyBodyFunctionExpression nodes, outside upstream's listeners.
+			if node.Body() == nil {
+				return
+			}
+			// Only inspect the last authored parameter; cloning/filtering the
+			// entire list is unnecessary. JSDoc can synthesize a this parameter.
+			for _, last := range slices.Backward(node.Parameters()) {
+				if utils.IsJSDocSyntaxNode(last) {
+					continue
+				}
+				if isCallbackName(parameterName(last)) {
+					ctx.ReportRange(utils.GetESTreeBindingIdentifierRange(ctx.SourceFile, last.Name()), callbackMessage)
+				}
+				break
+			}
+		}
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				call := node.AsCallExpression()
+				// Ordinary import() is an ESTree ImportExpression, not a call.
+				// IsImportCall also includes import.defer(), which the pinned
+				// reference parser still exposes as a CallExpression.
+				if call.Expression.Kind == ast.KindImportKeyword {
+					return
+				}
+				callee := utils.ESTreeCallCallee(call.Expression)
+				if isCallbackName(propertyName(callee)) {
+					ctx.ReportNode(node, callbackMessage)
+					return
+				}
+				args := call.Arguments.Nodes
+				if len(args) == 0 {
+					return
+				}
+				arg := utils.ESTreeRuntimeExpression(args[len(args)-1])
+				if arg.Kind != ast.KindFunctionExpression && arg.Kind != ast.KindArrowFunction {
+					return
+				}
+				object, property := utils.MemberExpressionParts(callee)
+				name := propertyName(utils.ESTreeRuntimeExpression(property))
+				if name == "on" || name == "once" {
+					return
+				}
+				objectName := propertyName(utils.ESTreeRuntimeExpression(object))
+				isLodash := objectName == "lodash" || objectName == "underscore" || objectName == "_"
+				if (isArrayMethod(name) && (len(args) == 1 || (len(args) == 2 && isLodash))) ||
+					(isArrayMethod(propertyName(callee)) && len(args) == 2) {
+					return
+				}
+				for _, first := range arg.Parameters() {
+					if utils.IsJSDocSyntaxNode(first) {
+						continue
+					}
+					firstName := parameterName(first)
+					if (firstName == "err" || firstName == "error") && !isInsideYieldOrAwait(node) {
+						ctx.ReportNode(arg, callbackMessage)
+					}
+					break
+				}
+			},
+			ast.KindFunctionDeclaration: checkLastParameter,
+			ast.KindFunctionExpression:  checkLastParameter,
+			ast.KindArrowFunction:       checkLastParameter,
+			// ESTree represents method/accessor/constructor values as functions.
+			ast.KindMethodDeclaration: checkLastParameter,
+			ast.KindGetAccessor:       checkLastParameter,
+			ast.KindSetAccessor:       checkLastParameter,
+			ast.KindConstructor:       checkLastParameter,
+		}
+	},
+}

--- a/internal/plugins/promise/rules/prefer_await_to_callbacks/prefer_await_to_callbacks.md
+++ b/internal/plugins/promise/rules/prefer_await_to_callbacks/prefer_await_to_callbacks.md
@@ -1,0 +1,45 @@
+# prefer-await-to-callbacks
+
+Prefer `async`/`await` to callback patterns.
+
+## Rule Details
+
+This rule reports calls to identifiers named `cb` or `callback`, function
+parameters with either name in the last position, and calls whose last argument
+is a function or arrow function with a first parameter named `err` or `error`.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+cb();
+callback();
+doSomething(arg, (err) => {});
+function doSomethingElse(cb) {}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+await doSomething(arg);
+async function doSomethingElse() {}
+function* values() {
+  yield yieldValue((err) => {});
+}
+eventEmitter.on('error', (err) => {});
+```
+
+The last-argument check allows `on` and `once` listeners and the array methods
+`map`, `every`, `forEach`, `some`, `find`, and `filter` with one argument. It also
+allows those methods with two arguments on `lodash`, `underscore`, or `_`, and
+direct calls to those method names with two arguments.
+
+Callbacks within an `await` or `yield` expression are exempt from the
+last-argument check. Direct `cb`/`callback` calls and last parameters with those
+names are still reported in those contexts.
+
+This rule has no options and provides no automatic fixes or suggestions.
+
+## Original Documentation
+
+- [eslint-plugin-promise: prefer-await-to-callbacks](https://github.com/eslint-community/eslint-plugin-promise/blob/v7.3.0/docs/rules/prefer-await-to-callbacks.md)
+- [Source code](https://github.com/eslint-community/eslint-plugin-promise/blob/v7.3.0/rules/prefer-await-to-callbacks.js)

--- a/internal/plugins/promise/rules/prefer_await_to_callbacks/prefer_await_to_callbacks_extras_test.go
+++ b/internal/plugins/promise/rules/prefer_await_to_callbacks/prefer_await_to_callbacks_extras_test.go
@@ -1,0 +1,293 @@
+package prefer_await_to_callbacks_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/promise/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/prefer_await_to_callbacks"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// Additional AST and branch coverage, checked against eslint-plugin-promise v7.3.0.
+func TestPreferAwaitToCallbacksExtras(t *testing.T) {
+	root := fixtures.GetRootDir()
+	root.FS = utils.NewOverlayVFS(root.FS, map[string]string{
+		filepath.Join(root.Dir, "tsconfig.callbacks.json"): `{"extends":"./tsconfig.json","compilerOptions":{"allowJs":true}}`,
+	})
+	rule_tester.RunRuleTester(root, "tsconfig.callbacks.json", t, &prefer_await_to_callbacks.PreferAwaitToCallbacksRule,
+		[]rule_tester.ValidTestCase{
+			// Only bare callback names in the final parameter position match.
+			{Code: `function work(cb, done) {}
+const expression = function(callback, done) {};
+const arrow = (cb, done) => {};`, Tsx: true},
+			{Code: `function work(cb = noop) {}
+const expression = function(...callback) {};
+const arrow = ({cb}) => {};
+function destructure([callback]) {}`, Tsx: true},
+			{Code: `function work(CB) {}
+CB(); Callback(); object.cb(); object.callback(); new callback();`, Tsx: true},
+			// Only the final inline callback and its first bare error parameter match.
+			{Code: `heart(); heart(handler); heart(...handlers); heart(err => {}, value);`, Tsx: true},
+			{Code: `heart(() => {}); heart((value, err) => {}); heart(({err}) => {}); heart(([error]) => {}); heart((err = null) => {}); heart((...error) => {});`, Tsx: true},
+			{Code: "new Task(err => {}); tag`${err => {}}`;", Tsx: true},
+			// Method exemptions use property names and exact argument counts.
+			{Code: `lodash.map(errors, err => {}); underscore.find(errors, error => {}); _.forEach(errors, err => {});`, Tsx: true},
+			{Code: `db.on(err => {}); db.once(1, 2, function(error) {}); errors.map(err => {}, receiver);`, Tsx: true},
+			{Code: `db[on](err => {}); db[(once)](error => {}); errors[map](err => {}); lodash[(filter)](errors, error => {});`, Tsx: true},
+			{Code: `class Events { #on() {} #once() {} #map() {} listen() { this.#on(err => {}); this.#once(error => {}); this.#map(err => {}); } }`, Tsx: true},
+			// Parentheses, optional chains and authored TypeScript wrappers.
+			{Code: `(errors.map)((err => {})); (lodash).map(errors, err => {}); errors?.map?.(err => {}); db?.[on]?.(err => {});`, Tsx: true},
+			{Code: `cb!(); (cb as Function)(); (callback satisfies Function)(); heart((err => {}) as Function); heart((err => {})!); heart((err => {}) satisfies Function);`, Tsx: true},
+			// Await and yield exemptions inspect every ancestor, including nested functions.
+			{Code: `async function work() { await wrap(() => { heart(err => {}); }); }
+function* values() { yield* wrap(heart(error => {})); }`, Tsx: true},
+			// ESTree method functions and TypeScript declaration/parameter boundaries.
+			{Code: `declare function work(callback: Function): void;
+abstract class Task { abstract method(cb: Function): void; }
+interface Worker { method(callback: Function): void; (cb: Function): void; }
+type Handler = (callback: Function) => void;`, Tsx: true},
+			{Code: `class Task { constructor(private cb: Function) {} }
+function work(cb: Function): void;
+function work(done: Function) {}`, Tsx: true},
+			{Code: `heart(function(this: Receiver, err: Error) {});`, Tsx: true},
+			// JSX expressions and JavaScript JSDoc casts retain runtime meaning.
+			{Code: `const view = <cb callback={handler} />;`, Tsx: true},
+			{Code: `/** @type {Function} */ (errors.map)(err => {});
+/** @this {Receiver} */
+function work() {}`, FileName: "casts.js"},
+			// Import expressions, synthetic JSDoc parameters and source trivia.
+			{Code: `import(err => {}); import("module", error => {});`, Tsx: true},
+			{Code: `class Task { constructor(public readonly callback: Function) {} }`, Tsx: true},
+			{Code: `/** @this {Receiver} */
+function work() {}
+heart(/** @this {Receiver} */ function() {});`, FileName: "jsdoc-parameters.js"},
+			{Code: `(callback<string>)(); heart((err => {}) as ((err: Error) => void));`, Tsx: true},
+			// RunRuleTester registers the configured rule as "test".
+			{Code: `/* eslint-disable test */
+cb(); heart(err => {}); function work(callback) {}
+/* eslint-enable test */
+// eslint-disable-next-line test
+callback();`, Tsx: true},
+		},
+		[]rule_tester.InvalidTestCase{
+			// Only bare callback names in the final parameter position match.
+			{Code: `const expression = function named(callback) {};
+const arrow = callback => {};
+async function work(cb) {}
+function* generator(callback) {}`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 35, EndLine: 1, EndColumn: 43},
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 2, Column: 15, EndLine: 2, EndColumn: 23},
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 3, Column: 21, EndLine: 3, EndColumn: 23},
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 4, Column: 21, EndLine: 4, EndColumn: 29},
+				}},
+			{Code: `function work(callback, cb) {}`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 25, EndLine: 1, EndColumn: 27},
+				}},
+			{Code: `function outer(cb) { cb(); }`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 16, EndLine: 1, EndColumn: 18},
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 22, EndLine: 1, EndColumn: 26},
+				}},
+			// Only the final inline callback and its first bare error parameter match.
+			{Code: `heart(async function named(error) {}); heart(function* named(err) {}); heart(async (err) => {});`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 7, EndLine: 1, EndColumn: 37},
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 46, EndLine: 1, EndColumn: 69},
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 78, EndLine: 1, EndColumn: 95},
+				}},
+			{Code: `heart((err, callback) => {});`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 7, EndLine: 1, EndColumn: 28},
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 13, EndLine: 1, EndColumn: 21},
+				}},
+			{Code: `cb(err => {}); callback(function(error) {});`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 1, EndLine: 1, EndColumn: 14},
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 16, EndLine: 1, EndColumn: 44},
+				}},
+			// Method exemptions use property names and exact argument counts.
+			{Code: `errors.map(errors, err => {});`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 20, EndLine: 1, EndColumn: 29},
+				}},
+			{Code: `errors.reduce(err => {}); on(err => {}); custom.map(1, 2, err => {});`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 15, EndLine: 1, EndColumn: 24},
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 30, EndLine: 1, EndColumn: 39},
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 59, EndLine: 1, EndColumn: 68},
+				}},
+			{Code: `db["on"](err => {}); errors["map"](err => {}); db[method](error => {});`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 10, EndLine: 1, EndColumn: 19},
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 36, EndLine: 1, EndColumn: 45},
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 59, EndLine: 1, EndColumn: 70},
+				}},
+			{Code: `class Events { #listen() {} listen() { this.#listen(err => {}); } }`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 53, EndLine: 1, EndColumn: 62},
+				}},
+			{Code: `db.on("ready", cb => {}); errors.map(callback => {});`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 16, EndLine: 1, EndColumn: 18},
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 38, EndLine: 1, EndColumn: 46},
+				}},
+			// Parentheses, optional chains and authored TypeScript wrappers.
+			{Code: `((cb))(); callback?.(); cb<string>();`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 1, EndLine: 1, EndColumn: 9},
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 11, EndLine: 1, EndColumn: 23},
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 25, EndLine: 1, EndColumn: 37},
+				}},
+			{Code: `((heart))(((err) => {})); heart?.(function(error) {});`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 12, EndLine: 1, EndColumn: 23},
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 35, EndLine: 1, EndColumn: 53},
+				}},
+			{Code: `(errors?.map)(err => {}); (db?.on)(err => {});`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 15, EndLine: 1, EndColumn: 24},
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 36, EndLine: 1, EndColumn: 45},
+				}},
+			{Code: `(errors.map)!(err => {}); (lodash as any).map(errors, err => {}); db[(on as string)](error => {});`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 15, EndLine: 1, EndColumn: 24},
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 55, EndLine: 1, EndColumn: 64},
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 86, EndLine: 1, EndColumn: 97},
+				}},
+			// Await and yield exemptions inspect every ancestor, including nested functions.
+			{Code: `async function work() { await cb(); await heart((err, callback) => {}); }
+function* values() { yield callback(); }`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 31, EndLine: 1, EndColumn: 35},
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 55, EndLine: 1, EndColumn: 63},
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 2, Column: 28, EndLine: 2, EndColumn: 38},
+				}},
+			{Code: `heart(async err => { await load(); });`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 7, EndLine: 1, EndColumn: 37},
+				}},
+			// ESTree method functions and TypeScript declaration/parameter boundaries.
+			{Code: `const object = { method(cb) {}, set value(callback) {}, get value() { return 1; } };
+class Task { constructor(cb) {} method(callback) {} set value(cb) {} get value() { return 1; } }`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 25, EndLine: 1, EndColumn: 27},
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 43, EndLine: 1, EndColumn: 51},
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 2, Column: 26, EndLine: 2, EndColumn: 28},
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 2, Column: 40, EndLine: 2, EndColumn: 48},
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 2, Column: 63, EndLine: 2, EndColumn: 65},
+				}},
+			{Code: `class Task { #method(cb) {} static async method(callback) {} *generator(cb) {} }
+const object = { [key](callback) {} };`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 22, EndLine: 1, EndColumn: 24},
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 49, EndLine: 1, EndColumn: 57},
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 73, EndLine: 1, EndColumn: 75},
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 2, Column: 24, EndLine: 2, EndColumn: 32},
+				}},
+			{Code: `function work(callback?: (err: Error) => void) {}
+const arrow = (cb: Function) => {};
+heart((err: Error) => {});`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 15, EndLine: 1, EndColumn: 46},
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 2, Column: 16, EndLine: 2, EndColumn: 28},
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 3, Column: 7, EndLine: 3, EndColumn: 25},
+				}},
+			{Code: `class Task { method(@decorate cb: Function) {} }`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 31, EndLine: 1, EndColumn: 43},
+				}},
+			// JSX expressions and JavaScript JSDoc casts retain runtime meaning.
+			{Code: `const view = <Box value={cb()} onReady={(callback) => {}}>{heart(err => <Item />)}</Box>;`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 26, EndLine: 1, EndColumn: 30},
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 42, EndLine: 1, EndColumn: 50},
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 66, EndLine: 1, EndColumn: 81},
+				}},
+			{Code: `/** @type {Function} */ (cb)();
+heart(/** @type {Function} */ (err => {}));
+/** @param {Function} callback */
+function work(callback) {}`, FileName: "casts.js",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 25, EndLine: 1, EndColumn: 31},
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 2, Column: 32, EndLine: 2, EndColumn: 41},
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 4, Column: 15, EndLine: 4, EndColumn: 23},
+				}},
+			// Complete diagnostic ranges include multiline callbacks and UTF-16 columns.
+			{Code: `const emoji = "😀"; cb(
+  value
+);
+heart(
+  async (error) => {
+    log(error);
+  }
+);
+function work(
+  value,
+  callback
+) {}`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 21, EndLine: 3, EndColumn: 2},
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 5, Column: 3, EndLine: 7, EndColumn: 4},
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 11, Column: 3, EndLine: 11, EndColumn: 11},
+				}},
+			{Code: `const café = "😀"; function work(c\u0062) {}
+call((\u0065rr) => {});`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 34, EndLine: 1, EndColumn: 41},
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 2, Column: 6, EndLine: 2, EndColumn: 22},
+				}},
+			// Import expressions, synthetic JSDoc parameters and source trivia.
+			{Code: `import.defer("module", err => {}); import.source("module", error => {});`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 24, EndLine: 1, EndColumn: 33},
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 60, EndLine: 1, EndColumn: 71},
+				}},
+			{Code: `class Task extends Base { constructor() { super(err => {}); } }`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 49, EndLine: 1, EndColumn: 58},
+				}},
+			{Code: `const obj = { [((cb))()]() {} };`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 16, EndLine: 1, EndColumn: 24},
+				}},
+			{Code: `class Task { constructor(@decorate callback: Function) {} }`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 36, EndLine: 1, EndColumn: 54},
+				}},
+			{Code: `function work(callback?) {}
+function other(cb /* comment */) {}
+cb /* comment */ ();`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 15, EndLine: 1, EndColumn: 24},
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 2, Column: 16, EndLine: 2, EndColumn: 18},
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 3, Column: 1, EndLine: 3, EndColumn: 20},
+				}},
+			{Code: `heart(/** @this {Receiver} */ function(err) {});
+/** @this {Receiver} */
+function work(callback) {}`, FileName: "jsdoc-parameters.js",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 31, EndLine: 1, EndColumn: 47},
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 3, Column: 15, EndLine: 3, EndColumn: 23},
+				}},
+			{Code: `/** @param {Function} [callback=noop] */
+function work(callback) {}
+heart(/** @param {Error} [err=null] */ function(err) {});`, FileName: "jsdoc-parameters.js",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 2, Column: 15, EndLine: 2, EndColumn: 23},
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 3, Column: 40, EndLine: 3, EndColumn: 56},
+				}},
+			// RunRuleTester registers the configured rule as "test".
+			{Code: `// eslint-disable-next-line test
+cb();
+callback(); // eslint-disable-line test
+heart(err => {});`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 4, Column: 7, EndLine: 4, EndColumn: 16},
+				}},
+		},
+	)
+}

--- a/internal/plugins/promise/rules/prefer_await_to_callbacks/prefer_await_to_callbacks_extras_test.go
+++ b/internal/plugins/promise/rules/prefer_await_to_callbacks/prefer_await_to_callbacks_extras_test.go
@@ -1,9 +1,9 @@
 package prefer_await_to_callbacks_test
 
 import (
-	"path/filepath"
 	"testing"
 
+	"github.com/microsoft/TypeScript/tsc/shim/tspath"
 	"github.com/web-infra-dev/rslint/internal/plugins/promise/fixtures"
 	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/prefer_await_to_callbacks"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
@@ -14,7 +14,8 @@ import (
 func TestPreferAwaitToCallbacksExtras(t *testing.T) {
 	root := fixtures.GetRootDir()
 	root.FS = utils.NewOverlayVFS(root.FS, map[string]string{
-		filepath.Join(root.Dir, "tsconfig.callbacks.json"): `{"extends":"./tsconfig.json","compilerOptions":{"allowJs":true}}`,
+		// The fixture VFS uses forward-slash paths on every platform.
+		tspath.ResolvePath(root.Dir, "tsconfig.callbacks.json"): `{"extends":"./tsconfig.json","compilerOptions":{"allowJs":true}}`,
 	})
 	rule_tester.RunRuleTester(root, "tsconfig.callbacks.json", t, &prefer_await_to_callbacks.PreferAwaitToCallbacksRule,
 		[]rule_tester.ValidTestCase{

--- a/internal/plugins/promise/rules/prefer_await_to_callbacks/prefer_await_to_callbacks_upstream_test.go
+++ b/internal/plugins/promise/rules/prefer_await_to_callbacks/prefer_await_to_callbacks_upstream_test.go
@@ -1,0 +1,112 @@
+package prefer_await_to_callbacks_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/promise/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/prefer_await_to_callbacks"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// Ported from eslint-plugin-promise v7.3.0:
+// https://github.com/eslint-community/eslint-plugin-promise/blob/v7.3.0/__tests__/prefer-await-to-callbacks.js
+// https://github.com/eslint-community/eslint-plugin-promise/blob/v7.3.0/docs/rules/prefer-await-to-callbacks.md
+func TestPreferAwaitToCallbacksUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &prefer_await_to_callbacks.PreferAwaitToCallbacksRule,
+		[]rule_tester.ValidTestCase{
+			// Upstream tests.
+			{Code: `async function hi() { await thing().catch(err => console.log(err)) }`, Tsx: true},
+			{Code: `async function hi() { await thing().then() }`, Tsx: true},
+			{Code: `async function hi() { await thing().catch() }`, Tsx: true},
+			{Code: `dbConn.on("error", err => { console.error(err) })`, Tsx: true},
+			{Code: `dbConn.once("error", err => { console.error(err) })`, Tsx: true},
+			{Code: `heart(something => {})`, Tsx: true},
+			{Code: `getErrors().map(error => responseTo(error))`, Tsx: true},
+			{Code: `errors.filter(err => err.status === 402)`, Tsx: true},
+			{Code: `errors.some(err => err.message.includes("Yo"))`, Tsx: true},
+			{Code: `errors.every(err => err.status === 402)`, Tsx: true},
+			{Code: `errors.filter(err => console.log(err))`, Tsx: true},
+			{Code: `const error = errors.find(err => err.stack.includes("file.js"))`, Tsx: true},
+			{Code: `this.myErrors.forEach(function(error) { log(error); })`, Tsx: true},
+			{Code: `find(errors, function(err) { return  err.type === "CoolError" })`, Tsx: true},
+			{Code: `map(errors, function(error) { return  err.type === "CoolError" })`, Tsx: true},
+			{Code: `_.find(errors, function(error) { return  err.type === "CoolError" })`, Tsx: true},
+			{Code: `_.map(errors, function(err) { return  err.type === "CoolError" })`, Tsx: true},
+			// Upstream documentation (the yield example is wrapped in a generator).
+			{Code: `await doSomething(arg)`, Tsx: true},
+			{Code: `async function doSomethingElse() {}`, Tsx: true},
+			{Code: `function* values() { yield yieldValue(err => {}) }`, Tsx: true},
+			{Code: `eventEmitter.on('error', err => {})`, Tsx: true},
+		},
+		[]rule_tester.InvalidTestCase{
+			// Upstream tests.
+			{Code: `heart(function(err) {})`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 7, EndLine: 1, EndColumn: 23},
+				}},
+			{Code: `heart(err => {})`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 7, EndLine: 1, EndColumn: 16},
+				}},
+			{Code: `heart("ball", function(err) {})`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 15, EndLine: 1, EndColumn: 31},
+				}},
+			{Code: `function getData(id, callback) {}`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 22, EndLine: 1, EndColumn: 30},
+				}},
+			{Code: `const getData = (cb) => {}`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 18, EndLine: 1, EndColumn: 20},
+				}},
+			{Code: `var x = function (x, cb) {}`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 22, EndLine: 1, EndColumn: 24},
+				}},
+			{Code: `cb()`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 1, EndLine: 1, EndColumn: 5},
+				}},
+			{Code: `callback()`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 1, EndLine: 1, EndColumn: 11},
+				}},
+			{Code: `heart(error => {})`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 7, EndLine: 1, EndColumn: 18},
+				}},
+			{Code: `async.map(files, fs.stat, function(err, results) { if (err) throw err; });`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 27, EndLine: 1, EndColumn: 73},
+				}},
+			{Code: `_.map(files, fs.stat, function(err, results) { if (err) throw err; });`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 23, EndLine: 1, EndColumn: 69},
+				}},
+			{Code: `map(files, fs.stat, function(err, results) { if (err) throw err; });`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 21, EndLine: 1, EndColumn: 67},
+				}},
+			{Code: `map(function(err, results) { if (err) throw err; });`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 5, EndLine: 1, EndColumn: 51},
+				}},
+			{Code: `customMap(errors, (err) => err.message)`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 19, EndLine: 1, EndColumn: 39},
+				}},
+			// Upstream documentation (the yield example is wrapped in a generator).
+			{Code: `cb()
+callback()
+doSomething(arg, (err) => {})
+function doSomethingElse(cb) {}`, Tsx: true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 1, Column: 1, EndLine: 1, EndColumn: 5},
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 2, Column: 1, EndLine: 2, EndColumn: 11},
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 3, Column: 18, EndLine: 3, EndColumn: 29},
+					{MessageId: "error", Message: "Avoid callbacks. Prefer Async/Await.", Line: 4, Column: 26, EndLine: 4, EndColumn: 28},
+				}},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstack.config.mts
+++ b/packages/rslint-test-tools/rstack.config.mts
@@ -694,6 +694,7 @@ define.test({
     './tests/eslint-plugin-promise/rules/no-return-in-finally.test.ts',
     './tests/eslint-plugin-promise/rules/no-return-wrap.test.ts',
     './tests/eslint-plugin-promise/rules/param-names.test.ts',
+    './tests/eslint-plugin-promise/rules/prefer-await-to-callbacks.test.ts',
     './tests/eslint-plugin-promise/rules/prefer-await-to-then.test.ts',
     './tests/eslint-plugin-promise/rules/prefer-catch.test.ts',
     './tests/eslint-plugin-promise/rules/valid-params.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-promise/rules/prefer-await-to-callbacks.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-promise/rules/prefer-await-to-callbacks.test.ts
@@ -1,0 +1,78 @@
+// Upstream: https://github.com/eslint-community/eslint-plugin-promise/blob/v7.3.0/__tests__/prefer-await-to-callbacks.js
+// Documentation: https://github.com/eslint-community/eslint-plugin-promise/blob/v7.3.0/docs/rules/prefer-await-to-callbacks.md
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+const message = 'Avoid callbacks. Prefer Async/Await.';
+
+ruleTester.run('prefer-await-to-callbacks', {} as never, {
+  valid: [
+    // Upstream tests.
+    {
+      code: 'async function hi() { await thing().catch(err => console.log(err)) }',
+    },
+    { code: 'async function hi() { await thing().then() }' },
+    { code: 'async function hi() { await thing().catch() }' },
+    { code: 'dbConn.on("error", err => { console.error(err) })' },
+    { code: 'dbConn.once("error", err => { console.error(err) })' },
+    { code: 'heart(something => {})' },
+    { code: 'getErrors().map(error => responseTo(error))' },
+    { code: 'errors.filter(err => err.status === 402)' },
+    { code: 'errors.some(err => err.message.includes("Yo"))' },
+    { code: 'errors.every(err => err.status === 402)' },
+    { code: 'errors.filter(err => console.log(err))' },
+    { code: 'const error = errors.find(err => err.stack.includes("file.js"))' },
+    { code: 'this.myErrors.forEach(function(error) { log(error); })' },
+    {
+      code: 'find(errors, function(err) { return  err.type === "CoolError" })',
+    },
+    {
+      code: 'map(errors, function(error) { return  err.type === "CoolError" })',
+    },
+    {
+      code: '_.find(errors, function(error) { return  err.type === "CoolError" })',
+    },
+    {
+      code: '_.map(errors, function(err) { return  err.type === "CoolError" })',
+    },
+    // Upstream documentation (the yield example is wrapped in a generator).
+    { code: 'await doSomething(arg)' },
+    { code: 'async function doSomethingElse() {}' },
+    { code: 'function* values() { yield yieldValue(err => {}) }' },
+    { code: "eventEmitter.on('error', err => {})" },
+  ],
+  invalid: [
+    // Upstream tests.
+    { code: 'heart(function(err) {})', errors: [{ message }] },
+    { code: 'heart(err => {})', errors: [{ message }] },
+    { code: 'heart("ball", function(err) {})', errors: [{ message }] },
+    { code: 'function getData(id, callback) {}', errors: [{ message }] },
+    { code: 'const getData = (cb) => {}', errors: [{ message }] },
+    { code: 'var x = function (x, cb) {}', errors: [{ message }] },
+    { code: 'cb()', errors: [{ message }] },
+    { code: 'callback()', errors: [{ message }] },
+    { code: 'heart(error => {})', errors: [{ message }] },
+    {
+      code: 'async.map(files, fs.stat, function(err, results) { if (err) throw err; });',
+      errors: [{ message }],
+    },
+    {
+      code: '_.map(files, fs.stat, function(err, results) { if (err) throw err; });',
+      errors: [{ message }],
+    },
+    {
+      code: 'map(files, fs.stat, function(err, results) { if (err) throw err; });',
+      errors: [{ message }],
+    },
+    {
+      code: 'map(function(err, results) { if (err) throw err; });',
+      errors: [{ message }],
+    },
+    { code: 'customMap(errors, (err) => err.message)', errors: [{ message }] },
+    // Upstream documentation (the yield example is wrapped in a generator).
+    {
+      code: 'cb()\ncallback()\ndoSomething(arg, (err) => {})\nfunction doSomethingElse(cb) {}',
+      errors: [{ message }, { message }, { message }, { message }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Add native `promise/prefer-await-to-callbacks`, matching eslint-plugin-promise v7.3.0. The rule reports direct `cb`/`callback` calls, final callback parameters, and final inline callbacks whose first parameter is `err`/`error`, preserving upstream's event, array-method, and await/yield exemptions. It has no options, fixes, or suggestions.

Register the rule and its JS integration test, add documentation, and port all 31 upstream tests plus documentation examples. The Go extras cover method/constructor functions, computed/private members, optional chains, TypeScript wrappers and parameter ranges, JSDoc, UTF-16 positions, and disable directives. Ordinary `import()` is excluded because ESTree represents it as an ImportExpression. Existing rslint AST/range helpers and tsgo ancestor traversal are reused.

Parameter checks read only the first or last authored parameter instead of copying the entire list. JSDoc-synthesized parameters are still excluded. A temporary Go benchmark measured the initial and final implementations; its source was removed before committing.

### Validation

- `go test ./internal/plugins/promise/rules/prefer_await_to_callbacks` — 92 inputs, including all upstream/documentation cases and 56 extras; no skips.
- `go test ./internal/rules -run '^TestAllContainsEveryGoRuleExactlyOnce$'`
- `golangci-lint run --new-from-merge-base=origin/main ./internal/plugins/promise ./internal/plugins/promise/rules/prefer_await_to_callbacks` — 0 issues.
- Rebuilt `@rslint/core` binary, refreshed schema output, and built JS artifacts.
- `CI=true pnpm --dir packages/rslint-test-tools exec rs test run tests/eslint-plugin-promise/rules/prefer-await-to-callbacks.test.ts`
- `pnpm run format:check`, spell-check with explicit changed-file paths, and `git diff --check`.
- Differential comparison with ESLint 10.9.0, eslint-plugin-promise 7.3.0 and typescript-eslint parser 8.65.0: 92 test inputs / 93 diagnostics and 5 real source files / 4 diagnostics matched. Both sides enabled only this rule; file coverage was asserted. Compared paths, rule names, message IDs/text, severity, complete ranges, and absence of fixes/suggestions.

### Go benchmark

macOS arm64, Apple M5 Max, Go 1.26.5. Medians of six samples with 128 source fragments per operation; parsing excluded, rule initialization, listener dispatch, and diagnostic reporting included. The baseline is the initial implementation of this new rule.

```sh
go test ./internal/plugins/promise/rules/prefer_await_to_callbacks -run '^$' -bench '^BenchmarkPreferAwaitToCallbacks$' -benchmem -benchtime=500ms -count=6 -cpu=1
```

| Path | ns/op before → after | Change | B/op before → after | allocs/op before → after |
| --- | ---: | ---: | ---: | ---: |
| Callback argument | 17,728 → 12,499.5 | -29.5% | 25,056 → 20,960 | 389 → 133 |
| Callback parameter | 12,274.5 → 9,703.5 | -20.9% | 23,008 → 20,960 | 261 → 133 |
| No match | 5,765 → 2,732 | -52.6% | 2,528 → 480 | 133 → 5 |
| Array exemption | 5,823 → 3,352.5 | -42.4% | 1,504 → 480 | 133 → 5 |
| Await exemption | 12,946 → 6,477 | -50.0% | 4,576 → 480 | 261 → 5 |
| Direct callback (control) | 8,967 → 8,614 | -3.9% | 20,960 → 20,960 | 133 → 133 |
| JSDoc `this` | 30,052 → 19,065.5 | -36.6% | 27,104 → 20,960 | 389 → 133 |

These measurements describe rule microbenchmarks; the control path's small timing change is treated as noise. No benchmark source or generated benchmark artifacts are included.

## Related Links

- [Upstream source (v7.3.0)](https://github.com/eslint-community/eslint-plugin-promise/blob/v7.3.0/rules/prefer-await-to-callbacks.js)
- [Upstream tests (v7.3.0)](https://github.com/eslint-community/eslint-plugin-promise/blob/v7.3.0/__tests__/prefer-await-to-callbacks.js)
- [Upstream documentation (v7.3.0)](https://github.com/eslint-community/eslint-plugin-promise/blob/v7.3.0/docs/rules/prefer-await-to-callbacks.md)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
