### PR TITLE
fix(utils): align glob code units and capture replacements

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -149,6 +149,15 @@ bundled standard libraries through the upstream `lib` build task.
 See [the compiler dependency guide](./CONTRIBUTING.md#typescript-compiler-dependency)
 for the pinned revision, migration rationale, and update workflow.
 
+Rule-facing string and matching helpers belong under `internal/utils/`:
+`ecmascript` owns JavaScript string values and UTF-16 conversion,
+`ecmascript/regexp` owns RegExp rewriting, capture numbering and replacement
+substitutions, and `minimatch3` owns the pinned glob grammar and path matching.
+The glob matcher uses code-unit input for regexp2; rule callers do not select a
+character encoding or translate backend capture numbers. These packages do not
+decide which files to lint or discover ignore files; those policies belong to
+configuration and target selection. Match timeouts remain at the engine boundary.
+
 ## 4. Parsing Pipeline
 
 The parsing and linting pipeline uses ts-go's native AST data model directly.

--- a/internal/plugins/import/rules/no_restricted_paths/no_restricted_paths_extras_test.go
+++ b/internal/plugins/import/rules/no_restricted_paths/no_restricted_paths_extras_test.go
@@ -27,6 +27,15 @@ func TestNoRestrictedPathsExtras(t *testing.T) {
 		t,
 		&no_restricted_paths.NoRestrictedPathsRule,
 		[]rule_tester.ValidTestCase{
+			// One wildcard does not select a filename containing two code units.
+			{
+				Code:     `import b from "../server/b"`,
+				FileName: "restricted-paths/client/😀.ts",
+				Options: zones(map[string]interface{}{
+					"target": "./restricted-paths/client/?.ts",
+					"from":   "./restricted-paths/server",
+				}),
+			},
 			// ---- Options: no options, empty options array and empty option object all disable the rule ----
 			{Code: `import b from "../server/b"`, FileName: "restricted-paths/client/a.ts"},
 			{Code: `import b from "../server/b"`, FileName: "restricted-paths/client/a.ts", Options: []interface{}{}},
@@ -172,6 +181,15 @@ func TestNoRestrictedPathsExtras(t *testing.T) {
 			// inspects a module specifier string literal and the linted file's path.
 		},
 		[]rule_tester.InvalidTestCase{
+			{
+				Code:     `import b from "../server/b"`,
+				FileName: "restricted-paths/client/😀.ts",
+				Options: zones(map[string]interface{}{
+					"target": "./restricted-paths/client/@(??).ts",
+					"from":   "./restricted-paths/server",
+				}),
+				Errors: []rule_tester.InvalidTestCaseError{unexpectedPath("../server/b", 1, 15)},
+			},
 			// ---- An extended glob list in a `target` selects the zone the way
 			// upstream's Minimatch does: `!(server)` names every directory but
 			// that one, so `client` is inside the zone ----

--- a/internal/plugins/import/rules/order/order_extras_branches_test.go
+++ b/internal/plugins/import/rules/order/order_extras_branches_test.go
@@ -557,6 +557,10 @@ func TestOrderMinimatchCompatibility(t *testing.T) {
 		&order.OrderRule,
 		[]rule_tester.ValidTestCase{
 			{
+				Code:    "import react from 'react';\nimport emoji from 'pkg/😀';",
+				Options: minimatchPathGroupOptions("pkg/?", nil),
+			},
+			{
 				Code:    "import react from 'react';\nimport scope from 'scope';",
 				Options: minimatchPathGroupOptions("scope/package", map[string]any{}),
 			},
@@ -568,6 +572,13 @@ func TestOrderMinimatchCompatibility(t *testing.T) {
 			},
 		},
 		[]rule_tester.InvalidTestCase{
+			// A supplementary character occupies two UTF-16 wildcard positions.
+			{
+				Code:    "import react from 'react';\nimport emoji from 'pkg/😀';",
+				Options: minimatchPathGroupOptions("pkg/@(??)", nil),
+				Output:  []string{"import emoji from 'pkg/😀';\nimport react from 'react';\n"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "order", Line: 2, Column: 1}},
+			},
 			// With patternOptions omitted, import/order disables leading comments
 			// and treats a leading # as an ordinary package-import pattern.
 			{

--- a/internal/utils/ecmascript/code_units.go
+++ b/internal/utils/ecmascript/code_units.go
@@ -25,6 +25,30 @@ func StringCodeUnits(s string) []uint16 {
 	return units
 }
 
+// StringCodeUnitRunes reads the same units as StringCodeUnits into rune slots,
+// for matching engines whose input is []rune. Supplementary characters occupy
+// two slots. These are UTF-16 units, not Unicode code points: converting the
+// result with string would lose surrogates; use StringFromCodeUnits instead.
+func StringCodeUnitRunes(s string) []rune {
+	units := make([]rune, StringCodeUnitCount(s))
+	for i, n := 0, 0; i < len(s); n++ {
+		if s[i] < utf8.RuneSelf {
+			units[n] = rune(s[i])
+			i++
+			continue
+		}
+		r, size := decodeStringRune(s[i:])
+		if r > 0xFFFF {
+			units[n], units[n+1] = utf16.EncodeRune(r)
+			n++
+		} else {
+			units[n] = r
+		}
+		i += size
+	}
+	return units
+}
+
 // DecodeStringRune reads the first code point from a JavaScript string value.
 // It differs from utf8.DecodeRuneInString only for the WTF-8 spelling the
 // compiler uses to preserve an unpaired UTF-16 surrogate.
@@ -91,6 +115,11 @@ func CombineSurrogatePairs(s string) string {
 func StringCodeUnitCount(s string) int {
 	count := 0
 	for i := 0; i < len(s); {
+		if s[i] < utf8.RuneSelf {
+			count++
+			i++
+			continue
+		}
 		r, size := decodeStringRune(s[i:])
 		if r > 0xFFFF {
 			count += 2

--- a/internal/utils/ecmascript/code_units_test.go
+++ b/internal/utils/ecmascript/code_units_test.go
@@ -45,6 +45,13 @@ func TestStringCodeUnits(t *testing.T) {
 			if got := StringCodeUnitCount(tt.value); got != len(tt.want) {
 				t.Errorf("StringCodeUnitCount(%q) = %d, want %d", tt.value, got, len(tt.want))
 			}
+			wantRunes := make([]rune, len(tt.want))
+			for i, unit := range tt.want {
+				wantRunes[i] = rune(unit)
+			}
+			if got := StringCodeUnitRunes(tt.value); !slices.Equal(got, wantRunes) {
+				t.Errorf("StringCodeUnitRunes(%q) = %v, want %v", tt.value, got, wantRunes)
+			}
 		})
 	}
 }

--- a/internal/utils/ecmascript/regexp/capture.go
+++ b/internal/utils/ecmascript/regexp/capture.go
@@ -1,0 +1,65 @@
+package regexp
+
+import "fmt"
+
+// captureLayout maps JavaScript's left-to-right capture numbers to regexp2's
+// unnamed-first numbering. It is immutable and shared by matching and string
+// substitution. Patterns with no named groups allocate no mapping.
+type captureLayout struct {
+	count   int
+	named   bool
+	numbers []int
+	names   map[string]int
+}
+
+func parseCaptureLayout(source string) (captureLayout, error) {
+	count, named := countGroups(source)
+	layout := captureLayout{count: count, named: named}
+	if !named {
+		return layout, nil
+	}
+	layout.names = make(map[string]int)
+	index, firstNamed := 0, count+1
+	var err error
+	scanGroups(source, func(name string) {
+		index++
+		if name != "" {
+			firstNamed = min(firstNamed, index)
+			if _, exists := layout.names[name]; exists {
+				// regexp2 merges duplicate names into one capture. JavaScript
+				// permits some duplicates across alternatives but still gives
+				// them separate numeric slots, which that engine cannot expose.
+				err = fmt.Errorf("%w: duplicate capture name %q", ErrUnsupportedSyntax, name)
+			}
+			layout.names[name] = index
+		}
+	})
+	unnamed := count - len(layout.names)
+	if err != nil || firstNamed > unnamed {
+		// All named groups already follow the unnamed groups (including a
+		// pattern whose captures are all named), so the numbering is identical.
+		return layout, err
+	}
+	layout.numbers = make([]int, count+1)
+	for _, index := range layout.names {
+		layout.numbers[index] = -1
+	}
+	nextUnnamed := 0
+	for index := 1; index <= count; index++ {
+		if layout.numbers[index] == -1 {
+			unnamed++
+			layout.numbers[index] = unnamed
+		} else {
+			nextUnnamed++
+			layout.numbers[index] = nextUnnamed
+		}
+	}
+	return layout, nil
+}
+
+func (layout captureLayout) number(index int) int {
+	if layout.numbers == nil {
+		return index
+	}
+	return layout.numbers[index]
+}

--- a/internal/utils/ecmascript/regexp/escape.go
+++ b/internal/utils/ecmascript/regexp/escape.go
@@ -276,6 +276,12 @@ func isDecimalDigit(source string, i int) bool {
 // countGroups reads how many capturing groups a pattern opens and whether any
 // of them is named, which is what a `\1` and a `\k` are read against.
 func countGroups(source string) (int, bool) {
+	return scanGroups(source, nil)
+}
+
+// scanGroups also lets compilation collect capture order using the same walk
+// that distinguishes backreferences from Annex B numeric escapes.
+func scanGroups(source string, visit func(name string)) (int, bool) {
 	count, named := 0, false
 	inClass := false
 	for i := 0; i < len(source); {
@@ -296,9 +302,19 @@ func countGroups(source string) (int, bool) {
 			switch {
 			case !strings.HasPrefix(rest, "?"):
 				count++
+				if visit != nil {
+					visit("")
+				}
 			case strings.HasPrefix(rest, "?<") && !strings.HasPrefix(rest, "?<=") && !strings.HasPrefix(rest, "?<!"):
 				count++
 				named = true
+				if visit != nil {
+					name := ""
+					if end := strings.IndexByte(rest, '>'); end >= 0 {
+						name = rest[2:end]
+					}
+					visit(name)
+				}
 			}
 		}
 		_, size := utf8.DecodeRuneInString(source[i:])

--- a/internal/utils/ecmascript/regexp/regexp.go
+++ b/internal/utils/ecmascript/regexp/regexp.go
@@ -25,9 +25,14 @@
 // match may run: a backtracking engine on a pattern a user wrote is a way to
 // hang the linter, and a match that overruns is reported as no match.
 //
-// Three things are deliberately not covered:
+// The following are deliberately not covered:
 //
 //   - The `v` flag's set syntax, which Compile refuses outright.
+//   - Duplicate named groups across alternatives, which Compile refuses:
+//     regexp2 merges their capture slots instead of numbering them separately.
+//   - Non-Unicode matching of supplementary characters and lone surrogates.
+//     The RegExp matcher still reads Go code points; Test and ReplaceFirst
+//     share that behavior. Glob matching adapts its own input to UTF-16 units.
 //   - Comparing a backreference, or a `\p{…}` property escape, without regard
 //     to case. JavaScript compares a backreference by the same canonicalization
 //     it compares a literal by, and draws a property escape from Unicode's own
@@ -40,8 +45,7 @@
 //     carry `i` has none to make, and compares both exactly.
 //   - Exhaustive syntax validation under `u`. The `u` flag makes JavaScript
 //     reject constructs it otherwise tolerates — a bare `]` outside a class is
-//     the usual one — and those still compile here. Every pattern JavaScript
-//     accepts is read correctly; some it rejects are read rather than refused.
+//     the usual one — and those still compile here instead of being refused.
 package regexp
 
 import (
@@ -63,14 +67,15 @@ const MatchTimeout = time.Second
 // ErrUnsupportedFlag is returned for a flag this package does not implement.
 var ErrUnsupportedFlag = errors.New("unsupported regexp flag")
 
-// ErrUnsupportedSyntax is returned for syntax JavaScript itself rejects.
+// ErrUnsupportedSyntax is returned for invalid or unsupported JavaScript syntax.
 var ErrUnsupportedSyntax = errors.New("unsupported regexp syntax")
 
 // RegExp is a compiled JavaScript regexp.
 type RegExp struct {
-	source string
-	flags  string
-	re     *regexp2.Regexp
+	source   string
+	flags    string
+	re       *regexp2.Regexp
+	captures captureLayout
 	// exact is false when the pattern fell back to regexp2's own
 	// case-insensitivity, which is close to JavaScript's but not identical.
 	exact bool
@@ -124,12 +129,16 @@ func Compile(source string, flags string) (*RegExp, error) {
 		return nil, err
 	}
 
+	captures, err := parseCaptureLayout(source)
+	if err != nil {
+		return nil, err
+	}
 	rewritten, exact, err := rewrite(source, rewriteOptions{
 		multiline:  set.multiline,
 		dotAll:     set.dotAll,
 		ignoreCase: set.ignoreCase,
 		unicode:    set.unicode,
-	})
+	}, captures)
 	if err != nil {
 		return nil, err
 	}
@@ -159,8 +168,15 @@ func Compile(source string, flags string) (*RegExp, error) {
 		return nil, errors.New(strings.ReplaceAll(err.Error(), rewritten, source))
 	}
 	re.MatchTimeout = MatchTimeout
+	for name, index := range captures.names {
+		if re.GroupNumberFromName(name) != captures.number(index) {
+			// Reject backend-only capture syntax (numeric slot names or
+			// balancing groups) that would invalidate the lexical mapping.
+			return nil, fmt.Errorf("%w: capture name %q", ErrUnsupportedSyntax, name)
+		}
+	}
 
-	return &RegExp{source: source, flags: flags, re: re, exact: exact}, nil
+	return &RegExp{source: source, flags: flags, re: re, exact: exact, captures: captures}, nil
 }
 
 // MustCompile is Compile for a pattern written in this repository rather than
@@ -217,9 +233,9 @@ func (r *RegExp) Flags() string { return r.flags }
 // String renders the regexp the way JavaScript writes a regexp literal.
 func (r *RegExp) String() string { return "/" + r.source + "/" + r.flags }
 
-// Unwrap returns the compiled regexp2 pattern, for a caller that needs
-// capture groups or replacement. The pattern it holds is the rewritten one, so
-// its own String does not match Source.
+// Unwrap returns the compiled regexp2 pattern. Both its pattern and capture
+// numbering belong to the backend, not JavaScript. Use ReplaceFirst for string
+// substitution; it preserves JavaScript capture numbers and dollar syntax.
 func (r *RegExp) Unwrap() *regexp2.Regexp {
 	if r == nil {
 		return nil

--- a/internal/utils/ecmascript/regexp/regexp_test.go
+++ b/internal/utils/ecmascript/regexp/regexp_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -113,6 +114,16 @@ func TestTest(t *testing.T) {
 		{name: "i named group", source: "^(?<n>a)$", flags: "i", subject: "A", want: true},
 		{name: "i named backreference", source: `^(?<w>a)\k<w>$`, flags: "i", subject: "aA", want: true},
 		{name: "i numbered backreference", source: `^(a)\1$`, flags: "i", subject: "Aa", want: true},
+		{name: "mixed numeric first capture", source: `^(?<dir>src)/(.*)/\1$`, subject: "src/cli/src", want: true},
+		{name: "mixed numeric second capture", source: `^(?<dir>src)/(.*)/\2$`, subject: "src/cli/cli", want: true},
+		{name: "mixed numeric wrong order", source: `^(?<dir>src)/(.*)/\1$`, subject: "src/cli/cli"},
+		{name: "nested mixed captures", source: `^(?<a>a(b))(?<c>c)(d)\1\2\3\4$`, subject: "abcdabbcd", want: true}, // cspell:ignore abcdabbcd
+		{name: "mixed named backreference", source: `^(?<a>a)(b)\k<a>\2$`, subject: "abab", want: true},
+		{name: "mixed forward reference", source: `^\1(?<a>a)(b)$`, subject: "ab", want: true},
+		{name: "mixed optional reference", source: `^(?<a>a)?(b)\1$`, subject: "b", want: true},
+		{name: "mixed class numeric escape", source: `^(?<a>a)(b)[\1]$`, subject: "ab\x01", want: true},
+		{name: "mixed octal escape", source: `^(?<a>a)(b)\12$`, subject: "ab\n", want: true},
+		{name: "mixed lookaround capture", source: `^(?=(?<a>a))(a)\1\2$`, subject: "aaa", want: true},
 
 		// ---- `u` switches `i` to simple case folding, which has no rule
 		// about ASCII, so every pair the plain `i` cases above keep apart
@@ -314,6 +325,9 @@ func TestCompileRejects(t *testing.T) {
 		{name: "range running backwards", source: "[b-a]", is: ErrUnsupportedSyntax},
 		{name: "class that no bracket closes", source: "[abc", is: ErrUnsupportedSyntax},
 		{name: "backslash at the end", source: `a\`, is: ErrUnsupportedSyntax},
+		{name: "duplicate capture names", source: `(?<a>x)|(?<a>y)`, is: ErrUnsupportedSyntax},
+		{name: "backend numeric capture slot", source: `(?<3>a)(b)`, is: ErrUnsupportedSyntax},
+		{name: "backend balancing capture", source: `(?<a>a)(?<b-a>b)`, is: ErrUnsupportedSyntax},
 	}
 
 	for _, test := range tests {
@@ -380,5 +394,148 @@ func TestNilIsSafe(t *testing.T) {
 	}
 	if re.Unwrap() != nil {
 		t.Error("a nil RegExp unwrapped to something")
+	}
+	for _, re := range []*RegExp{nil, {}} {
+		if got, err := re.ReplaceFirst("input", "replacement"); got != "input" || err != nil {
+			t.Errorf("nil/zero RegExp.ReplaceFirst = %q, %v", got, err)
+		}
+	}
+}
+
+func TestReplaceFirst(t *testing.T) {
+	// Expectations are from JavaScript String#replace with a non-global RegExp.
+	for _, test := range []struct{ source, input, replacement, want string }{
+		{`^src/(.+)$`, "src/bin/test.js", "$1", "bin/test.js"},
+		{`a`, "aaa", "b", "baa"},
+		{`z`, "abc", "x", "abc"},
+		{`b`, "abc", "$$:$&:$`:$'", "a$:b:a:cc"},
+		{`(a)(b)?`, "a", "$2-$1-$3-$0-$_-$+-${1}", "-a-$3-$0-$_-$+-${1}"},
+		{`(a)`, "a", "$12:$01:$00:$99", "a2:a:$00:$99"},
+		{`(?<name>a)`, "a", "$<name>:$<missing>:$<name", "a::$<name"},
+		{`(?<name>a)(b)`, "ab", "$1:$2:$<name>", "a:b:a"},
+		{`(?<dir>src)/(.*)`, "src/cli.js", "$1/$2", "src/cli.js"},
+		{`(a)(?<name>b)(c)`, "abc", "$1:$2:$3:$<name>", "a:b:c:b"},
+		{`(?<a>a(b))(?<c>c)(d)`, "abcd", "$1:$2:$3:$4", "ab:b:c:d"},
+		{`(?<a>a)?(b)`, "b", "$1:$2:$<a>", ":b:"},
+		{`(?<a>a)|(b)`, "b", "$1:$2:$<a>", ":b:"},
+		{`(?<a>a)`, "a", "$<0>:$<1>:$<>:$<a>", ":::a"},
+		{`(?<__proto__>a)(b)`, "ab", "$<__proto__>:$1:$2", "a:a:b"},
+		{`(a)`, "a", "$<name>", "$<name>"},
+		{`b`, "😀b中文", "$&$", "😀b$中文"},
+		{`(中文)`, "😀中文尾", "$1:$`:$'", "😀中文:😀:尾尾"},
+		{`^`, "abc", "$", "$abc"},
+		{`$`, "中文", "$`", "中文中文"},
+		{`(?<=src/)(.+)`, "src/cli.js", "dist/$1", "src/dist/cli.js"},
+		{`(?<=(?<dir>src)/)(.*)`, "src/cli.js", "$1:$2", "src/src:cli.js"},
+		{`(?<a>a)(b)\1`, "aba", "$1:$2", "a:b"},
+		{``, "", "$&:$1", ":$1"},
+	} {
+		t.Run(test.source+"/"+test.replacement, func(t *testing.T) {
+			re := MustCompile(test.source, "")
+			got, err := re.ReplaceFirst(test.input, test.replacement)
+			if err != nil || got != test.want {
+				t.Errorf("ReplaceFirst(%q, %q) = %q, %v; want %q", test.input, test.replacement, got, err, test.want)
+			}
+		})
+	}
+	// The method always replaces once, even if the compiled pattern accepts g.
+	if got, err := MustCompile("a", "g").ReplaceFirst("aaa", "b"); err != nil || got != "baa" {
+		t.Errorf("global ReplaceFirst = %q, %v", got, err)
+	}
+	// Ten or more captures disambiguate $12 and retain $100's final zero.
+	if got, err := MustCompile(strings.Repeat("(a)", 12), "").ReplaceFirst(strings.Repeat("a", 12), "$12:$100"); err != nil || got != "a:a0" {
+		t.Errorf("two-digit ReplaceFirst = %q, %v", got, err)
+	}
+}
+
+func TestReplaceFirstTimeout(t *testing.T) {
+	re := MustCompile(`^(a+)+b$`, "")
+	re.Unwrap().MatchTimeout = time.Nanosecond
+	input := strings.Repeat("a", 200)
+	if got, err := re.ReplaceFirst(input, "changed"); err == nil || got != input {
+		t.Errorf("timed out ReplaceFirst = %q, %v; want unchanged input and error", got, err)
+	}
+}
+
+func TestReplaceFirstConcurrent(t *testing.T) {
+	re := MustCompile(`(?<dir>src)/(.*)`, "")
+	var workers sync.WaitGroup
+	for range 16 {
+		workers.Go(func() {
+			for range 50 {
+				got, err := re.ReplaceFirst("src/cli.js", "$2:$<dir>:$1")
+				if err != nil || got != "cli.js:src:src" || !re.Test("src/cli.js") {
+					t.Errorf("shared regexp returned %q, %v", got, err)
+				}
+			}
+		})
+	}
+	workers.Wait()
+}
+
+func FuzzCompileAndReplace(f *testing.F) {
+	for _, source := range []string{`(?<a>a)(b)\1`, `(?<3>a)(b)`, `(?<0>a)`, `(?<a>a)(?<b-a>b)`, `(?<x>a)|(?<x>b)`, `\((a)[()]`, `(?<=a)(b)`} {
+		f.Add(source, "ab", "$1:$2:$<a>:$<0>:$99")
+	}
+	f.Fuzz(func(t *testing.T, source, input, replacement string) {
+		if len(source) > 128 || len(input) > 128 || len(replacement) > 128 {
+			return
+		}
+		re, err := Compile(source, "")
+		if err != nil {
+			return
+		}
+		re.Unwrap().MatchTimeout = time.Millisecond
+		if got, err := re.ReplaceFirst(input, replacement); err != nil && got != input {
+			t.Fatalf("failed replacement changed input: %q -> %q", input, got)
+		}
+	})
+}
+
+func BenchmarkReplaceFirst(b *testing.B) {
+	for _, test := range []struct{ name, source, replacement string }{
+		{"plain", `^src/(.*)\.ts$`, "dist/$1.js"},
+		{"mixed", `(?<dir>src)/(.*)`, "$1/$2"},
+		{"named", `(?<dir>src)/(?<file>.*)`, "$<dir>/$<file>"},
+		{"no_match", `^lib/(.*)`, "dist/$1"},
+	} {
+		b.Run(test.name, func(b *testing.B) {
+			re := MustCompile(test.source, "")
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				if _, err := re.ReplaceFirst("src/cli.ts", test.replacement); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkRegExp(b *testing.B) {
+	for _, test := range []struct{ name, source, input string }{
+		{"plain", `^src/(.*)\.ts$`, "src/cli.ts"},
+		{"named", `^(?<dir>src)/(?<file>.*)\.ts$`, "src/cli.ts"},
+		{"mixed", `^(?<dir>src)/(.*)\.ts$`, "src/cli.ts"},
+		{"backreference", `^(?<dir>src)/(.*)/\1$`, "src/cli/src"},
+	} {
+		b.Run(test.name, func(b *testing.B) {
+			b.Run("compile", func(b *testing.B) {
+				b.ReportAllocs()
+				for b.Loop() {
+					if _, err := Compile(test.source, ""); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+			b.Run("test", func(b *testing.B) {
+				re := MustCompile(test.source, "")
+				b.ReportAllocs()
+				b.ResetTimer()
+				for b.Loop() {
+					re.Test(test.input)
+				}
+			})
+		})
 	}
 }

--- a/internal/utils/ecmascript/regexp/replace.go
+++ b/internal/utils/ecmascript/regexp/replace.go
@@ -1,0 +1,88 @@
+package regexp
+
+import "strings"
+
+// ReplaceFirst replaces the first match using JavaScript replacement-string
+// substitutions: $$, $&, $`, $', $1 through $99, and $<name>. Numeric captures
+// follow their opening parentheses, including named groups. An unmatched
+// capture substitutes the empty string; an unknown numeric capture stays
+// literal. The g flag does not request additional replacements from this method.
+// Matching uses the same engine semantics as TestOrError. A timeout returns the
+// unchanged input and an error, so callers can skip a transformation safely.
+func (r *RegExp) ReplaceFirst(input, replacement string) (string, error) {
+	if r == nil || r.re == nil {
+		return input, nil
+	}
+	runes := []rune(input)
+	match, err := r.re.FindRunesMatch(runes)
+	if err != nil || match == nil {
+		return input, err
+	}
+	start, end := match.Index, match.Index+match.Length
+	if len(runes) != len(input) {
+		start = runeByteIndex(input, match.Index)
+		end = start + runeByteIndex(input[start:], match.Length)
+	}
+	prefix, suffix := input[:start], input[end:]
+	var result strings.Builder
+	result.Grow(len(input) + len(replacement))
+	result.WriteString(prefix)
+	for index := 0; index < len(replacement); index++ {
+		if replacement[index] != '$' || index+1 == len(replacement) {
+			result.WriteByte(replacement[index])
+			continue
+		}
+		next := replacement[index+1]
+		switch next {
+		case '$':
+			result.WriteByte('$')
+		case '&':
+			result.WriteString(input[start:end])
+		case '`':
+			result.WriteString(prefix)
+		case '\'':
+			result.WriteString(suffix)
+		case '<':
+			end := strings.IndexByte(replacement[index+2:], '>')
+			if !r.captures.named || end < 0 {
+				result.WriteByte('$')
+				continue
+			}
+			if number, ok := r.captures.names[replacement[index+2:index+2+end]]; ok {
+				result.WriteString(match.GroupByNumber(r.captures.number(number)).String())
+			}
+			index += end + 1
+		default:
+			if next < '0' || next > '9' {
+				result.WriteByte('$')
+				continue
+			}
+			number := int(next - '0')
+			if index+2 < len(replacement) && replacement[index+2] >= '0' && replacement[index+2] <= '9' {
+				two := number*10 + int(replacement[index+2]-'0')
+				if two > 0 && two <= r.captures.count {
+					number = two
+					index++
+				}
+			}
+			if number == 0 || number > r.captures.count {
+				result.WriteByte('$')
+				continue
+			}
+			result.WriteString(match.GroupByNumber(r.captures.number(number)).String())
+		}
+		index++
+	}
+	result.WriteString(suffix)
+	return result.String(), nil
+}
+
+func runeByteIndex(s string, count int) int {
+	for index := range s {
+		if count == 0 {
+			return index
+		}
+		count--
+	}
+	return len(s)
+}

--- a/internal/utils/ecmascript/regexp/rewrite.go
+++ b/internal/utils/ecmascript/regexp/rewrite.go
@@ -2,6 +2,7 @@ package regexp
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"unicode/utf8"
 )
@@ -103,7 +104,7 @@ type openGroup struct {
 // canonicalization it compares a literal by, and it draws `\p{…}` from
 // Unicode's own tables; a widened pattern can name neither, so the caller falls
 // back to regexp2's own case-insensitivity there, which is close but not exact.
-func rewrite(source string, options rewriteOptions) (string, bool, error) {
+func rewrite(source string, options rewriteOptions, captures captureLayout) (string, bool, error) {
 	var out strings.Builder
 	out.Grow(len(source))
 
@@ -114,9 +115,8 @@ func rewrite(source string, options rewriteOptions) (string, bool, error) {
 	groups := []openGroup{}
 	// How a `\1` and a `\k` read is settled by the pattern as a whole, so the
 	// groups are counted before the walk rather than as it goes.
-	groupCount, named := countGroups(source)
 	context := func() escapeContext {
-		return escapeContext{unicode: current.unicode, groups: groupCount, named: named}
+		return escapeContext{unicode: current.unicode, groups: captures.count, named: captures.named}
 	}
 
 	for i := 0; i < len(source); {
@@ -159,7 +159,15 @@ func rewrite(source string, options rewriteOptions) (string, bool, error) {
 				if current.ignoreCase {
 					exact = false
 				}
-				out.WriteString(source[i:end])
+				if captures.numbers == nil {
+					out.WriteString(source[i:end])
+				} else {
+					index, _ := strconv.Atoi(source[i+size : end])
+					// Delimit the rewritten number so a following digit cannot
+					// become part of the reference. Escape decoding already
+					// distinguished this from an octal or identity escape.
+					out.WriteString(`\k<` + strconv.Itoa(captures.number(index)) + `>`)
+				}
 
 			case escapeAssertion:
 				// A pattern cannot repeat a position, and lowering the

--- a/internal/utils/minimatch3/minimatch.go
+++ b/internal/utils/minimatch3/minimatch.go
@@ -24,9 +24,8 @@
 // them stays cheap. minimatch instead caps how deep it recurses, and answers
 // that a path does not match once it hits the cap.
 //
-// A `?` and a character class each match one whole character, where minimatch
-// counts the UTF-16 units JavaScript strings are made of and so needs `??` for
-// a character outside the basic multilingual plane.
+// A `?` and a character class each match one UTF-16 code unit, as minimatch
+// does. A character outside the basic multilingual plane therefore needs `??`.
 //
 // A `/` separates the parts of a path and a `\` escapes the character after
 // it, on every platform. minimatch 3 rewrote a `\` to a `/` when it ran on
@@ -39,8 +38,10 @@
 package minimatch3
 
 import (
+	"fmt"
 	"strings"
 	"time"
+	"unicode/utf16"
 
 	"github.com/dlclark/regexp2"
 	"github.com/web-infra-dev/rslint/internal/utils/ecmascript"
@@ -273,7 +274,7 @@ func (m *Matcher) parsePart(pattern string) (patternPart, bool) {
 	// Skip the regexp for non-magical patterns, unescaping the pattern so it
 	// compares exactly against a name.
 	if !hasMagic {
-		return patternPart{literal: globUnescape(pattern)}, true
+		return patternPart{literal: ecmascript.CombineSurrogatePairs(globUnescape(pattern))}, true
 	}
 
 	re, err := regexp2.Compile("^"+endAnchors(source)+`\z`, regexp2.None)
@@ -387,7 +388,9 @@ func (m *Matcher) parseSource(pattern string, isSub bool) (string, bool, bool) {
 	// The index a rune is reported at is its offset in bytes, which is what the
 	// character class slicing below wants: every character the parser gives a
 	// meaning to is ASCII, so an offset always lands on a rune boundary.
-	for i, c := range pattern {
+	for i, size := 0, 0; i < len(pattern); i += size {
+		var c rune
+		c, size = ecmascript.DecodeStringRune(pattern[i:])
 		// skip over any that are escaped.
 		if escaping && strings.ContainsRune(reSpecials, c) {
 			re += `\` + string(c)
@@ -538,6 +541,18 @@ func (m *Matcher) parseSource(pattern string, isSub bool) (string, bool, bool) {
 			// a literal standing on its own is widened here.
 			// minimatch builds `new RegExp(re, "i")`, with no `u`, so the
 			// comparison is the one that never crosses into ASCII.
+			if c > 0xFFFF {
+				// minimatch compiles without `u`: even inside a class these
+				// are two separate units, and neither participates in case
+				// folding. Emit escapes before closing or widening the class.
+				high, low := utf16.EncodeRune(c)
+				re += codeUnitEscape(high) + codeUnitEscape(low)
+				continue
+			}
+			if c >= 0xD800 && c <= 0xDFFF {
+				re += codeUnitEscape(c)
+				continue
+			}
 			if m.options.NoCase && !inClass {
 				if class, widened := esregexp.CaseClass(c, false); widened {
 					re += class
@@ -635,6 +650,10 @@ func (m *Matcher) parseSource(pattern string, isSub bool) (string, bool, bool) {
 	return re, hasMagic, true
 }
 
+func codeUnitEscape(unit rune) string {
+	return fmt.Sprintf(`\u%04x`, unit)
+}
+
 // isValidJSClass asks the ECMAScript scanner whether class is a complete
 // character class. minimatch uses the RegExp constructor for this check; the
 // scanner accepts a literal instead, so delimiters and raw line terminators
@@ -644,7 +663,18 @@ func isValidJSClass(class string) bool {
 	literal.Grow(len(class) + 2)
 	literal.WriteByte('/')
 	backslashes := 0
-	for _, r := range class {
+	for i := 0; i < len(class); {
+		r, size := ecmascript.DecodeStringRune(class[i:])
+		i += size
+		if r >= 0xD800 && r <= 0xDFFF {
+			escaped := codeUnitEscape(r)
+			if backslashes%2 != 0 {
+				escaped = escaped[1:]
+			}
+			literal.WriteString(escaped)
+			backslashes = 0
+			continue
+		}
 		switch r {
 		case '\\':
 			literal.WriteRune(r)
@@ -933,9 +963,9 @@ func (m *Matcher) matchOneFrom(file []string, row []patternPart, fi int, pi int,
 func (p patternPart) match(name string) bool {
 	if p.re == nil {
 		// A part without wildcards has to match exactly.
-		return name == p.literal
+		return name == p.literal || (strings.IndexByte(name, 0xED) >= 0 && ecmascript.CombineSurrogatePairs(name) == p.literal)
 	}
-	matched, err := p.re.MatchString(name)
+	matched, err := p.re.MatchRunes(ecmascript.StringCodeUnitRunes(name))
 	return err == nil && matched
 }
 

--- a/internal/utils/minimatch3/minimatch_test.go
+++ b/internal/utils/minimatch3/minimatch_test.go
@@ -5,7 +5,10 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf16"
+	"unicode/utf8"
 
+	"github.com/web-infra-dev/rslint/internal/utils/ecmascript"
 	"github.com/web-infra-dev/rslint/internal/utils/minimatch3"
 )
 
@@ -205,6 +208,77 @@ func TestMatch(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMatchUTF16(t *testing.T) {
+	descending := ecmascript.StringFromCodeUnits([]uint16{'[', 0xDFFF, '-', 0xD800, ']'})
+	// JavaScript minimatch 3.1.5 compiles globs without the Unicode regexp flag.
+	for _, test := range []struct {
+		pattern, path string
+		want          bool
+	}{
+		{"?", "😀", false},
+		{"??", "😀", true},
+		{"@(??)", "😀", true},
+		{"src/@(??).js", "src/😀.js", true},
+		{"[😀]", "😀", false},
+		{"[😀][😀]", "😀", true},
+		{"[!a]", "😀", false},
+		{"[!a][!a]", "😀", true},
+		{"😀?", "😀a", true},
+		{"😀?", "😀😀", false},
+		{"[😀-😁]", "[😀-😁]", true},
+		{"[😀-😁]", "😀", false},
+		{"[😀", "[😀", true},
+		{`\😀?`, "😀a", true},
+		{"[中]", "中", true},
+		{"[中]?", "中😀", false},
+		{"{😀,中}?", "😀a", true},
+		{"**/@(😀|??).js", "src/😀.js", true},
+		{"!(??)", "😀", false},
+		{"[!]", "😀", false},
+		{"[!][!]", "😀", true},
+		{descending, descending, true},
+	} {
+		for _, noCase := range []bool{false, true} {
+			if got := minimatch3.New(test.pattern, minimatch3.Options{NoCase: noCase, NoNegate: true}).Match(test.path); got != test.want {
+				t.Errorf("Match(%q, %q, NoCase=%v) = %v, want %v", test.pattern, test.path, noCase, got, test.want)
+			}
+		}
+	}
+	// Compiler strings may spell a surrogate pair as adjacent WTF-8 pieces.
+	pair := string([]byte{0xED, 0xA0, 0xBD, 0xED, 0xB8, 0x80})
+	for _, pattern := range []string{"😀", pair, "[😀][😀]", "??"} {
+		for _, input := range []string{"😀", pair} {
+			if !minimatch3.New(pattern, minimatch3.Options{}).Match(input) {
+				t.Errorf("Match(%q, %q) lost a surrogate pair", pattern, input)
+			}
+		}
+	}
+	lone := ecmascript.StringFromCodeUnits([]uint16{0xD83D})
+	for _, pattern := range []string{"?", "[😀]", lone} {
+		if !minimatch3.New(pattern, minimatch3.Options{}).Match(lone) {
+			t.Errorf("Match(%q, lone surrogate) = false", pattern)
+		}
+	}
+}
+
+func FuzzMatchUTF16(f *testing.F) {
+	for _, input := range []string{"a", "中文", "😀", "a😀中", "𐐀", "a\n"} {
+		f.Add(input)
+	}
+	f.Fuzz(func(t *testing.T, input string) {
+		if len(input) == 0 || len(input) > 64 || !utf8.ValidString(input) || strings.Contains(input, "/") || input == "." || input == ".." || strings.ContainsRune("\n\r\u2028\u2029", []rune(input)[0]) {
+			return
+		}
+		count := len(utf16.Encode([]rune(input)))
+		for _, size := range []int{count, count + 1} {
+			pattern := "@(" + strings.Repeat("?", size) + ")"
+			if got := minimatch3.New(pattern, minimatch3.Options{Dot: true}).Match(input); got != (size == count) {
+				t.Errorf("Match(%q, %q) = %v", pattern, input, got)
+			}
+		}
+	})
 }
 
 // TestMatchOptions covers the options this port carries over from minimatch.
@@ -598,6 +672,25 @@ func TestBraceExpand(t *testing.T) {
 				if got[i] != test.want[i] {
 					t.Fatalf("BraceExpand(%q) = %q, want %q", test.pattern, got, test.want)
 				}
+			}
+		})
+	}
+}
+func BenchmarkMatch(b *testing.B) {
+	for _, test := range []struct{ name, pattern, path string }{
+		{"literal", "src/components/Button.tsx", "src/components/Button.tsx"},
+		{"ascii", "src/**/*.ts", "src/components/button.ts"},
+		{"long_ascii", "**/*.ts", "src/" + strings.Repeat("component", 24) + ".ts"},
+		{"bmp", "src/**/*.ts", "src/组件/按钮.ts"},
+		{"astral", "src/**/*.ts", "src/😀/button.ts"},
+		{"extglob", "src/@(??|cli).ts", "src/😀.ts"},
+	} {
+		b.Run(test.name, func(b *testing.B) {
+			matcher := minimatch3.New(test.pattern, minimatch3.Options{})
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				matcher.Match(test.path)
 			}
 		})
 	}


### PR DESCRIPTION
JavaScript minimatch 3.1.5 counts an emoji as two wildcard positions, while the current shared matcher counts a Go rune. Mixed named/unnamed captures also use regexp2's unnamed-first numbering: `(?<dir>src)/(.*)` with `$1/$2` produces the wrong path. This PR fixes these shared compatibility gaps and adds `RegExp.ReplaceFirst` for reusable first-match substitutions.

- Add a UTF-16 rune-buffer adapter using the existing ECMAScript string decoder. Apply it to minimatch subjects and emit code-unit escapes for pattern literals/classes; retain literal comparisons and globstar traversal.
- Reuse the capture scanner to cache lexical capture numbering. Apply the same mapping to numeric regexp backreferences and JavaScript replacement substitutions, including optional captures and named substitutions. Replacement timeouts return the unchanged input and an error.
- Keep grammar, encoding and capture adaptation in their owning utility packages, and document these boundaries in `architecture.md`. No third-party dependency or rule-specific compatibility option is added.
- Add helper regressions, fuzz targets, benchmarks and observable import/order and import/no-restricted-paths regressions. Existing upstream suites stay intact.

This is independent of the pending n/hashbang port. That rule branch can adopt these helpers after this PR merges.

Validation passed across the affected utility and consumer packages: ecmascript, esregexp, minimatch3, utils, import/utils, no-restricted-syntax, id-match, no-invalid-regexp, import/order, import/no-restricted-paths, jest/valid-title and rstest/valid-title. The full esregexp and minimatch3 suites also passed with `go test -race`.

- Differential comparison against Node 22.18.0 and minimatch 3.1.5: 15,288 glob cases, 4,680 replacement cases and 520 regexp matching cases, with zero mismatches.
- Twenty seconds per fuzz target: 2,400,598 regexp executions checking crash/timeout safety, and 841,023 glob executions checking UTF-16 wildcard counts. Both passed.
- Scoped `golangci-lint run --new-from-merge-base=origin/main`: zero issues. Explicit changed-file spelling checks and `pnpm run format:check` passed.
- No full-repository or JS integration suite was run for this Go-only utility change.

Performance was measured on an Apple M5 Max with Go 1.26.5 using precompiled binaries, one benchmark CPU, six samples and alternating before/after order. Matching reuses compiled patterns. The replacement baseline is the initial helper from the pending n/hashbang worktree; this API does not exist on main.

| Operation | Before | After | Change |
| --- | ---: | ---: | ---: |
| ASCII glob | 501.9 ns | 510.2 ns | +1.7% |
| Long ASCII glob | 3294.5 ns | 3339.0 ns | +1.4% |
| Chinese path glob | 335.1 ns | 355.4 ns | +6.0% |
| Emoji path glob | 384.6 ns | 400.9 ns | +4.3% |
| Plain replacement | 444.8 ns | 359.4 ns | -19.2% |
| Mixed-capture replacement | 492.2 ns | 366.1 ns | -25.6% |
| Named replacement | 501.1 ns | 376.8 ns | -24.8% |

Ordinary glob allocation counts are unchanged. Replacement allocations fall from 13–17 to 10–12 per call. Caching capture metadata adds approximately 0.2 microseconds to named/mixed regexp compilation in these samples; steady-state regexp Test controls stay within about 1%. These are helper microbenchmarks, not whole-linter throughput measurements.

Remaining boundaries are explicit in the RegExp package documentation: duplicate named groups are rejected because regexp2 merges their numeric slots, and complete non-u RegExp UTF-16 execution is outside this change. Test and ReplaceFirst retain the same underlying matching semantics. The replacement token behavior follows [ECMAScript GetSubstitution](https://tc39.es/ecma262/multipage/text-processing.html#sec-getsubstitution).
