### PR TITLE
feat(rstest): add no-async-mock-factory rule

### DIFF
--- a/internal/plugins/rstest/all.go
+++ b/internal/plugins/rstest/all.go
@@ -8,6 +8,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/hoisted_apis_on_top"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/max_expects"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/no_alias_methods"
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/no_async_mock_factory"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/no_commented_out_tests"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/no_conditional_expect"
 	no_conditional_in "github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/no_conditional_in_test"
@@ -64,6 +65,7 @@ func GetAllRules() []rule.Rule {
 		hoisted_apis_on_top.HoistedApisOnTopRule,
 		max_expects.MaxExpectsRule,
 		no_alias_methods.NoAliasMethodsRule,
+		no_async_mock_factory.NoAsyncMockFactoryRule,
 		no_commented_out_tests.NoCommentedOutTestsRule,
 		no_conditional_expect.NoConditionalExpectRule,
 		no_conditional_in.NoConditionalInTestRule,

--- a/internal/plugins/rstest/fixtures/async-mock-factories.ts
+++ b/internal/plugins/rstest/fixtures/async-mock-factories.ts
@@ -1,0 +1,3 @@
+export const asyncModuleFactory = async () => ({ sum: () => 0 });
+
+export const syncModuleFactory = () => ({ sum: () => 0 });

--- a/internal/plugins/rstest/rules/no_async_mock_factory/no_async_mock_factory.go
+++ b/internal/plugins/rstest/rules/no_async_mock_factory/no_async_mock_factory.go
@@ -5,6 +5,7 @@ import (
 	"github.com/microsoft/TypeScript/tsc/shim/checker"
 	"github.com/microsoft/TypeScript/tsc/shim/core"
 	rstestUtils "github.com/web-infra-dev/rslint/internal/plugins/rstest/utils"
+	lintprogram "github.com/web-infra-dev/rslint/internal/program"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 	"github.com/web-infra-dev/rslint/internal/utils/ecmascript"
@@ -199,6 +200,16 @@ func classifyFunction(ctx rule.RuleContext, fn *ast.Node) verdict {
 		return verdictPromise
 	}
 
+	// A path that runs off the end of a block body hands back `undefined`,
+	// which the runtime's `instanceof Promise` check lets through: such a
+	// factory only sometimes returns a promise, and this rule reports the ones
+	// that certainly do. `async` is settled above, where the implicit
+	// `undefined` is wrapped like every other value the body hands back.
+	if body := fn.Body(); body != nil && body.Kind == ast.KindBlock &&
+		utils.IsFunctionEndReachable(fn) {
+		return verdictUnknown
+	}
+
 	returned, ok := returnedExpressions(fn)
 	if !ok || len(returned) == 0 {
 		return verdictUnknown
@@ -212,9 +223,10 @@ func classifyFunction(ctx rule.RuleContext, fn *ast.Node) verdict {
 }
 
 // classifyThroughDeclaration follows an identifier to a declaration in this
-// file. A name that resolves to more than one declaration, to another file, or
-// to anything but a `const` function or a function declaration is left to the
-// type layer, where a reassignment or a re-export is accounted for.
+// file. A name that resolves to more than one declaration, to another file, to
+// anything but a `const` function or a function declaration, or to a function
+// declaration that is written to, is left to the type layer, where a
+// reassignment or a re-export is accounted for.
 func classifyThroughDeclaration(ctx rule.RuleContext, factory *ast.Node) verdict {
 	if factory.Kind != ast.KindIdentifier || ctx.Refs == nil {
 		return verdictUnknown
@@ -230,6 +242,12 @@ func classifyThroughDeclaration(ctx rule.RuleContext, factory *ast.Node) verdict
 
 	switch declaration.Kind {
 	case ast.KindFunctionDeclaration:
+		// A function declaration's name is a writable binding, and an
+		// assignment to it adds no declaration of its own: the body below is
+		// the installed factory only while nothing writes to the name.
+		if isWrittenTo(ctx, symbol) {
+			return verdictUnknown
+		}
 		return classifyFunction(ctx, declaration)
 	case ast.KindVariableDeclaration:
 		if !ast.IsVarConst(declaration) {
@@ -244,6 +262,17 @@ func classifyThroughDeclaration(ctx rule.RuleContext, factory *ast.Node) verdict
 	return verdictUnknown
 }
 
+// isWrittenTo reports whether anything in this file assigns to the symbol,
+// which would replace the value its declaration describes.
+func isWrittenTo(ctx rule.RuleContext, symbol *ast.Symbol) bool {
+	for _, reference := range ctx.Refs.References(symbol) {
+		if utils.IsWriteReference(reference) {
+			return true
+		}
+	}
+	return false
+}
+
 // classifyByType asks the TypeChecker, and only ever answers verdictPromise or
 // verdictUnknown: it exists to decide the cases syntax could not, never to
 // overrule it.
@@ -254,7 +283,7 @@ func classifyByType(ctx rule.RuleContext, factory *ast.Node) verdict {
 	if ctx.TypeChecker == nil {
 		return verdictUnknown
 	}
-	if alwaysReturnsPromise(ctx.TypeChecker, ctx.TypeChecker.GetTypeAtLocation(factory)) {
+	if alwaysReturnsPromise(ctx.Program(), ctx.TypeChecker, ctx.TypeChecker.GetTypeAtLocation(factory)) {
 		return verdictPromise
 	}
 	return verdictUnknown
@@ -265,7 +294,7 @@ func classifyByType(ctx rule.RuleContext, factory *ast.Node) verdict {
 // their signatures has to return a promise: a type that mixes an async factory
 // with a synchronous one leaves the outcome to run time, and this rule stays
 // silent rather than report a call that may well work.
-func alwaysReturnsPromise(typeChecker *checker.Checker, t *checker.Type) bool {
+func alwaysReturnsPromise(sourceProgram *lintprogram.Program, typeChecker *checker.Checker, t *checker.Type) bool {
 	if t == nil {
 		return false
 	}
@@ -275,7 +304,7 @@ func alwaysReturnsPromise(typeChecker *checker.Checker, t *checker.Type) bool {
 			return false
 		}
 		for _, part := range parts {
-			if !alwaysReturnsPromise(typeChecker, part) {
+			if !alwaysReturnsPromise(sourceProgram, typeChecker, part) {
 				return false
 			}
 		}
@@ -287,7 +316,7 @@ func alwaysReturnsPromise(typeChecker *checker.Checker, t *checker.Type) bool {
 		return false
 	}
 	for _, signature := range signatures {
-		if !isPromiseInstanceType(typeChecker, checker.Checker_getReturnTypeOfSignature(typeChecker, signature), 0) {
+		if !isPromiseInstanceType(sourceProgram, typeChecker, checker.Checker_getReturnTypeOfSignature(typeChecker, signature), 0) {
 			return false
 		}
 	}
@@ -295,14 +324,17 @@ func alwaysReturnsPromise(typeChecker *checker.Checker, t *checker.Type) bool {
 }
 
 // isPromiseInstanceType reports whether a value of type t is an instance of
-// `Promise`, matching the type by its name.
+// the global `Promise`. The name alone does not settle it: a file is free to
+// declare its own `Promise`, and a value of that type is not what the
+// runtime's `instanceof Promise` looks for, so the symbol has to come from the
+// default library.
 //
 // utils.IsThenableType is deliberately not used. It answers "has a `then` whose
 // first parameter is a callback", which is wider than the `instanceof Promise`
 // the runtime performs, and the gap is reachable: mocking a module that itself
 // exports `then` gives the factory a thenable return type while the runtime
 // accepts it happily.
-func isPromiseInstanceType(typeChecker *checker.Checker, t *checker.Type, depth int) bool {
+func isPromiseInstanceType(sourceProgram *lintprogram.Program, typeChecker *checker.Checker, t *checker.Type, depth int) bool {
 	if t == nil || depth > 8 {
 		return false
 	}
@@ -315,7 +347,7 @@ func isPromiseInstanceType(typeChecker *checker.Checker, t *checker.Type, depth 
 			return false
 		}
 		for _, part := range parts {
-			if !isPromiseInstanceType(typeChecker, part, depth+1) {
+			if !isPromiseInstanceType(sourceProgram, typeChecker, part, depth+1) {
 				return false
 			}
 		}
@@ -324,7 +356,7 @@ func isPromiseInstanceType(typeChecker *checker.Checker, t *checker.Type, depth 
 	if utils.IsIntersectionType(t) {
 		// `Promise<T> & Branded` is still a promise at run time.
 		for _, part := range t.Types() {
-			if isPromiseInstanceType(typeChecker, part, depth+1) {
+			if isPromiseInstanceType(sourceProgram, typeChecker, part, depth+1) {
 				return true
 			}
 		}
@@ -336,7 +368,8 @@ func isPromiseInstanceType(typeChecker *checker.Checker, t *checker.Type, depth 
 		checker.Type_objectFlags(resolved)&checker.ObjectFlagsReference != 0 {
 		resolved = resolved.Target()
 	}
-	if symbol := checker.Type_symbol(resolved); symbol != nil && symbol.Name == "Promise" {
+	if symbol := checker.Type_symbol(resolved); symbol != nil && symbol.Name == "Promise" &&
+		utils.IsSymbolFromDefaultLibrary(sourceProgram, symbol) {
 		return true
 	}
 	if checker.Type_objectFlags(resolved)&checker.ObjectFlagsClassOrInterface == 0 {
@@ -344,7 +377,7 @@ func isPromiseInstanceType(typeChecker *checker.Checker, t *checker.Type, depth 
 	}
 	// A subclass of Promise is an instance of Promise.
 	for _, base := range checker.Checker_getBaseTypes(typeChecker, resolved) {
-		if isPromiseInstanceType(typeChecker, base, depth+1) {
+		if isPromiseInstanceType(sourceProgram, typeChecker, base, depth+1) {
 			return true
 		}
 	}
@@ -461,6 +494,15 @@ func returnedExpressions(fn *ast.Node) ([]*ast.Node, bool) {
 // `import … with { rstest: 'importActual' }` moves code across statements.
 func suggestions(ctx rule.RuleContext, factory *ast.Node) []rule.RuleSuggestion {
 	if !isFunctionExpressionLike(factory) {
+		return nil
+	}
+	// Both rewrites take the promise out of the value while leaving the
+	// factory's own return type as written, so an annotated
+	// `(): Promise<T> => …` would be left annotating a `T`. Rewriting the
+	// annotation as well is a second edit with its own shapes to get right —
+	// `PromiseLike<T>`, a union, an alias — so an annotated factory is simply
+	// left alone.
+	if factory.Type() != nil {
 		return nil
 	}
 	returned, complete := returnedExpressions(factory)
@@ -592,8 +634,10 @@ func isDefinitelyNotPromise(node *ast.Node) bool {
 }
 
 // bodyAwaits reports whether the function's own body suspends: an `await`
-// expression, `for await`, or an `await using` declaration. A nested function
-// has its own body and does not count.
+// expression, `for await`, or an `await using` declaration. A nested function's
+// body does not count — but everything else written on that nested function
+// does: a computed member name and a decorator are evaluated where the function
+// appears, which is this body.
 func bodyAwaits(fn *ast.Node) bool {
 	body := fn.Body()
 	if body == nil {
@@ -607,7 +651,13 @@ func bodyAwaits(fn *ast.Node) bool {
 			return found
 		}
 		if ast.IsFunctionLike(node) {
-			return false
+			nestedBody := node.Body()
+			return node.ForEachChild(func(child *ast.Node) bool {
+				if child == nestedBody {
+					return false
+				}
+				return walk(child)
+			})
 		}
 		switch node.Kind {
 		case ast.KindAwaitExpression:

--- a/internal/plugins/rstest/rules/no_async_mock_factory/no_async_mock_factory.go
+++ b/internal/plugins/rstest/rules/no_async_mock_factory/no_async_mock_factory.go
@@ -1,0 +1,631 @@
+package no_async_mock_factory
+
+import (
+	"github.com/microsoft/TypeScript/tsc/shim/ast"
+	"github.com/microsoft/TypeScript/tsc/shim/checker"
+	"github.com/microsoft/TypeScript/tsc/shim/core"
+	rstestUtils "github.com/web-infra-dev/rslint/internal/plugins/rstest/utils"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+	"github.com/web-infra-dev/rslint/internal/utils/ecmascript"
+)
+
+// Rstest installs the second argument of a module mock as the module's own
+// factory and calls it while the module graph is being built, so it has to hand
+// back the module object there and then. The generated wrapper checks the
+// result with `instanceof Promise` and throws
+// "[Rstest] An async mock factory is not supported." when it matches
+// (packages/core/src/core/plugins/mockRuntimeCode.js). `mock`, `doMock`,
+// `mockRequire` and `doMockRequire` are all produced by the same
+// `getMockImplementation`, so the four behave identically here.
+//
+// Nothing in the type system stops it: the factory parameter is
+// `MockFactory<T> = () => Partial<T>` (packages/core/src/types/mock.ts), a
+// string module path leaves `T` as `unknown`, and every promise is assignable
+// to `Partial<unknown>`. The throw surfaces only once the mocked module is
+// really loaded, which is why it is worth catching in the editor.
+//
+// The gate is "returns a Promise", not "is declared async": a plain function
+// returning `Promise.resolve(…)` throws just the same, and an async generator
+// hands back an AsyncGenerator rather than a promise and does not throw. A
+// hand-written thenable is not caught by `instanceof Promise` either; it breaks
+// differently and is out of scope.
+
+var mockAPIs = map[string]bool{
+	"mock":          true,
+	"doMock":        true,
+	"mockRequire":   true,
+	"doMockRequire": true,
+}
+
+// asyncModuleLoaders are the plugin-managed members that load a module
+// asynchronously, so a factory built on either can only hand back a promise.
+// Their `require` twins are synchronous and are not listed.
+//
+// The two reach their failure by different routes on @rstest/core 0.11.8.
+// `() => rs.importActual('./m')` runs and hits the runtime's promise check.
+// `() => rs.importMock('./m')` throws "importMock() was not transformed by
+// Rstest" instead, because that call site is not rewritten inside a factory the
+// build hoists. Both are reported under the one message: the factory is
+// asynchronous either way and the mock cannot take effect.
+var asyncModuleLoaders = map[string]bool{
+	"importActual": true,
+	"importMock":   true,
+}
+
+// promiseStatics are the `Promise` statics whose result is a promise. `Promise`
+// also carries `withResolvers`, whose result is an object holding one, so it is
+// deliberately absent.
+var promiseStatics = map[string]bool{
+	"resolve":    true,
+	"reject":     true,
+	"all":        true,
+	"allSettled": true,
+	"race":       true,
+	"any":        true,
+}
+
+func buildAsyncMockFactoryMessage(member string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id: "asyncMockFactory",
+		Description: "Mock factory must return the module object synchronously; '" + member +
+			"()' throws when the factory returns a Promise. To keep part of the original module, " +
+			"import it with `with { rstest: 'importActual' }` and spread it in.",
+		Data: map[string]string{"member": member},
+	}
+}
+
+var removeAsyncMessage = rule.RuleMessage{
+	Id:          "suggestRemoveAsync",
+	Description: "Remove 'async' so the factory returns the module object directly.",
+}
+
+var unwrapPromiseResolveMessage = rule.RuleMessage{
+	Id:          "suggestUnwrapPromiseResolve",
+	Description: "Return the module object directly instead of wrapping it in 'Promise.resolve()'.",
+}
+
+// verdict is what the layers below conclude about a factory argument.
+type verdict int
+
+const (
+	// verdictUnknown means the layer could not decide and the next one has to
+	// look. It is the answer that is reported on only when a TypeChecker
+	// settles it, so a source-only program stays silent rather than guessing.
+	verdictUnknown verdict = iota
+	// verdictPromise means the factory certainly hands back a promise.
+	verdictPromise
+	// verdictSync means it certainly does not.
+	verdictSync
+)
+
+var NoAsyncMockFactoryRule = rule.Rule{
+	Name:   "rstest/no-async-mock-factory",
+	Schema: rule.EmptyArraySchema,
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				argument, member := mockFactoryArgument(node)
+				if argument == nil {
+					return
+				}
+
+				factory := utils.SkipAssertionsAndParens(argument)
+				if factory == nil {
+					return
+				}
+
+				switch classify(ctx, factory) {
+				case verdictSync, verdictUnknown:
+					return
+				}
+
+				ctx.ReportNodeWithDeferredSuggestions(
+					argument,
+					buildAsyncMockFactoryMessage(member),
+					func() []rule.RuleSuggestion { return suggestions(ctx, factory) },
+				)
+			},
+		}
+	},
+}
+
+// mockFactoryArgument returns the factory argument of a module mock call the
+// build rewrites, together with the member as it is written. It is nil for
+// everything else.
+func mockFactoryArgument(node *ast.Node) (*ast.Node, string) {
+	utility := rstestUtils.ParseRstestPluginManagedCall(node)
+	if utility == nil || !mockAPIs[utility.Member] || !rstestUtils.IsTransformablePosition(node) {
+		return nil, ""
+	}
+
+	call := node.AsCallExpression()
+	if call.Arguments == nil {
+		return nil, ""
+	}
+	// The transform reads the path and the factory positionally. A third
+	// argument fails the build, and a spread's elements are only known at run
+	// time, so neither shape reaches a factory this rule can judge. What the
+	// path itself is written as does not matter: a string, a dynamic import
+	// and a variable all install the same factory. An explicit type argument
+	// only names the mocked module's shape and is no exemption either.
+	arguments := call.Arguments.Nodes
+	if len(arguments) != 2 {
+		return nil, ""
+	}
+	for _, argument := range arguments {
+		if argument == nil || argument.Kind == ast.KindSpreadElement {
+			return nil, ""
+		}
+	}
+	return arguments[1], utility.Member
+}
+
+// classify walks the three layers in order: what the syntax settles on its own,
+// what a declaration in this file settles, and — only for what is left — what
+// the types say.
+func classify(ctx rule.RuleContext, factory *ast.Node) verdict {
+	if v := classifySyntactically(ctx, factory); v != verdictUnknown {
+		return v
+	}
+	if v := classifyThroughDeclaration(ctx, factory); v != verdictUnknown {
+		return v
+	}
+	return classifyByType(ctx, factory)
+}
+
+// classifySyntactically answers from the argument alone, without resolving a
+// binding and without types.
+func classifySyntactically(ctx rule.RuleContext, factory *ast.Node) verdict {
+	// An object literal in this position is the mock options bag, not a
+	// factory.
+	if factory.Kind == ast.KindObjectLiteralExpression {
+		return verdictSync
+	}
+	if !isFunctionExpressionLike(factory) {
+		return verdictUnknown
+	}
+	return classifyFunction(ctx, factory)
+}
+
+func classifyFunction(ctx rule.RuleContext, fn *ast.Node) verdict {
+	flags := ast.GetFunctionFlags(fn)
+	// A generator hands back a Generator and an async generator an
+	// AsyncGenerator. Neither is a promise, so neither trips the runtime gate.
+	if flags&ast.FunctionFlagsGenerator != 0 {
+		return verdictSync
+	}
+	if flags&ast.FunctionFlagsAsync != 0 {
+		return verdictPromise
+	}
+
+	returned, ok := returnedExpressions(fn)
+	if !ok || len(returned) == 0 {
+		return verdictUnknown
+	}
+	for _, expression := range returned {
+		if !isPromiseProducingExpression(ctx, expression) {
+			return verdictUnknown
+		}
+	}
+	return verdictPromise
+}
+
+// classifyThroughDeclaration follows an identifier to a declaration in this
+// file. A name that resolves to more than one declaration, to another file, or
+// to anything but a `const` function or a function declaration is left to the
+// type layer, where a reassignment or a re-export is accounted for.
+func classifyThroughDeclaration(ctx rule.RuleContext, factory *ast.Node) verdict {
+	if factory.Kind != ast.KindIdentifier || ctx.Refs == nil {
+		return verdictUnknown
+	}
+	symbol := ctx.Refs.Resolve(factory)
+	if symbol == nil || len(symbol.Declarations) != 1 {
+		return verdictUnknown
+	}
+	declaration := symbol.Declarations[0]
+	if declaration == nil || ast.GetSourceFileOfNode(declaration) != ctx.SourceFile {
+		return verdictUnknown
+	}
+
+	switch declaration.Kind {
+	case ast.KindFunctionDeclaration:
+		return classifyFunction(ctx, declaration)
+	case ast.KindVariableDeclaration:
+		if !ast.IsVarConst(declaration) {
+			return verdictUnknown
+		}
+		initializer := utils.SkipAssertionsAndParens(declaration.Initializer())
+		if initializer == nil || !isFunctionExpressionLike(initializer) {
+			return verdictUnknown
+		}
+		return classifyFunction(ctx, initializer)
+	}
+	return verdictUnknown
+}
+
+// classifyByType asks the TypeChecker, and only ever answers verdictPromise or
+// verdictUnknown: it exists to decide the cases syntax could not, never to
+// overrule it.
+//
+// A source-only program has no TypeChecker, and the rule then reports what the
+// first two layers found and nothing more.
+func classifyByType(ctx rule.RuleContext, factory *ast.Node) verdict {
+	if ctx.TypeChecker == nil {
+		return verdictUnknown
+	}
+	if alwaysReturnsPromise(ctx.TypeChecker, ctx.TypeChecker.GetTypeAtLocation(factory)) {
+		return verdictPromise
+	}
+	return verdictUnknown
+}
+
+// alwaysReturnsPromise reports whether calling a value of type t can only
+// produce a promise. Every union member has to be callable and every one of
+// their signatures has to return a promise: a type that mixes an async factory
+// with a synchronous one leaves the outcome to run time, and this rule stays
+// silent rather than report a call that may well work.
+func alwaysReturnsPromise(typeChecker *checker.Checker, t *checker.Type) bool {
+	if t == nil {
+		return false
+	}
+	if utils.IsUnionType(t) {
+		parts := t.Types()
+		if len(parts) == 0 {
+			return false
+		}
+		for _, part := range parts {
+			if !alwaysReturnsPromise(typeChecker, part) {
+				return false
+			}
+		}
+		return true
+	}
+
+	signatures := utils.GetCallSignatures(typeChecker, t)
+	if len(signatures) == 0 {
+		return false
+	}
+	for _, signature := range signatures {
+		if !isPromiseInstanceType(typeChecker, checker.Checker_getReturnTypeOfSignature(typeChecker, signature), 0) {
+			return false
+		}
+	}
+	return true
+}
+
+// isPromiseInstanceType reports whether a value of type t is an instance of
+// `Promise`, matching the type by its name.
+//
+// utils.IsThenableType is deliberately not used. It answers "has a `then` whose
+// first parameter is a callback", which is wider than the `instanceof Promise`
+// the runtime performs, and the gap is reachable: mocking a module that itself
+// exports `then` gives the factory a thenable return type while the runtime
+// accepts it happily.
+func isPromiseInstanceType(typeChecker *checker.Checker, t *checker.Type, depth int) bool {
+	if t == nil || depth > 8 {
+		return false
+	}
+	if utils.IsTypeFlagSet(t, checker.TypeFlagsAnyOrUnknown) {
+		return false
+	}
+	if utils.IsUnionType(t) {
+		parts := t.Types()
+		if len(parts) == 0 {
+			return false
+		}
+		for _, part := range parts {
+			if !isPromiseInstanceType(typeChecker, part, depth+1) {
+				return false
+			}
+		}
+		return true
+	}
+	if utils.IsIntersectionType(t) {
+		// `Promise<T> & Branded` is still a promise at run time.
+		for _, part := range t.Types() {
+			if isPromiseInstanceType(typeChecker, part, depth+1) {
+				return true
+			}
+		}
+		return false
+	}
+
+	resolved := t
+	if utils.IsTypeFlagSet(resolved, checker.TypeFlagsObject) &&
+		checker.Type_objectFlags(resolved)&checker.ObjectFlagsReference != 0 {
+		resolved = resolved.Target()
+	}
+	if symbol := checker.Type_symbol(resolved); symbol != nil && symbol.Name == "Promise" {
+		return true
+	}
+	if checker.Type_objectFlags(resolved)&checker.ObjectFlagsClassOrInterface == 0 {
+		return false
+	}
+	// A subclass of Promise is an instance of Promise.
+	for _, base := range checker.Checker_getBaseTypes(typeChecker, resolved) {
+		if isPromiseInstanceType(typeChecker, base, depth+1) {
+			return true
+		}
+	}
+	return false
+}
+
+// isPromiseProducingExpression reports whether the expression can only evaluate
+// to a promise, judged by how it is written.
+func isPromiseProducingExpression(ctx rule.RuleContext, node *ast.Node) bool {
+	node = utils.SkipAssertionsAndParens(node)
+	if node == nil {
+		return false
+	}
+
+	switch node.Kind {
+	case ast.KindNewExpression:
+		callee := utils.SkipAssertionsAndParens(node.AsNewExpression().Expression)
+		return isUnshadowedPromiseIdentifier(callee)
+	case ast.KindCallExpression:
+	default:
+		return false
+	}
+
+	call := node.AsCallExpression()
+	// A dynamic import always yields a promise, whatever it names.
+	if call.Expression != nil && call.Expression.Kind == ast.KindImportKeyword {
+		return true
+	}
+	if call.QuestionDotToken != nil {
+		return false
+	}
+
+	// `rs.importActual` / `rs.importMock` load a module asynchronously. The
+	// shapes the build rewrites differ per member, and `importActual` honours
+	// a local declaration of the receiver, so both questions go through the
+	// shared table rather than being assumed here.
+	if utility := rstestUtils.ParseRstestPluginManagedCall(node); utility != nil {
+		if !asyncModuleLoaders[utility.Member] {
+			return false
+		}
+		return !utility.API.ResolvesReceiver ||
+			!rstestUtils.ReceiverIsLocallyDeclared(ctx, utility.NamespaceNode)
+	}
+
+	callee := utils.SkipAssertionsAndParens(call.Expression)
+	if callee == nil || callee.Kind != ast.KindPropertyAccessExpression {
+		return false
+	}
+	access := callee.AsPropertyAccessExpression()
+	if access.QuestionDotToken != nil {
+		return false
+	}
+	name := access.Name()
+	if name == nil || name.Kind != ast.KindIdentifier || !promiseStatics[name.AsIdentifier().Text] {
+		return false
+	}
+	return isUnshadowedPromiseIdentifier(utils.SkipAssertionsAndParens(access.Expression))
+}
+
+// isUnshadowedPromiseIdentifier reports whether node is the global `Promise`.
+// A file that declares its own `Promise` is left to the type layer.
+func isUnshadowedPromiseIdentifier(node *ast.Node) bool {
+	return node != nil && node.Kind == ast.KindIdentifier &&
+		node.AsIdentifier().Text == "Promise" &&
+		!utils.IsShadowed(node, "Promise")
+}
+
+func isFunctionExpressionLike(node *ast.Node) bool {
+	return node != nil &&
+		(node.Kind == ast.KindArrowFunction || node.Kind == ast.KindFunctionExpression)
+}
+
+// returnedExpressions collects every expression the function can hand back. The
+// second result is false when the body is missing or holds a bare `return;`,
+// which makes the set incomplete and the function undecidable here.
+func returnedExpressions(fn *ast.Node) ([]*ast.Node, bool) {
+	body := fn.Body()
+	if body == nil {
+		return nil, false
+	}
+	if body.Kind != ast.KindBlock {
+		return []*ast.Node{body}, true
+	}
+
+	returned := make([]*ast.Node, 0, 2)
+	complete := true
+	var walk func(node *ast.Node) bool
+	walk = func(node *ast.Node) bool {
+		if node == nil {
+			return false
+		}
+		// A nested function's returns belong to that function.
+		if ast.IsFunctionLike(node) {
+			return false
+		}
+		if node.Kind == ast.KindReturnStatement {
+			expression := node.AsReturnStatement().Expression
+			if expression == nil {
+				complete = false
+				return false
+			}
+			returned = append(returned, expression)
+			return false
+		}
+		return node.ForEachChild(walk)
+	}
+	body.ForEachChild(walk)
+	return returned, complete
+}
+
+// suggestions builds the two narrow rewrites that are safe to apply on their
+// own. Neither is offered as a fix: the common shape awaits the real module
+// inside the factory, and turning that into a top-level
+// `import … with { rstest: 'importActual' }` moves code across statements.
+func suggestions(ctx rule.RuleContext, factory *ast.Node) []rule.RuleSuggestion {
+	if !isFunctionExpressionLike(factory) {
+		return nil
+	}
+	returned, complete := returnedExpressions(factory)
+	if !complete {
+		return nil
+	}
+
+	if ast.GetFunctionFlags(factory)&ast.FunctionFlagsAsync != 0 {
+		return removeAsyncSuggestion(ctx, factory, returned)
+	}
+	return unwrapPromiseResolveSuggestion(ctx, factory, returned)
+}
+
+// removeAsyncSuggestion drops the `async` keyword, which is equivalent only
+// when the body neither awaits nor already hands back a promise of its own.
+func removeAsyncSuggestion(ctx rule.RuleContext, factory *ast.Node, returned []*ast.Node) []rule.RuleSuggestion {
+	for _, expression := range returned {
+		if !isDefinitelyNotPromise(expression) {
+			return nil
+		}
+	}
+	if bodyAwaits(factory) {
+		return nil
+	}
+
+	modifiers := factory.Modifiers()
+	if modifiers == nil {
+		return nil
+	}
+	for _, modifier := range modifiers.Nodes {
+		if modifier == nil || modifier.Kind != ast.KindAsyncKeyword {
+			continue
+		}
+		keyword := utils.TrimNodeTextRange(ctx.SourceFile, modifier)
+		text := ctx.SourceFile.Text()
+		removal := core.NewTextRange(
+			keyword.Pos(),
+			ecmascript.SkipLeadingWhitespace(text, keyword.End(), len(text)),
+		)
+		if utils.HasCommentInSpan(ctx.Comments.All(), removal.Pos(), removal.End()) {
+			return nil
+		}
+		return []rule.RuleSuggestion{{
+			Message:  removeAsyncMessage,
+			FixesArr: []rule.RuleFix{rule.RuleFixRemoveRange(removal)},
+		}}
+	}
+	return nil
+}
+
+// unwrapPromiseResolveSuggestion replaces a lone `Promise.resolve(x)` with `x`.
+func unwrapPromiseResolveSuggestion(ctx rule.RuleContext, factory *ast.Node, returned []*ast.Node) []rule.RuleSuggestion {
+	if len(returned) != 1 {
+		return nil
+	}
+	wrapper := utils.SkipAssertionsAndParens(returned[0])
+	if wrapper == nil || wrapper.Kind != ast.KindCallExpression {
+		return nil
+	}
+	call := wrapper.AsCallExpression()
+	callee := utils.SkipAssertionsAndParens(call.Expression)
+	if callee == nil || callee.Kind != ast.KindPropertyAccessExpression {
+		return nil
+	}
+	access := callee.AsPropertyAccessExpression()
+	name := access.Name()
+	if name == nil || name.Kind != ast.KindIdentifier || name.AsIdentifier().Text != "resolve" ||
+		!isUnshadowedPromiseIdentifier(utils.SkipAssertionsAndParens(access.Expression)) {
+		return nil
+	}
+	if call.Arguments == nil || len(call.Arguments.Nodes) != 1 {
+		return nil
+	}
+	resolved := call.Arguments.Nodes[0]
+	if resolved == nil || resolved.Kind == ast.KindSpreadElement || !isDefinitelyNotPromise(resolved) {
+		return nil
+	}
+
+	// The whole call is replaced by the resolved value as written, so anything
+	// in the space that goes — a comment around `Promise.resolve` or around the
+	// argument — would be deleted with it.
+	wrapperRange := utils.TrimNodeTextRange(ctx.SourceFile, wrapper)
+	resolvedRange := utils.TrimNodeTextRange(ctx.SourceFile, resolved)
+	comments := ctx.Comments.All()
+	if utils.HasCommentInSpan(comments, wrapperRange.Pos(), resolvedRange.Pos()) ||
+		utils.HasCommentInSpan(comments, resolvedRange.End(), wrapperRange.End()) {
+		return nil
+	}
+
+	replacement := ctx.SourceFile.Text()[resolvedRange.Pos():resolvedRange.End()]
+	// A concise arrow body starting with `{` would parse as a block.
+	if factory.Body() == returned[0] && len(replacement) > 0 && replacement[0] == '{' {
+		replacement = "(" + replacement + ")"
+	}
+	return []rule.RuleSuggestion{{
+		Message:  unwrapPromiseResolveMessage,
+		FixesArr: []rule.RuleFix{rule.RuleFixReplaceRange(wrapperRange, replacement)},
+	}}
+}
+
+// isDefinitelyNotPromise reports whether the expression's value can be read off
+// the syntax and is certainly not a promise. It gates the suggestions, so
+// anything it cannot vouch for is a "no".
+func isDefinitelyNotPromise(node *ast.Node) bool {
+	node = utils.SkipAssertionsAndParens(node)
+	if node == nil {
+		return false
+	}
+	switch node.Kind {
+	case ast.KindObjectLiteralExpression,
+		ast.KindArrayLiteralExpression,
+		ast.KindStringLiteral,
+		ast.KindNoSubstitutionTemplateLiteral,
+		ast.KindTemplateExpression,
+		ast.KindNumericLiteral,
+		ast.KindBigIntLiteral,
+		ast.KindRegularExpressionLiteral,
+		ast.KindTrueKeyword,
+		ast.KindFalseKeyword,
+		ast.KindNullKeyword,
+		ast.KindArrowFunction,
+		ast.KindFunctionExpression,
+		ast.KindClassExpression:
+		return true
+	case ast.KindIdentifier:
+		return node.AsIdentifier().Text == "undefined" && !utils.IsShadowed(node, "undefined")
+	}
+	return false
+}
+
+// bodyAwaits reports whether the function's own body suspends: an `await`
+// expression, `for await`, or an `await using` declaration. A nested function
+// has its own body and does not count.
+func bodyAwaits(fn *ast.Node) bool {
+	body := fn.Body()
+	if body == nil {
+		return false
+	}
+
+	found := false
+	var walk func(node *ast.Node) bool
+	walk = func(node *ast.Node) bool {
+		if node == nil || found {
+			return found
+		}
+		if ast.IsFunctionLike(node) {
+			return false
+		}
+		switch node.Kind {
+		case ast.KindAwaitExpression:
+			found = true
+			return true
+		case ast.KindForOfStatement:
+			if node.AsForInOrOfStatement().AwaitModifier != nil {
+				found = true
+				return true
+			}
+		case ast.KindVariableDeclarationList:
+			if ast.IsVarAwaitUsing(node) {
+				found = true
+				return true
+			}
+		}
+		return node.ForEachChild(walk)
+	}
+	body.ForEachChild(walk)
+	return found
+}

--- a/internal/plugins/rstest/rules/no_async_mock_factory/no_async_mock_factory.md
+++ b/internal/plugins/rstest/rules/no_async_mock_factory/no_async_mock_factory.md
@@ -8,6 +8,8 @@ Rstest installs the second argument of `rs.mock`, `rs.doMock`, `rs.mockRequire` 
 
 What matters is the value the factory actually returns, not how it is written: an `async` function, a plain function returning `Promise.resolve(…)`, `new Promise(…)`, a dynamic `import(…)` and `rs.importActual(…)` all amount to the same thing. A generator and a hand-written thenable hand back something that is not a promise, so the runtime lets them through and so does this rule.
 
+Only a factory that can *only* return a promise is reported. One with a path that runs off the end of its body returns `undefined` there, which the runtime accepts, so it is left alone.
+
 A factory the syntax cannot settle — one that comes from another module, or that a helper produces — is judged from its type when a TypeScript project is available, and goes unreported without type information. A type that mixes a promise-returning signature with a synchronous one is never reported, because such a call may well work.
 
 ## Incorrect
@@ -43,4 +45,4 @@ Two narrow suggestions are offered where the rewrite is exactly equivalent:
 - **Remove `async`**, when the body neither suspends nor already hands back a promise of its own.
 - **Return the value directly instead of wrapping it in `Promise.resolve(…)`**, when the factory's only returned expression is a single-argument `Promise.resolve(…)` around a value that is plainly not a promise.
 
-Both share one precondition: the code being rewritten must contain no comment. Each suggestion replaces a whole span, so a comment sitting inside that span would be deleted with it. When that happens the rule reports without a suggestion and leaves the change to you.
+Both share two preconditions. The code being rewritten must contain no comment, because each suggestion replaces a whole span and a comment sitting inside that span would be deleted with it. And the factory must carry no return type annotation of its own, because both rewrites take the promise out of the value while leaving the annotation as written, which would leave `(): Promise<T> => …` annotating a plain `T`. When either fails the rule reports without a suggestion and leaves the change to you.

--- a/internal/plugins/rstest/rules/no_async_mock_factory/no_async_mock_factory.md
+++ b/internal/plugins/rstest/rules/no_async_mock_factory/no_async_mock_factory.md
@@ -1,0 +1,46 @@
+# rstest/no-async-mock-factory
+
+## Rule Details
+
+A mock factory must hand back the module object synchronously.
+
+Rstest installs the second argument of `rs.mock`, `rs.doMock`, `rs.mockRequire` and `rs.doMockRequire` as the mocked module's own factory and calls it while the module graph is being built, where the module itself is what has to come back. Returning a promise always fails and throws `[Rstest] An async mock factory is not supported.` — and the type system does not reject it, so the error surfaces only once the mocked module is really loaded, which can be far from the mock itself.
+
+What matters is the value the factory actually returns, not how it is written: an `async` function, a plain function returning `Promise.resolve(…)`, `new Promise(…)`, a dynamic `import(…)` and `rs.importActual(…)` all amount to the same thing. A generator and a hand-written thenable hand back something that is not a promise, so the runtime lets them through and so does this rule.
+
+A factory the syntax cannot settle — one that comes from another module, or that a helper produces — is judged from its type when a TypeScript project is available, and goes unreported without type information. A type that mixes a promise-returning signature with a synchronous one is never reported, because such a call may well work.
+
+## Incorrect
+
+```ts
+import { rs } from '@rstest/core';
+
+rs.mock('./api', async () => {
+  const actual = await rs.importActual<typeof import('./api')>('./api');
+  return { ...actual, get: rs.fn() };
+});
+
+rs.mock('./config', () => Promise.resolve({ endpoint: 'http://localhost' }));
+```
+
+## Correct
+
+```ts
+import * as actual from './api' with { rstest: 'importActual' };
+import { rs } from '@rstest/core';
+
+rs.mock('./api', () => ({ ...actual, get: rs.fn() }));
+
+rs.mock('./config', () => ({ endpoint: 'http://localhost' }));
+```
+
+## Suggestions
+
+The rule provides no autofix. The common shape awaits the real module inside the factory, and rewriting that means adding a top-level `import … with { rstest: 'importActual' }` and reshaping the body — a change across statements that should not be applied unattended.
+
+Two narrow suggestions are offered where the rewrite is exactly equivalent:
+
+- **Remove `async`**, when the body neither suspends nor already hands back a promise of its own.
+- **Return the value directly instead of wrapping it in `Promise.resolve(…)`**, when the factory's only returned expression is a single-argument `Promise.resolve(…)` around a value that is plainly not a promise.
+
+Both share one precondition: the code being rewritten must contain no comment. Each suggestion replaces a whole span, so a comment sitting inside that span would be deleted with it. When that happens the rule reports without a suggestion and leaves the change to you.

--- a/internal/plugins/rstest/rules/no_async_mock_factory/no_async_mock_factory_extras_test.go
+++ b/internal/plugins/rstest/rules/no_async_mock_factory/no_async_mock_factory_extras_test.go
@@ -1,0 +1,349 @@
+// TestNoAsyncMockFactoryExtras covers what the syntax layer cannot settle on
+// the factory alone: which call shapes the Rstest build actually rewrites,
+// where the call has to stand, what the argument list has to look like, and the
+// boundaries of the two suggestions.
+//
+// `rs['mock'](…)`, `rs.mock?.(…)` and `rs?.mock(…)` were each run against
+// @rstest/core 0.11.8 with an async factory: all three threw
+// "mock() was not transformed by Rstest" rather than the async-factory error,
+// so the factory never runs and there is nothing to report.
+package no_async_mock_factory
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoAsyncMockFactoryExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoAsyncMockFactoryRule,
+		[]rule_tester.ValidTestCase{
+			// ---- shapes the build leaves as the throwing stub ----
+			// None of these four members is matched through a computed
+			// property, an optional call or an optional receiver, so the
+			// factory never runs and there is nothing to report.
+			{Code: `rs['mock']('./sum', async () => ({ sum: 0 }))`},
+			{Code: `rs.mock?.('./sum', async () => ({ sum: 0 }))`},
+			{Code: `rs?.mock('./sum', async () => ({ sum: 0 }))`},
+			{Code: "rs[`mock`]('./sum', async () => ({ sum: 0 }))"},
+
+			// The rewrite matches the receiver by the name written at the call
+			// site, so a renamed binding is an ordinary call that throws where
+			// it stands.
+			{Code: `import { rs as mocker } from '@rstest/core';
+mocker.mock('./sum', async () => ({ sum: 0 }))`},
+			{Code: `import * as core from '@rstest/core';
+core.rs.mock('./sum', async () => ({ sum: 0 }))`},
+
+			// ---- positions the call cannot be lifted out of ----
+			{Code: `const mocked = rs.mock('./sum', async () => ({ sum: 0 }))`},
+			{Code: `await rs.mock('./sum', async () => ({ sum: 0 }))`},
+			{Code: `consume(rs.mock('./sum', async () => ({ sum: 0 })))`},
+			{Code: `void rs.mock('./sum', async () => ({ sum: 0 }))`},
+			{Code: `rs.mock('./sum', async () => ({ sum: 0 })), other()`},
+
+			// ---- argument lists the transform gives up on ----
+			{Code: `rs.mock(...args)`},
+			{Code: `rs.mock('./sum', ...factories)`},
+			{Code: `rs.mock('./sum', async () => ({ sum: 0 }), extra)`},
+
+			// ---- the local declaration decides where the build asks for one ----
+			// `importActual` is one of the two members whose rewrite honours an
+			// ordinary binding, so this file's own `rs` really runs and the
+			// factory is synchronous.
+			{Code: `const rs = { mock: (p: string, f: () => unknown) => f(), importActual: () => ({ sum: 0 }) };
+rs.mock('./sum', () => rs.importActual('./sum'))`},
+			// A file that declares its own `Promise` is left to the types,
+			// which see a plain object here.
+			{Code: `export {};
+const Promise = { resolve: (value: unknown) => value };
+rs.mock('./sum', () => Promise.resolve({ sum: 0 }))`},
+
+			// ---- the types settle what the syntax could not ----
+			{Code: `declare const factory: () => { sum: number };
+rs.mock('./sum', factory)`},
+			// A union that mixes an async factory with a synchronous one may
+			// well work at run time.
+			{Code: `declare const factory: (() => Promise<{ sum: number }>) | (() => { sum: number });
+rs.mock('./sum', factory)`},
+			{Code: `declare const factory: any;
+rs.mock('./sum', factory)`},
+			// A module that exports `then` gives the factory a thenable return
+			// type, but `instanceof Promise` does not match it and the runtime
+			// does not throw.
+			{Code: `declare const factory: () => { then(onFulfilled: (value: unknown) => void): void };
+rs.mock('./sum', factory)`},
+			{Code: `import { syncModuleFactory } from './async-mock-factories';
+rs.mock('./sum', syncModuleFactory)`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- shapes the build does rewrite ----
+			// `as`, `satisfies` and `!` are erased before the rewrite runs, and
+			// it reads through parentheses.
+			{
+				Code: `(rs as any)!.mock('./sum', async () => ({ sum: 0 }))`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "asyncMockFactory",
+					Line:      1,
+					Column:    28,
+					EndLine:   1,
+					EndColumn: 52,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+						MessageId: "suggestRemoveAsync",
+						Output:    `(rs as any)!.mock('./sum', () => ({ sum: 0 }))`,
+					}},
+				}},
+			},
+			// The report covers the argument as written, so an assertion
+			// wrapped around the factory is part of the range.
+			{
+				Code: `rs.mock('./sum', (async () => ({ sum: 0 })) as never)`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "asyncMockFactory",
+					Line:      1,
+					Column:    18,
+					EndLine:   1,
+					EndColumn: 53,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+						MessageId: "suggestRemoveAsync",
+						Output:    `rs.mock('./sum', (() => ({ sum: 0 })) as never)`,
+					}},
+				}},
+			},
+
+			// A block is still a statement position; the build lifts the call
+			// out of it.
+			{
+				Code: `
+if (flag) {
+  rs.mock('./sum', async () => ({ sum: 0 }));
+}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "asyncMockFactory",
+					Line:      3,
+					Column:    20,
+					EndLine:   3,
+					EndColumn: 44,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+						MessageId: "suggestRemoveAsync",
+						Output: `
+if (flag) {
+  rs.mock('./sum', () => ({ sum: 0 }));
+}
+`,
+					}},
+				}},
+			},
+
+			// ---- what the first argument is written as does not matter ----
+			{
+				Code: `rs.mock(import('./sum'), async () => ({ sum: 0 }))`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "asyncMockFactory",
+					Line:      1,
+					Column:    26,
+					EndLine:   1,
+					EndColumn: 50,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+						MessageId: "suggestRemoveAsync",
+						Output:    `rs.mock(import('./sum'), () => ({ sum: 0 }))`,
+					}},
+				}},
+			},
+			{
+				Code: `rs.mock(modulePath, async () => ({ sum: 0 }))`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "asyncMockFactory",
+					Line:      1,
+					Column:    21,
+					EndLine:   1,
+					EndColumn: 45,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+						MessageId: "suggestRemoveAsync",
+						Output:    `rs.mock(modulePath, () => ({ sum: 0 }))`,
+					}},
+				}},
+			},
+			// An explicit type argument names the mocked module's shape. It
+			// says nothing about when the factory hands it back.
+			{
+				Code: `rs.mock<{ sum: number }>('./sum', async () => ({ sum: 0 }))`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "asyncMockFactory",
+					Line:      1,
+					Column:    35,
+					EndLine:   1,
+					EndColumn: 59,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+						MessageId: "suggestRemoveAsync",
+						Output:    `rs.mock<{ sum: number }>('./sum', () => ({ sum: 0 }))`,
+					}},
+				}},
+			},
+
+			// ---- the types settle what the syntax could not ----
+			{
+				Code: `declare const factory: () => Promise<{ sum: number }>;
+rs.mock('./sum', factory)`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "asyncMockFactory",
+					Line:      2,
+					Column:    18,
+					EndLine:   2,
+					EndColumn: 25,
+				}},
+			},
+			// Inline, and still undecidable from the syntax alone.
+			{
+				Code: `declare function buildMock(): Promise<{ sum: number }>;
+rs.mock('./sum', () => buildMock())`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "asyncMockFactory",
+					Line:      2,
+					Column:    18,
+					EndLine:   2,
+					EndColumn: 35,
+				}},
+			},
+			{
+				Code: `import { asyncModuleFactory } from './async-mock-factories';
+rs.mock('./sum', asyncModuleFactory)`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "asyncMockFactory",
+					Line:      2,
+					Column:    18,
+					EndLine:   2,
+					EndColumn: 36,
+				}},
+			},
+			// A subclass of Promise is still `instanceof Promise`.
+			{
+				Code: `declare class Deferred<T> extends Promise<T> {}
+declare const factory: () => Deferred<{ sum: number }>;
+rs.mock('./sum', factory)`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "asyncMockFactory",
+					Line:      3,
+					Column:    18,
+					EndLine:   3,
+					EndColumn: 25,
+				}},
+			},
+
+			// ---- suggestion boundaries ----
+			// Removing `async` would not make the body synchronous.
+			{
+				Code: `declare function buildMock(): Promise<{ sum: number }>;
+rs.mock('./sum', async () => buildMock())`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "asyncMockFactory",
+					Line:      2,
+					Column:    18,
+					EndLine:   2,
+					EndColumn: 41,
+				}},
+			},
+			// A bare `return` leaves the returned set incomplete.
+			{
+				Code: `rs.mock('./sum', async function () { if (flag) { return; } return { sum: 0 }; })`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "asyncMockFactory",
+					Line:      1,
+					Column:    18,
+					EndLine:   1,
+					EndColumn: 80,
+				}},
+			},
+			// The body suspends, so dropping `async` would not compile.
+			{
+				Code: `rs.mock('./sum', async () => { await ready; return { sum: 0 }; })`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "asyncMockFactory",
+					Line:      1,
+					Column:    18,
+					EndLine:   1,
+					EndColumn: 65,
+				}},
+			},
+			{
+				Code: `rs.mock('./sum', async () => { for await (const part of parts) { use(part); } return { sum: 0 }; })`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "asyncMockFactory",
+					Line:      1,
+					Column:    18,
+					EndLine:   1,
+					EndColumn: 99,
+				}},
+			},
+			{
+				Code: `rs.mock('./sum', async () => { await using handle = open(); return { sum: 0 }; })`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "asyncMockFactory",
+					Line:      1,
+					Column:    18,
+					EndLine:   1,
+					EndColumn: 81,
+				}},
+			},
+			// A nested function's `await` belongs to that function.
+			{
+				Code: `rs.mock('./sum', async () => ({ load: async () => { await ready; } }))`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "asyncMockFactory",
+					Line:      1,
+					Column:    18,
+					EndLine:   1,
+					EndColumn: 70,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+						MessageId: "suggestRemoveAsync",
+						Output:    `rs.mock('./sum', () => ({ load: async () => { await ready; } }))`,
+					}},
+				}},
+			},
+			// Unwrapping would leave a promise behind.
+			{
+				Code: `rs.mock('./sum', () => Promise.resolve(buildMock()))`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "asyncMockFactory",
+					Line:      1,
+					Column:    18,
+					EndLine:   1,
+					EndColumn: 52,
+				}},
+			},
+			// A comment inside the replaced span would be deleted with it.
+			{
+				Code: `rs.mock('./sum', () => Promise.resolve(/* keep */ { sum: 0 }))`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "asyncMockFactory",
+					Line:      1,
+					Column:    18,
+					EndLine:   1,
+					EndColumn: 62,
+				}},
+			},
+			// A `return` statement takes the object without parentheses; a
+			// concise arrow body needs them.
+			{
+				Code: `rs.mock('./sum', () => Promise.resolve([1, 2]))`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "asyncMockFactory",
+					Line:      1,
+					Column:    18,
+					EndLine:   1,
+					EndColumn: 47,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+						MessageId: "suggestUnwrapPromiseResolve",
+						Output:    `rs.mock('./sum', () => [1, 2])`,
+					}},
+				}},
+			},
+		},
+	)
+}

--- a/internal/plugins/rstest/rules/no_async_mock_factory/no_async_mock_factory_extras_test.go
+++ b/internal/plugins/rstest/rules/no_async_mock_factory/no_async_mock_factory_extras_test.go
@@ -80,6 +80,30 @@ rs.mock('./sum', factory)`},
 rs.mock('./sum', factory)`},
 			{Code: `import { syncModuleFactory } from './async-mock-factories';
 rs.mock('./sum', syncModuleFactory)`},
+			// A local class named `Promise` is not the one the runtime checks
+			// against: `new Promise()` hands back an ordinary object here.
+			{Code: `export {};
+class Promise { sum = 0; }
+rs.doMockRequire('./sum', () => new Promise())`},
+
+			// ---- a path that returns nothing ----
+			// A false `flag` reaches the end of the body and returns
+			// `undefined`, which is not a promise, so the factory only
+			// sometimes hands one back.
+			{Code: `rs.doMockRequire('./sum', () => { if (flag) return Promise.resolve({ sum: 0 }); })`},
+			{Code: `rs.mock('./sum', function () {
+  if (flag) {
+    return Promise.resolve({ sum: 0 });
+  }
+})`},
+			// The declaration is not the factory that is installed: the name is
+			// written to before the call, and the type layer sees only
+			// `() => unknown`.
+			{Code: `function factory(): unknown {
+  return Promise.resolve({ sum: 0 });
+}
+factory = () => ({ sum: 0 });
+rs.doMock('./sum', factory)`},
 		},
 		[]rule_tester.InvalidTestCase{
 			// ---- shapes the build does rewrite ----
@@ -326,6 +350,42 @@ rs.mock('./sum', async () => buildMock())`,
 					Column:    18,
 					EndLine:   1,
 					EndColumn: 62,
+				}},
+			},
+			// Removing `async` would leave the annotation promising a promise
+			// the factory no longer returns, and unwrapping `Promise.resolve`
+			// has the same problem, so neither is suggested.
+			{
+				Code: `rs.mock('./sum', async (): Promise<{ sum: number }> => ({ sum: 0 }))`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "asyncMockFactory",
+					Line:      1,
+					Column:    18,
+					EndLine:   1,
+					EndColumn: 68,
+				}},
+			},
+			{
+				Code: `rs.mock('./sum', (): Promise<{ sum: number }> => Promise.resolve({ sum: 0 }))`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "asyncMockFactory",
+					Line:      1,
+					Column:    18,
+					EndLine:   1,
+					EndColumn: 77,
+				}},
+			},
+			// A nested function's computed name is evaluated in this body, so
+			// the `await` in it is the factory's own and dropping `async` would
+			// not parse.
+			{
+				Code: `rs.mock('./sum', async () => ({ [await ready]() { return 0; } }))`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "asyncMockFactory",
+					Line:      1,
+					Column:    18,
+					EndLine:   1,
+					EndColumn: 65,
 				}},
 			},
 			// A `return` statement takes the object without parentheses; a

--- a/internal/plugins/rstest/rules/no_async_mock_factory/no_async_mock_factory_source_only_test.go
+++ b/internal/plugins/rstest/rules/no_async_mock_factory/no_async_mock_factory_source_only_test.go
@@ -60,6 +60,13 @@ rs.mock('./sum', () => rs.importActual('./sum'));`,
 			want: 0,
 		},
 		{
+			// The binder's reachability is available without a TypeChecker, so
+			// the fall-through path is seen here too.
+			name:   "path that returns nothing",
+			source: `rs.doMockRequire('./sum', () => { if (flag) return Promise.resolve({ sum: 0 }); });`,
+			want:   0,
+		},
+		{
 			name:   "synchronous factory",
 			source: `rs.mock('./sum', () => ({ sum: () => 0 }));`,
 			want:   0,

--- a/internal/plugins/rstest/rules/no_async_mock_factory/no_async_mock_factory_source_only_test.go
+++ b/internal/plugins/rstest/rules/no_async_mock_factory/no_async_mock_factory_source_only_test.go
@@ -1,0 +1,129 @@
+// TestNoAsyncMockFactorySourceOnly locks the rule's behaviour on a program that
+// carries no TypeChecker. The two syntax layers have to keep working there, and
+// the type layer has to fall silent rather than panic.
+package no_async_mock_factory
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/microsoft/TypeScript/tsc/shim/ast"
+	"github.com/microsoft/TypeScript/tsc/shim/bundled"
+	"github.com/microsoft/TypeScript/tsc/shim/core"
+	"github.com/microsoft/TypeScript/tsc/shim/tspath"
+	"github.com/microsoft/TypeScript/tsc/shim/vfs/cachedvfs"
+	"github.com/microsoft/TypeScript/tsc/shim/vfs/osvfs"
+	lintprogram "github.com/web-infra-dev/rslint/internal/program"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/testutil"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+func TestNoAsyncMockFactorySourceOnly(t *testing.T) {
+	testCases := []struct {
+		name   string
+		source string
+		want   int
+	}{
+		{
+			name:   "async arrow",
+			source: `rs.mock('./sum', async () => ({ sum: () => 0 }));`,
+			want:   1,
+		},
+		{
+			name:   "promise-producing body",
+			source: `rs.doMock('./sum', () => Promise.resolve({ sum: 0 }));`,
+			want:   1,
+		},
+		{
+			name: "declaration in this file",
+			source: `const factory = async () => ({ sum: () => 0 });
+rs.mock('./sum', factory);`,
+			want: 1,
+		},
+		{
+			// The syntax layer matches `Promise` by the name as written, and
+			// this file declares its own. With no types left to ask, the rule
+			// stays silent rather than guess.
+			name: "shadowed Promise",
+			source: `const Promise = { resolve: (value: unknown) => value };
+rs.mock('./sum', () => Promise.resolve({ sum: 0 }));`,
+			want: 0,
+		},
+		{
+			// `importActual` is one of the two members whose rewrite honours an
+			// ordinary binding of the receiver.
+			name: "locally declared receiver",
+			source: `const rs = { mock: (p: string, f: () => unknown) => f(), importActual: () => ({ sum: 0 }) };
+rs.mock('./sum', () => rs.importActual('./sum'));`,
+			want: 0,
+		},
+		{
+			name:   "synchronous factory",
+			source: `rs.mock('./sum', () => ({ sum: () => 0 }));`,
+			want:   0,
+		},
+		{
+			// Without a TypeChecker there is nothing left to ask, so the rule
+			// stays silent. This is the one shape it knowingly misses.
+			name:   "undecidable without types",
+			source: `rs.mock('./sum', buildMock);`,
+			want:   0,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := lintSourceOnly(t, testCase.source); got != testCase.want {
+				t.Fatalf("source-only diagnostics = %d, want %d", got, testCase.want)
+			}
+		})
+	}
+}
+
+func lintSourceOnly(t *testing.T, source string) int {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	filePath := tspath.NormalizePath(filepath.Join(tmpDir, "case.ts"))
+	if err := os.WriteFile(filePath, []byte(source), 0644); err != nil {
+		t.Fatal(err)
+	}
+	program, err := utils.CreateProgramFromOptionsLenient(true, &core.CompilerOptions{
+		Target:          core.ScriptTargetESNext,
+		Module:          core.ModuleKindCommonJS,
+		ESModuleInterop: core.TSTrue,
+		SkipLibCheck:    core.TSTrue,
+	}, []string{filePath}, utils.CreateCompilerHost(tmpDir, bundled.WrapFS(cachedvfs.From(osvfs.FS()))))
+	if err != nil {
+		t.Fatal(err)
+	}
+	sourceProgram, err := lintprogram.NewFromBoundSources(program, program.SourceFiles())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	count := 0
+	testutil.LintProgram(t, testutil.LintProgramOptions{
+		Program:                sourceProgram,
+		ExcludedPathSubstrings: testutil.DefaultExcludedPathSubstrings,
+		GetRulesForFile: func(sourceFile *ast.SourceFile) []rule.ConfiguredRule {
+			if sourceFile.FileName() != filePath {
+				return nil
+			}
+			return []rule.ConfiguredRule{{
+				Name:     NoAsyncMockFactoryRule.Name,
+				Severity: rule.SeverityError,
+				Run: func(ctx rule.RuleContext) rule.RuleListeners {
+					if ctx.TypeChecker != nil {
+						t.Fatal("expected a program without a TypeChecker")
+					}
+					return NoAsyncMockFactoryRule.Run(ctx, nil)
+				},
+			}}
+		},
+		OnDiagnostic: func(rule.RuleDiagnostic) { count++ },
+	})
+	return count
+}

--- a/internal/plugins/rstest/rules/no_async_mock_factory/no_async_mock_factory_test.go
+++ b/internal/plugins/rstest/rules/no_async_mock_factory/no_async_mock_factory_test.go
@@ -1,0 +1,355 @@
+// TestNoAsyncMockFactory covers the shapes the syntax settles on its own: the
+// four module mock APIs, the ways a factory is written, and the expressions
+// that can only produce a promise.
+//
+// The shapes here were run against @rstest/core 0.11.8 by mocking a real module
+// and importing it. `async () => …`, `async function () {}`,
+// `Promise.resolve/all/allSettled/race/any(…)`, `new Promise(…)`, `import(…)`
+// and `rs.importActual(…)` each threw
+// "[Rstest] An async mock factory is not supported."; `doMock` threw it with
+// the same factory, and the runtime builds all four APIs from one
+// `getMockImplementation`. The generator, async generator and synchronous
+// factories completed without it.
+package no_async_mock_factory
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoAsyncMockFactory(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoAsyncMockFactoryRule,
+		[]rule_tester.ValidTestCase{
+			// ---- no factory at all ----
+			{Code: `rs.mock('./sum')`},
+			{Code: `rs.doMock('./sum')`},
+			{Code: `rs.mockRequire('./sum')`},
+			{Code: `rs.doMockRequire('./sum')`},
+
+			// ---- the second argument is the options bag ----
+			{Code: `rs.mock('./sum', { spy: true })`},
+			{Code: `rstest.doMock('./sum', { spy: true })`},
+
+			// ---- synchronous factories ----
+			{Code: `rs.mock('./sum', () => ({ sum: () => 0 }))`},
+			{Code: `rs.mock('./sum', function () { return { sum: 0 }; })`},
+			{Code: `rs.mock('./sum', function factory() { return { sum: 0 }; })`},
+			{Code: `rs.mock('./sum', () => buildMock())`},
+
+			// A generator hands back a Generator and an async generator an
+			// AsyncGenerator. Neither is `instanceof Promise`, so the runtime
+			// lets both through.
+			{Code: `rs.mock('./sum', function* () { yield 1; })`},
+			{Code: `rs.mock('./sum', async function* () { yield 1; })`},
+
+			// `instanceof Promise` does not recognize a hand-written thenable,
+			// so the runtime does not throw on one.
+			{Code: `rs.mock('./sum', () => ({ then() {} }))`},
+
+			// `Promise.withResolvers()` returns an object holding a promise.
+			{Code: `rs.mock('./sum', () => Promise.withResolvers())`},
+
+			// One branch is synchronous, so the call may well work.
+			{Code: `rs.mock('./sum', () => (cond ? Promise.resolve({}) : { sum: 0 }))`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- the four APIs share one implementation ----
+			{
+				Code: `rs.mock('./sum', async () => ({ sum: () => 0 }))`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "asyncMockFactory",
+					Message:   "Mock factory must return the module object synchronously; 'mock()' throws when the factory returns a Promise. To keep part of the original module, import it with `with { rstest: 'importActual' }` and spread it in.",
+					Line:      1,
+					Column:    18,
+					EndLine:   1,
+					EndColumn: 48,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+						MessageId: "suggestRemoveAsync",
+						Output:    `rs.mock('./sum', () => ({ sum: () => 0 }))`,
+					}},
+				}},
+			},
+			{
+				Code: `rs.doMock('./sum', async () => ({ sum: () => 0 }))`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "asyncMockFactory",
+					Message:   "Mock factory must return the module object synchronously; 'doMock()' throws when the factory returns a Promise. To keep part of the original module, import it with `with { rstest: 'importActual' }` and spread it in.",
+					Line:      1,
+					Column:    20,
+					EndLine:   1,
+					EndColumn: 50,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+						MessageId: "suggestRemoveAsync",
+						Output:    `rs.doMock('./sum', () => ({ sum: () => 0 }))`,
+					}},
+				}},
+			},
+			{
+				Code: `rs.mockRequire('./sum', async () => ({ sum: () => 0 }))`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "asyncMockFactory",
+					Line:      1,
+					Column:    25,
+					EndLine:   1,
+					EndColumn: 55,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+						MessageId: "suggestRemoveAsync",
+						Output:    `rs.mockRequire('./sum', () => ({ sum: () => 0 }))`,
+					}},
+				}},
+			},
+			{
+				Code: `rstest.doMockRequire('./sum', async () => ({ sum: () => 0 }))`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "asyncMockFactory",
+					Line:      1,
+					Column:    31,
+					EndLine:   1,
+					EndColumn: 61,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+						MessageId: "suggestRemoveAsync",
+						Output:    `rstest.doMockRequire('./sum', () => ({ sum: () => 0 }))`,
+					}},
+				}},
+			},
+
+			// ---- every way of writing an async function ----
+			{
+				Code: `rs.mock('./sum', async function () { return { sum: 0 }; })`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "asyncMockFactory",
+					Line:      1,
+					Column:    18,
+					EndLine:   1,
+					EndColumn: 58,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+						MessageId: "suggestRemoveAsync",
+						Output:    `rs.mock('./sum', function () { return { sum: 0 }; })`,
+					}},
+				}},
+			},
+			{
+				Code: `rs.mock('./sum', async function factory() { return { sum: 0 }; })`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "asyncMockFactory",
+					Line:      1,
+					Column:    18,
+					EndLine:   1,
+					EndColumn: 65,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+						MessageId: "suggestRemoveAsync",
+						Output:    `rs.mock('./sum', function factory() { return { sum: 0 }; })`,
+					}},
+				}},
+			},
+
+			// The shape the migration guide warns about: the factory awaits the
+			// real module. Turning that into a top-level
+			// `import … with { rstest: 'importActual' }` crosses statements, so
+			// the diagnostic stands without a suggestion.
+			{
+				Code: `
+rs.mock('./sum', async () => {
+  const actual = await rs.importActual('./sum');
+  return { ...actual, sum: () => 0 };
+});
+`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "asyncMockFactory",
+					Line:      2,
+					Column:    18,
+					EndLine:   5,
+					EndColumn: 2,
+				}},
+			},
+
+			// ---- the expressions that can only produce a promise ----
+			{
+				Code: `rs.mock('./sum', () => Promise.resolve({ sum: 0 }))`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "asyncMockFactory",
+					Line:      1,
+					Column:    18,
+					EndLine:   1,
+					EndColumn: 51,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+						MessageId: "suggestUnwrapPromiseResolve",
+						Output:    `rs.mock('./sum', () => ({ sum: 0 }))`,
+					}},
+				}},
+			},
+			{
+				Code: `rs.mock('./sum', function () { return Promise.resolve({ sum: 0 }); })`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "asyncMockFactory",
+					Line:      1,
+					Column:    18,
+					EndLine:   1,
+					EndColumn: 69,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+						MessageId: "suggestUnwrapPromiseResolve",
+						Output:    `rs.mock('./sum', function () { return { sum: 0 }; })`,
+					}},
+				}},
+			},
+			{
+				Code: `rs.mock('./sum', () => Promise.reject(new Error('boom')))`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "asyncMockFactory",
+					Line:      1,
+					Column:    18,
+					EndLine:   1,
+					EndColumn: 57,
+				}},
+			},
+			{
+				Code: `rs.mock('./sum', () => Promise.all([]))`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "asyncMockFactory",
+					Line:      1,
+					Column:    18,
+					EndLine:   1,
+					EndColumn: 39,
+				}},
+			},
+			{
+				Code: `rs.mock('./sum', () => Promise.allSettled([]))`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "asyncMockFactory",
+					Line:      1,
+					Column:    18,
+					EndLine:   1,
+					EndColumn: 46,
+				}},
+			},
+			{
+				Code: `rs.mock('./sum', () => Promise.race([]))`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "asyncMockFactory",
+					Line:      1,
+					Column:    18,
+					EndLine:   1,
+					EndColumn: 40,
+				}},
+			},
+			{
+				Code: `rs.mock('./sum', () => Promise.any([]))`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "asyncMockFactory",
+					Line:      1,
+					Column:    18,
+					EndLine:   1,
+					EndColumn: 39,
+				}},
+			},
+			{
+				Code: `rs.mock('./sum', () => new Promise((resolve) => resolve({ sum: 0 })))`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "asyncMockFactory",
+					Line:      1,
+					Column:    18,
+					EndLine:   1,
+					EndColumn: 69,
+				}},
+			},
+			{
+				Code: `rs.mock('./sum', () => import('./sum'))`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "asyncMockFactory",
+					Line:      1,
+					Column:    18,
+					EndLine:   1,
+					EndColumn: 39,
+				}},
+			},
+			{
+				Code: `rs.mock('./sum', () => rs.importActual('./sum'))`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "asyncMockFactory",
+					Line:      1,
+					Column:    18,
+					EndLine:   1,
+					EndColumn: 48,
+				}},
+			},
+			{
+				Code: `rs.mock('./sum', () => rs.importMock('./sum'))`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "asyncMockFactory",
+					Line:      1,
+					Column:    18,
+					EndLine:   1,
+					EndColumn: 46,
+				}},
+			},
+
+			// Every branch of the body hands back a promise.
+			{
+				Code: `
+rs.mock('./sum', function () {
+  if (flag) {
+    return Promise.resolve({ sum: 0 });
+  }
+  return import('./sum');
+});
+`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "asyncMockFactory",
+					Line:      2,
+					Column:    18,
+					EndLine:   7,
+					EndColumn: 2,
+				}},
+			},
+
+			// ---- a declaration in this file settles the identifier ----
+			{
+				Code: `
+const factory = async () => ({ sum: () => 0 });
+rs.mock('./sum', factory);
+`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "asyncMockFactory",
+					Line:      3,
+					Column:    18,
+					EndLine:   3,
+					EndColumn: 25,
+				}},
+			},
+			{
+				Code: `
+async function factory() {
+  return { sum: () => 0 };
+}
+rs.mock('./sum', factory);
+`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "asyncMockFactory",
+					Line:      5,
+					Column:    18,
+					EndLine:   5,
+					EndColumn: 25,
+				}},
+			},
+			{
+				Code: `
+const factory = () => Promise.resolve({ sum: () => 0 });
+rs.mock('./sum', factory);
+`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "asyncMockFactory",
+					Line:      3,
+					Column:    18,
+					EndLine:   3,
+					EndColumn: 25,
+				}},
+			},
+		},
+	)
+}

--- a/internal/plugins/rstest/rules/prefer_import_in_mock/prefer_import_in_mock.go
+++ b/internal/plugins/rstest/rules/prefer_import_in_mock/prefer_import_in_mock.go
@@ -105,7 +105,7 @@ var PreferImportInMockRule = rule.Rule{
 // naming the module inside it. Both are nil when the call is anything else.
 func mockPathArgument(node *ast.Node) (*ast.Node, *ast.Node) {
 	utility := rstestUtils.ParseRstestPluginManagedCall(node)
-	if utility == nil || !mockMethods[utility.Member] || !isTransformablePosition(node) {
+	if utility == nil || !mockMethods[utility.Member] || !rstestUtils.IsTransformablePosition(node) {
 		return nil, nil
 	}
 	call := node.AsCallExpression()
@@ -150,27 +150,4 @@ func commentBetween(ctx rule.RuleContext, outer core.TextRange, inner core.TextR
 	comments := ctx.Comments.All()
 	return utils.HasCommentInSpan(comments, outer.Pos(), inner.Pos()) ||
 		utils.HasCommentInSpan(comments, inner.End(), outer.End())
-}
-
-// isTransformablePosition reports whether the call stands on its own as a
-// statement, which is the only place the mock transform can lift it out of.
-// Rstest moves the call above the module's imports, so a call whose value is
-// consumed — an argument to another call, a variable initializer, an operand
-// of a comma expression, an awaited expression — is either left untransformed,
-// and throws, or is lifted out of an expression that no longer parses without
-// it. The wrappers the transform cannot see do not change the position.
-func isTransformablePosition(node *ast.Node) bool {
-	// Climb while the parent is only a wrapper around what we came from, so
-	// `(rs.mock('./dep'));` is judged by the statement, not by the parentheses.
-	outermost := node
-	for {
-		parent := outermost.Parent
-		if parent == nil {
-			return false
-		}
-		if utils.SkipAssertionsAndParens(parent) != outermost {
-			return parent.Kind == ast.KindExpressionStatement
-		}
-		outermost = parent
-	}
 }

--- a/internal/plugins/rstest/utils/transformable_position.go
+++ b/internal/plugins/rstest/utils/transformable_position.go
@@ -1,0 +1,29 @@
+package utils
+
+import (
+	"github.com/microsoft/TypeScript/tsc/shim/ast"
+	internalUtils "github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// IsTransformablePosition reports whether the call stands on its own as a
+// statement, which is the only place the mock transform can lift it out of.
+// Rstest moves the call above the module's imports, so a call whose value is
+// consumed — an argument to another call, a variable initializer, an operand
+// of a comma expression, an awaited expression — is either left untransformed,
+// and throws, or is lifted out of an expression that no longer parses without
+// it. The wrappers the transform cannot see do not change the position.
+func IsTransformablePosition(node *ast.Node) bool {
+	// Climb while the parent is only a wrapper around what we came from, so
+	// `(rs.mock('./dep'));` is judged by the statement, not by the parentheses.
+	outermost := node
+	for {
+		parent := outermost.Parent
+		if parent == nil {
+			return false
+		}
+		if internalUtils.SkipAssertionsAndParens(parent) != outermost {
+			return parent.Kind == ast.KindExpressionStatement
+		}
+		outermost = parent
+	}
+}

--- a/packages/rslint-test-tools/rstack.config.mts
+++ b/packages/rslint-test-tools/rstack.config.mts
@@ -637,6 +637,7 @@ define.test({
     './tests/rstest/rules/hoisted-apis-on-top.test.ts',
     './tests/rstest/rules/max-expects.test.ts',
     './tests/rstest/rules/no-alias-methods.test.ts',
+    './tests/rstest/rules/no-async-mock-factory.test.ts',
     './tests/rstest/rules/no-commented-out-tests.test.ts',
     './tests/rstest/rules/no-conditional-expect.test.ts',
     './tests/rstest/rules/no-conditional-in-test.test.ts',

--- a/packages/rslint-test-tools/tests/cli/js-config/presets.test.ts
+++ b/packages/rslint-test-tools/tests/cli/js-config/presets.test.ts
@@ -154,6 +154,7 @@ describe('defineConfig and config presets', () => {
     expect(rec.plugins).toContain('rstest');
     expect(rec.rules).toEqual({
       'rstest/expect-expect': 'warn',
+      'rstest/no-async-mock-factory': 'error',
       'rstest/no-commented-out-tests': 'warn',
       'rstest/no-conditional-expect': 'error',
       'rstest/no-disabled-tests': 'warn',

--- a/packages/rslint-test-tools/tests/rstest/rules/no-async-mock-factory.test.ts
+++ b/packages/rslint-test-tools/tests/rstest/rules/no-async-mock-factory.test.ts
@@ -1,0 +1,85 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-async-mock-factory', {} as never, {
+  valid: [
+    { code: `rs.mock('./sum')` },
+    { code: `rs.mock('./sum', { spy: true })` },
+    { code: `rs.mock('./sum', () => ({ sum: () => 0 }))` },
+    { code: `rs.mock('./sum', function* () { yield 1; })` },
+    { code: `rs.mock('./sum', async function* () { yield 1; })` },
+    { code: `rs.mock('./sum', () => ({ then() {} }))` },
+    { code: `rs['mock']('./sum', async () => ({ sum: 0 }))` },
+    { code: `rs?.mock('./sum', async () => ({ sum: 0 }))` },
+    { code: `rs.mock?.('./sum', async () => ({ sum: 0 }))` },
+    { code: `const mocked = rs.mock('./sum', async () => ({ sum: 0 }))` },
+    { code: `rs.mock('./sum', async () => ({ sum: 0 }), extra)` },
+    { code: `rs.mock('./sum', ...factories)` },
+    {
+      code: `import { rs as mocker } from '@rstest/core';\nmocker.mock('./sum', async () => ({ sum: 0 }))`,
+    },
+  ],
+  invalid: [
+    {
+      code: `rs.mock('./sum', async () => ({ sum: () => 0 }))`,
+      errors: [
+        {
+          messageId: 'asyncMockFactory',
+          line: 1,
+          column: 18,
+          endLine: 1,
+          endColumn: 48,
+        },
+      ],
+    },
+    {
+      code: `rstest.doMock('./sum', () => Promise.resolve({ sum: 0 }))`,
+      errors: [
+        {
+          messageId: 'asyncMockFactory',
+          line: 1,
+          column: 24,
+          endLine: 1,
+          endColumn: 57,
+        },
+      ],
+    },
+    {
+      code: `rs.mockRequire('./sum', () => import('./sum'))`,
+      errors: [
+        {
+          messageId: 'asyncMockFactory',
+          line: 1,
+          column: 25,
+          endLine: 1,
+          endColumn: 46,
+        },
+      ],
+    },
+    {
+      code: `rs.doMockRequire('./sum', async function () { return { sum: 0 }; })`,
+      errors: [
+        {
+          messageId: 'asyncMockFactory',
+          line: 1,
+          column: 27,
+          endLine: 1,
+          endColumn: 67,
+        },
+      ],
+    },
+    {
+      code: `rs.mock<{ sum: number }>('./sum', async () => ({ sum: 0 }))`,
+      errors: [
+        {
+          messageId: 'asyncMockFactory',
+          line: 1,
+          column: 35,
+          endLine: 1,
+          endColumn: 59,
+        },
+      ],
+    },
+  ],
+});

--- a/packages/rslint/src/config/presets/rstest.ts
+++ b/packages/rslint/src/config/presets/rstest.ts
@@ -4,6 +4,7 @@ const recommended: RslintConfigEntry = {
   plugins: ['rstest'],
   rules: {
     'rstest/expect-expect': 'warn',
+    'rstest/no-async-mock-factory': 'error',
     'rstest/no-commented-out-tests': 'warn',
     'rstest/no-conditional-expect': 'error',
     'rstest/no-disabled-tests': 'warn',


### PR DESCRIPTION
## Summary

Add `rstest/no-async-mock-factory`, which reports a mock factory for `rs.mock`, `rs.doMock`, `rs.mockRequire` or `rs.doMockRequire` that can only return a promise — Rstest calls the factory while the module graph is being built and throws `[Rstest] An async mock factory is not supported.` The type system does not catch it and the throw surfaces only once the mocked module is loaded, so the rule enters `recommended` at `error`.

## Related Links

Related #935

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
