### PR TITLE
perf: reduce import cycle graph work

### DIFF
--- a/internal/plugins/import/rules/no_cycle/graph.go
+++ b/internal/plugins/import/rules/no_cycle/graph.go
@@ -16,9 +16,8 @@ import (
 
 // graphKey identifies one shape of the dependency graph. The references
 // themselves come from Program's generic module graph, so only what turns a
-// reference into a graph edge belongs here. maxDepth does not: it bounds the
-// search, not the graph, so configurations that differ only in maxDepth share
-// one graph.
+// reference into a graph edge belongs here. For searches using this graph,
+// maxDepth bounds the search rather than changing its edges.
 type graphKey struct {
 	settings           string
 	referenceKinds     program.ModuleReferenceKinds
@@ -59,6 +58,82 @@ type moduleGraph struct {
 	group []int32
 }
 
+type directTargetsKey struct {
+	file  *ast.SourceFile
+	kinds program.ModuleReferenceKinds
+}
+
+type directCyclesKey struct {
+	file           *ast.SourceFile
+	kinds          program.ModuleReferenceKinds
+	settings       string
+	ignoreExternal bool
+}
+
+type directCycle struct {
+	reference   program.ModuleReference
+	dynamicBack bool
+}
+
+// directCyclesFor answers maxDepth: 1 without constructing the whole graph.
+// At that depth the search only visits the initial target, so a report needs
+// a direct edge back to self, which also proves the two share a component.
+// Cache both positive and empty answers to avoid rescanning a high-degree
+// file on later lint passes. Keep source order and duplicates for reporting.
+func directCyclesFor(ctx rule.RuleContext, sourceGraph program.ModuleGraph, settings *import_utils.ModuleSettings, opts ruleOptions, refs []program.ModuleReference) []directCycle {
+	self := ctx.SourceFile
+	key := directCyclesKey{file: self, kinds: opts.referenceKinds, settings: settings.Key(), ignoreExternal: opts.ignoreExternal}
+	return rule.CachedByProgram(ctx, key, func() []directCycle {
+		if fileIsExcluded(settings, opts, self) {
+			return nil
+		}
+		var cycles []directCycle
+		type backEdge struct{ dynamic, found bool }
+		checked := make(map[*ast.SourceFile]backEdge)
+		for _, ref := range refs {
+			if ref.TypeOnly || ref.Target == nil || ref.Target == self {
+				continue
+			}
+			back, known := checked[ref.Target]
+			if !known {
+				// An excluded target cannot close a cycle. Avoid collecting its
+				// references, especially for large external export files.
+				if !fileIsExcluded(settings, opts, ref.Target) {
+					targets := directTargetsFor(ctx, sourceGraph, ref.Target, opts.referenceKinds)
+					back.dynamic, back.found = targets[self]
+				}
+				checked[ref.Target] = back
+			}
+			if back.found {
+				cycles = append(cycles, directCycle{reference: ref, dynamicBack: back.dynamic})
+			}
+		}
+		return cycles
+	})
+}
+
+// directTargetsFor indexes a file only when a depth-one search reaches it.
+// Sharing this set avoids repeatedly scanning a high-degree target for each
+// of its importers. The value records whether any runtime reference to a
+// target is dynamic: the unsafe option withholds that target's static edges
+// too. This set does not apply settings or unsafe, so its key only needs the
+// selected syntax kinds. Neither cache retains a Program through its value.
+func directTargetsFor(ctx rule.RuleContext, sourceGraph program.ModuleGraph, file *ast.SourceFile, kinds program.ModuleReferenceKinds) map[*ast.SourceFile]bool {
+	return rule.CachedByProgram(ctx, directTargetsKey{file: file, kinds: kinds}, func() map[*ast.SourceFile]bool {
+		var targets map[*ast.SourceFile]bool
+		for _, ref := range sourceGraph.References(file, kinds) {
+			if ref.TypeOnly || ref.Target == nil {
+				continue
+			}
+			if targets == nil {
+				targets = make(map[*ast.SourceFile]bool)
+			}
+			targets[ref.Target] = targets[ref.Target] || ref.Dynamic()
+		}
+		return targets
+	})
+}
+
 // moduleGraphFor returns the Program generation's dependency graph for these
 // options, building it on the first file that asks for it.
 func moduleGraphFor(ctx rule.RuleContext, sourceGraph program.ModuleGraph, opts ruleOptions) *moduleGraph {
@@ -80,29 +155,27 @@ func buildModuleGraph(ctx rule.RuleContext, sourceGraph program.ModuleGraph, set
 		nodes: make([]moduleNode, len(files)),
 		index: make(map[*ast.SourceFile]int32, len(files)),
 	}
+	// Classify files once and collect only included references. The second
+	// pass converts their targets after the complete index is available,
+	// avoiding another index lookup for every source file.
 	for i, file := range files {
-		graph.index[file] = int32(i)
-	}
-
-	for i, file := range files {
-		// An edge into an excluded file is never traversable, so no search can
-		// enter it and no reference of its own can close a cycle back to it.
-		// Its outgoing references are therefore never needed, which keeps
-		// ignored — and, under ignoreExternal, node_modules — files out of the
-		// collection work entirely.
 		if fileIsExcluded(settings, opts, file) {
 			continue
 		}
-		refs := sourceGraph.References(file, opts.referenceKinds)
+		graph.index[file] = int32(i)
+		graph.nodes[i].refs = sourceGraph.References(file, opts.referenceKinds)
+	}
+
+	for i := range graph.nodes {
+		node := &graph.nodes[i]
+		refs := node.refs
 		if len(refs) == 0 {
 			continue
 		}
-		node := &graph.nodes[i]
-		node.refs = refs
 		node.edge = make([]int32, len(refs))
 		for r := range refs {
 			node.edge[r] = -1
-			if !referenceIsTraversable(settings, opts, refs[r]) {
+			if refs[r].TypeOnly || refs[r].Target == nil {
 				continue
 			}
 			if target, ok := graph.index[refs[r].Target]; ok {
@@ -114,42 +187,21 @@ func buildModuleGraph(ctx rule.RuleContext, sourceGraph program.ModuleGraph, set
 			node.expand = withheldDynamicEdges(node)
 		}
 	}
-
 	graph.computeGroups()
 	return graph
 }
 
-// fileIsExcluded reports whether referenceIsTraversable drops every edge into
-// file: its path is covered by `import/ignore`, or ignoreExternal is set and
-// the path is external. IsExternalPath only consults its specifier when the
-// resolved path is empty, so passing none matches what it answers for any
-// edge resolving to this file.
+// fileIsExcluded reports whether every edge into file is dropped: its path is
+// covered by `import/ignore`, or ignoreExternal is set and the path is external.
+// A resolved reference's Path is its target's FileName, which tsgo requires to
+// be absolute and nonempty. IsExternalPath only consults the specifier for an
+// empty path, so every reference resolving to this file has the same answer.
 func fileIsExcluded(settings *import_utils.ModuleSettings, opts ruleOptions, file *ast.SourceFile) bool {
 	fileName := file.FileName()
 	if settings.IsIgnoredPath(fileName) {
 		return true
 	}
 	return opts.ignoreExternal && settings.IsExternalPath("", fileName)
-}
-
-// referenceIsTraversable reports whether an edge is one the rule follows: it
-// has to survive into the emitted JavaScript, name a file the runtime loaded,
-// and be neither ignored by `import/ignore` nor set aside by ignoreExternal.
-func referenceIsTraversable(settings *import_utils.ModuleSettings, opts ruleOptions, reference program.ModuleReference) bool {
-	if reference.TypeOnly || reference.Target == nil {
-		return false
-	}
-	if settings.IsIgnoredPath(reference.Target.FileName()) {
-		return false
-	}
-	return !shouldIgnoreExternal(settings, opts, reference)
-}
-
-func shouldIgnoreExternal(settings *import_utils.ModuleSettings, opts ruleOptions, reference program.ModuleReference) bool {
-	if !opts.ignoreExternal {
-		return false
-	}
-	return settings.IsExternalPath(reference.Text(), reference.Path())
 }
 
 // withheldDynamicEdges applies allowUnsafeDynamicCyclicDependency: a file's

--- a/internal/plugins/import/rules/no_cycle/no_cycle.go
+++ b/internal/plugins/import/rules/no_cycle/no_cycle.go
@@ -7,6 +7,8 @@ import (
 	"math"
 	"strings"
 
+	"github.com/microsoft/TypeScript/tsc/shim/ast"
+	import_utils "github.com/web-infra-dev/rslint/internal/plugins/import/utils"
 	"github.com/web-infra-dev/rslint/internal/program"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
@@ -35,7 +37,11 @@ var NoCycleRule = rule.Rule{
 	Schema: rule.NewSchema(schemaJSON),
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		opts := parseOptions(options)
-		checkSourceFile(ctx, opts)
+		if opts.maxDepth == 1 {
+			checkDirectCycles(ctx, opts)
+		} else {
+			checkSourceFile(ctx, opts)
+		}
 		return rule.RuleListeners{}
 	},
 }
@@ -171,6 +177,45 @@ func checkSourceFile(ctx rule.RuleContext, opts ruleOptions) {
 			reportNode = node.refs[r].Specifier
 		}
 		ctx.ReportNode(reportNode, messageCycle(route))
+	}
+}
+
+func checkDirectCycles(ctx rule.RuleContext, opts ruleOptions) {
+	if ctx.SourceFile == nil || !ctx.Program().IsValid() {
+		return
+	}
+	myPath := ctx.SourceFile.FileName()
+	if myPath == "" || myPath == "<text>" {
+		return
+	}
+	sourceGraph := ctx.Program().ModuleGraph()
+	refs := sourceGraph.References(ctx.SourceFile, opts.referenceKinds)
+	if len(refs) == 0 {
+		return
+	}
+	settings := import_utils.SettingsFor(ctx)
+	cycles := directCyclesFor(ctx, sourceGraph, settings, opts, refs)
+	if len(cycles) == 0 {
+		return
+	}
+	seen := make(map[*ast.SourceFile]bool)
+	for _, cycle := range cycles {
+		ref := cycle.reference
+		if opts.allowUnsafeDynamicCyclicDependency && (ref.Dynamic() || cycle.dynamicBack) {
+			continue
+		}
+		if seen[ref.Target] {
+			continue
+		}
+		// The general search marks a target only when it is visited, after
+		// filtering the initial reference. A skipped dynamic import must not
+		// suppress a later static import of the same file.
+		seen[ref.Target] = true
+		reportNode := ref.Declaration
+		if reportNode == nil {
+			reportNode = ref.Specifier
+		}
+		ctx.ReportNode(reportNode, messageCycle(nil))
 	}
 }
 

--- a/internal/plugins/import/rules/no_cycle/no_cycle_extras_test.go
+++ b/internal/plugins/import/rules/no_cycle/no_cycle_extras_test.go
@@ -2,11 +2,22 @@ package no_cycle_test
 
 import (
 	"encoding/json"
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+	"sync/atomic"
 	"testing"
 
+	"github.com/microsoft/TypeScript/tsc/shim/core"
+	"github.com/microsoft/TypeScript/tsc/shim/tspath"
+	"github.com/microsoft/TypeScript/tsc/shim/vfs"
 	"github.com/web-infra-dev/rslint/internal/plugins/import/fixtures"
 	"github.com/web-infra-dev/rslint/internal/plugins/import/rules/no_cycle"
+	"github.com/web-infra-dev/rslint/internal/program"
+	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
+	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
 // TestNoCycleExtras locks in branches, real-user shapes, and tsgo AST edge
@@ -19,6 +30,19 @@ func TestNoCycleExtras(t *testing.T) {
 		t,
 		&no_cycle.NoCycleRule,
 		withDefaultNoCycleValidFileName([]rule_tester.ValidTestCase{
+			// Excluding a target, an intermediate file, or the importer breaks
+			// every route into that file, including duplicate references.
+			{Code: `import "./no-cycle/depth-one"; import "./no-cycle/depth-one"; ` + rootExports, Settings: map[string]interface{}{"import/ignore": []interface{}{`/depth-one\.ts$`}}},
+			{Code: `import "./no-cycle/depth-two"; ` + rootExports, Settings: map[string]interface{}{"import/ignore": []interface{}{`/depth-one\.ts$`}}},
+			{Code: `import "./no-cycle/depth-one"; ` + rootExports, Settings: map[string]interface{}{"import/ignore": []interface{}{`/file\.ts$`}}},
+			{Code: `import "./no-cycle/depth-one"; ` + rootExports, Options: map[string]interface{}{"ignoreExternal": true}, Settings: map[string]interface{}{"import/external-module-folders": []interface{}{"no-cycle"}}},
+			{Code: `import "./no-cycle/depth-one"; ` + rootExports, Options: map[string]interface{}{"ignoreExternal": true}, Settings: map[string]interface{}{"import/external-module-folders": []interface{}{""}}},
+			{Code: `import "./no-cycle/depth-one"; import("./no-cycle/depth-one"); ` + rootExports, Options: map[string]interface{}{"allowUnsafeDynamicCyclicDependency": true}, Settings: map[string]interface{}{"import/ignore": []interface{}{`/depth-one\.ts$`}}},
+
+			// Suppression still applies to reports after graph filtering.
+			{Code: "// eslint-disable-next-line test\n" + `import "./no-cycle/depth-one"; ` + rootExports},
+			{Code: `/* eslint-disable test */ import "./no-cycle/depth-one"; ` + rootExports},
+
 			// ---- JSDoc import types are comments, not module-graph edges ----
 			// @typescript-eslint/parser exposes these through comments / parser
 			// services rather than ESTree import nodes, so import/no-cycle ignores
@@ -87,6 +111,38 @@ func TestNoCycleExtras(t *testing.T) {
 			{Code: `import { depthThree } from "./no-cycle/depth-three"; export const rootValue = depthThree; export type RootType = string;`, Options: []interface{}{map[string]interface{}{"maxDepth": json.Number("2")}}},
 		}),
 		withDefaultNoCycleInvalidFileName([]rule_tester.InvalidTestCase{
+			// Local bare aliases are not external when they resolve to local files.
+			{
+				Code:     `import { aliasB } from "@cycles/alias-b"; export const aliasA = aliasB;`,
+				FileName: "no-cycle/alias-a.ts",
+				TSConfig: "tsconfig.no-cycle-paths.json",
+				Options:  map[string]interface{}{"ignoreExternal": true},
+				Errors:   []rule_tester.InvalidTestCaseError{cycleError(messageDetected)},
+			},
+			// An empty external folder list and an unrelated ignore pattern
+			// keep the original diagnostic and its complete source range.
+			{
+				Code:     "/* leading comment */\n" + `import "./no-cycle/depth-two"; ` + rootExports,
+				Options:  map[string]interface{}{"ignoreExternal": true},
+				Settings: map[string]interface{}{"import/external-module-folders": []interface{}{}, "import/ignore": []interface{}{`/missing/`}},
+				Errors:   []rule_tester.InvalidTestCaseError{{MessageId: "cycle", Message: messageViaDepthOne, Line: 2, Column: 1, EndLine: 2, EndColumn: 31}},
+			},
+			// A missing target must not become an edge to the first graph node.
+			{
+				Code:   "import './no-cycle/does-not-exist';\n" + `import "./no-cycle/depth-one"; ` + rootExports,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "cycle", Message: messageDetected, Line: 2, Column: 1}},
+			},
+			// Excluding one cyclic target must not exclude its remaining siblings.
+			{
+				Code:     "import './no-cycle/depth-one';\n" + `import "./no-cycle/independent-b"; ` + rootExports,
+				Settings: map[string]interface{}{"import/ignore": []interface{}{`/depth-one\.ts$`}},
+				Errors:   []rule_tester.InvalidTestCaseError{{MessageId: "cycle", Message: messageDetected, Line: 2, Column: 1}},
+			},
+			{
+				Code:   "/* eslint-disable test */\nimport './no-cycle/depth-one';\n/* eslint-enable test */\n" + `import "./no-cycle/independent-b"; ` + rootExports,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "cycle", Message: messageDetected, Line: 4, Column: 1}},
+			},
+
 			// Control for the JSDoc cases above: with the same JavaScript filename,
 			// tsconfig, and target, an authored import is a graph edge and closes
 			// the cycle through no-cycle/depth-one.ts.
@@ -270,4 +326,346 @@ export const realValue = realBarrel.run || run;`,
 			},
 		}),
 	)
+}
+
+// These small Programs exercise repeated queries against the same generation;
+// ordinary rule-tester cases each construct a new Program and cannot expose
+// configuration-dependent answers leaking through the direct-cycle caches.
+func TestNoCycleDepthOneReferenceSemantics(t *testing.T) {
+	tests := []struct {
+		name    string
+		source  string
+		target  string
+		options map[string]interface{}
+		want    []string
+	}{
+		{
+			name:   "type-only references do not consume duplicate runtime targets",
+			source: "import type { B } from './b';\nimport './b';\nimport './b.ts';",
+			target: "import './a'; export type B = string;",
+			want:   []string{"import './b';"},
+		},
+		{
+			name:    "a skipped dynamic reference does not consume the static target",
+			source:  "import('./b');\nimport './b';",
+			target:  "import './a';",
+			options: map[string]interface{}{"allowUnsafeDynamicCyclicDependency": true},
+			want:    []string{"import './b';"},
+		},
+		{
+			name:    "a later dynamic source reference does not suppress the static one",
+			source:  "import './b';\nimport('./b');",
+			target:  "import './a';",
+			options: map[string]interface{}{"allowUnsafeDynamicCyclicDependency": true},
+			want:    []string{"import './b';"},
+		},
+		{
+			name:   "the first dynamic source reports when unsafe cycles are forbidden",
+			source: "import('./b');\nimport './b';",
+			target: "import './a';",
+			want:   []string{"import('./b')"},
+		},
+		{
+			name:   "self imports do not consume the return edge",
+			source: "import './a';\nimport './b';",
+			target: "import './a';",
+			want:   []string{"import './b';"},
+		},
+		{
+			name:    "a later dynamic back edge withholds the static back edge",
+			source:  "import './b';",
+			target:  "import './a';\nimport('./a');",
+			options: map[string]interface{}{"allowUnsafeDynamicCyclicDependency": true},
+		},
+		{
+			name:    "a later static back edge does not erase the dynamic back edge",
+			source:  "import './b';",
+			target:  "import('./a');\nimport './a';",
+			options: map[string]interface{}{"allowUnsafeDynamicCyclicDependency": true},
+		},
+		{
+			name:   "mixed back edges report when unsafe cycles are forbidden",
+			source: "import './b';",
+			target: "import('./a');\nimport './a';",
+			want:   []string{"import './b';"},
+		},
+		{
+			name:    "unrelated and unresolved dynamic imports do not withhold self",
+			source:  "import './b';",
+			target:  "import('./c');\nimport('./missing');\nimport './a';",
+			options: map[string]interface{}{"allowUnsafeDynamicCyclicDependency": true},
+			want:    []string{"import './b';"},
+		},
+		{
+			name:   "a type-only return edge is not a cycle",
+			source: "import './b'; export type A = string;",
+			target: "import type { A } from './a';",
+		},
+		{
+			name:   "named type reexports retain upstream dependency semantics",
+			source: "import './b'; export type A = string;",
+			target: "export type { A } from './a';",
+			want:   []string{"import './b';"},
+		},
+		{
+			name:    "dynamic references outside selected kinds do not withhold CommonJS",
+			source:  "require('./b');",
+			target:  "require('./a');\nimport('./a');",
+			options: map[string]interface{}{"esmodule": false, "commonjs": true, "allowUnsafeDynamicCyclicDependency": true},
+			want:    []string{"require('./b')"},
+		},
+		{
+			name:    "AMD references form direct cycles when selected",
+			source:  "define(['./b'], () => {});",
+			target:  "require(['./a'], () => {});",
+			options: map[string]interface{}{"esmodule": false, "amd": true},
+			want:    []string{"define(['./b'], () => {})"},
+		},
+		{
+			name:   "unselected call references cannot close a cycle",
+			source: "require('./b'); define(['./b'], () => {});",
+			target: "require('./a'); define(['./a'], () => {});",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root, roots := noCycleDepthOneRoot(t, map[string]string{
+				"a.ts": tt.source,
+				"b.ts": tt.target,
+				"c.ts": "export {};",
+			})
+			p := noCycleDepthOneProgram(t, root, roots)
+			options := map[string]interface{}{"maxDepth": 1}
+			for key, value := range tt.options {
+				options[key] = value
+			}
+			// Both cold and cached queries must report the same first source.
+			for range 2 {
+				reports := noCycleDepthOneReports(t, p, root, "a.ts", options, nil, rule.EditDemandNone)
+				assertNoCycleDepthOneReports(t, reports, tt.want)
+			}
+		})
+	}
+}
+
+func TestNoCycleDepthOneCacheIsolation(t *testing.T) {
+	files := map[string]string{
+		"a.ts":          "import './local';\nimport './external/b';\nimport './dynamic';\nrequire('./common');\ndefine(['./amd'], () => {});",
+		"local.ts":      "import './a'; import './other';",
+		"external/b.ts": "import '../a';",
+		"dynamic.ts":    "import './a'; import('./a');",
+		"common.ts":     "require('./a'); import('./a');",
+		"amd.ts":        "define(['./a'], () => {});",
+		"other.ts":      "import './local';",
+		"unrelated.ts":  "import './local';",
+	}
+	local, external, dynamic := "import './local';", "import './external/b';", "import './dynamic';"
+	tests := []struct {
+		name     string
+		options  map[string]interface{}
+		settings map[string]interface{}
+		want     []string
+	}{
+		{name: "ignored target", settings: map[string]interface{}{"import/ignore": []interface{}{`/local\.ts$`}}, want: []string{external, dynamic}},
+		{name: "external target", options: map[string]interface{}{"ignoreExternal": true}, settings: map[string]interface{}{"import/external-module-folders": []interface{}{"external"}}, want: []string{local, dynamic}},
+		{name: "unsafe enabled", options: map[string]interface{}{"allowUnsafeDynamicCyclicDependency": true}, want: []string{local, external}},
+		{name: "no filters", want: []string{local, external, dynamic}},
+		{name: "external option disabled", settings: map[string]interface{}{"import/external-module-folders": []interface{}{"external"}}, want: []string{local, external, dynamic}},
+		{name: "empty external folders", options: map[string]interface{}{"ignoreExternal": true}, settings: map[string]interface{}{"import/external-module-folders": []interface{}{}}, want: []string{local, external, dynamic}},
+		{name: "ignored self", settings: map[string]interface{}{"import/ignore": []interface{}{`/a\.ts$`}}},
+		{name: "CommonJS only", options: map[string]interface{}{"esmodule": false, "commonjs": true, "allowUnsafeDynamicCyclicDependency": true}, want: []string{"require('./common')"}},
+		{name: "ESM and CommonJS unsafe", options: map[string]interface{}{"commonjs": true, "allowUnsafeDynamicCyclicDependency": true}, want: []string{local, external}},
+		{name: "AMD only", options: map[string]interface{}{"esmodule": false, "amd": true}, want: []string{"define(['./amd'], () => {})"}},
+		{name: "all syntax kinds", options: map[string]interface{}{"commonjs": true, "amd": true}, want: []string{local, external, dynamic, "require('./common')", "define(['./amd'], () => {})"}},
+		{name: "no syntax kinds", options: map[string]interface{}{"esmodule": false}},
+	}
+	for _, reverse := range []bool{false, true} {
+		t.Run(fmt.Sprintf("reverse=%t", reverse), func(t *testing.T) {
+			root, roots := noCycleDepthOneRoot(t, files)
+			p := noCycleDepthOneProgram(t, root, roots)
+			for index := range tests {
+				if reverse {
+					index = len(tests) - 1 - index
+				}
+				tt := tests[index]
+				t.Run(tt.name, func(t *testing.T) {
+					options := map[string]interface{}{"maxDepth": 1}
+					for key, value := range tt.options {
+						options[key] = value
+					}
+					for range 2 {
+						reports := noCycleDepthOneReports(t, p, root, "a.ts", options, tt.settings, rule.EditDemandNone)
+						assertNoCycleDepthOneReports(t, reports, tt.want)
+					}
+				})
+			}
+			// The same target's cached return set must answer separately for
+			// another importer it reaches and an importer it does not reach.
+			options := map[string]interface{}{"maxDepth": 1}
+			assertNoCycleDepthOneReports(t, noCycleDepthOneReports(t, p, root, "other.ts", options, nil, rule.EditDemandNone), []string{local})
+			assertNoCycleDepthOneReports(t, noCycleDepthOneReports(t, p, root, "unrelated.ts", options, nil, rule.EditDemandNone), nil)
+		})
+	}
+}
+
+func TestNoCycleDepthOneDepthBoundary(t *testing.T) {
+	root, roots := noCycleDepthOneRoot(t, map[string]string{
+		"a.ts": "import './b';",
+		"b.ts": "import './c';",
+		"c.ts": "import './a';",
+	})
+	p := noCycleDepthOneProgram(t, root, roots)
+	for _, depth := range []int{1, 2, 1} {
+		reports := noCycleDepthOneReports(t, p, root, "a.ts", map[string]interface{}{"maxDepth": depth}, nil, rule.EditDemandNone)
+		if depth == 1 {
+			assertNoCycleDepthOneReports(t, reports, nil)
+		} else if len(reports) != 1 || reports[0].Message.Description != "Dependency cycle via ./c:1" {
+			t.Fatalf("maxDepth 2 reports = %v, want the indirect cycle", reports)
+		}
+	}
+}
+
+func TestNoCycleDepthOneConcurrentQueries(t *testing.T) {
+	t.Parallel()
+	root, roots := noCycleDepthOneRoot(t, map[string]string{
+		"a.ts": "import './b';",
+		"b.ts": "import './a'; import('./a');",
+	})
+	p := noCycleDepthOneProgram(t, root, roots)
+	for index := range 24 {
+		t.Run(strconv.Itoa(index), func(t *testing.T) {
+			t.Parallel()
+			unsafe := index%2 == 0
+			demand := []rule.EditDemand{rule.EditDemandNone, rule.EditDemandAutofix, rule.EditDemandSuggestion, rule.EditDemandAutofix | rule.EditDemandSuggestion}[(index/2)%4]
+			options := map[string]interface{}{"maxDepth": 1, "allowUnsafeDynamicCyclicDependency": unsafe}
+			var want []string
+			if !unsafe {
+				want = []string{"import './b';"}
+			}
+			for range 3 {
+				assertNoCycleDepthOneReports(t, noCycleDepthOneReports(t, p, root, "a.ts", options, nil, demand), want)
+			}
+		})
+	}
+}
+
+func TestNoCycleDepthOneExcludedTargetsAreNotCollected(t *testing.T) {
+	for _, ignoreExternal := range []bool{false, true} {
+		t.Run(fmt.Sprintf("ignoreExternal=%t", ignoreExternal), func(t *testing.T) {
+			root, roots := noCycleDepthOneRoot(t, map[string]string{
+				"a.ts":          "import './external/b';",
+				"external/b.ts": "import '../a'; define(['no-cycle-demand-probe'], () => {});",
+			})
+			root.FS = utils.NewOverlayVFS(root.FS, map[string]string{
+				tspath.ResolvePath(root.Dir, "node_modules/no-cycle-demand-probe/package.json"): `{"name":"no-cycle-demand-probe","types":"index.d.ts"}`,
+				tspath.ResolvePath(root.Dir, "node_modules/no-cycle-demand-probe/index.d.ts"):   "export {};",
+			})
+			probe := &noCycleDepthOneProbeFS{FS: root.FS}
+			root.FS = probe
+			p := noCycleDepthOneProgram(t, root, roots)
+			probe.probes.Store(0)
+			options := map[string]interface{}{"maxDepth": 1, "amd": true, "ignoreExternal": ignoreExternal}
+			settings := map[string]interface{}{"import/ignore": []interface{}{`/external/`}}
+			if ignoreExternal {
+				settings = map[string]interface{}{"import/external-module-folders": []interface{}{"external"}}
+			}
+			assertNoCycleDepthOneReports(t, noCycleDepthOneReports(t, p, root, "a.ts", options, settings, rule.EditDemandNone), nil)
+			if got := probe.probes.Load(); got != 0 {
+				t.Fatalf("excluded target caused %d module-resolution probes", got)
+			}
+			// The positive control makes this fail if the probe cannot see
+			// AMD resolution, and also checks a cached negative answer
+			// does not survive into the unfiltered configuration.
+			assertNoCycleDepthOneReports(t, noCycleDepthOneReports(t, p, root, "a.ts", options, nil, rule.EditDemandNone), []string{"import './external/b';"})
+			if probe.probes.Load() == 0 {
+				t.Fatal("unfiltered target did not resolve the AMD probe")
+			}
+		})
+	}
+}
+
+type noCycleDepthOneProbeFS struct {
+	vfs.FS
+	probes atomic.Int64
+}
+
+func (fs *noCycleDepthOneProbeFS) FileExists(path string) bool {
+	if strings.Contains(path, "no-cycle-demand-probe") {
+		fs.probes.Add(1)
+	}
+	return fs.FS.FileExists(path)
+}
+
+func noCycleDepthOneRoot(t *testing.T, files map[string]string) (rule_tester.Root, []string) {
+	t.Helper()
+	if len(files) == 0 {
+		t.Fatal("no-cycle depth-one fixture has no files")
+	}
+	root := fixtures.GetRootDir()
+	root.Dir = tspath.ResolvePath(root.Dir, "no-cycle-depth-one-extras")
+	normalized := make(map[string]string, len(files))
+	roots := make([]string, 0, len(files))
+	for name, code := range files {
+		path := tspath.ResolvePath(root.Dir, name)
+		normalized[path] = code
+		roots = append(roots, path)
+	}
+	slices.Sort(roots)
+	root.FS = utils.NewOverlayVFS(root.FS, normalized)
+	return root, roots
+}
+
+func noCycleDepthOneProgram(t *testing.T, root rule_tester.Root, roots []string) *program.Program {
+	t.Helper()
+	p, err := program.NewFromRoots(program.RootOptions{
+		RootFileNames: roots,
+		Host:          utils.CreateCompilerHost(root.Dir, root.FS),
+		CompilerOptions: &core.CompilerOptions{
+			NoLib:            core.TSTrue,
+			Module:           core.ModuleKindESNext,
+			ModuleResolution: core.ModuleResolutionKindBundler,
+		},
+		SingleThreaded: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(p.SourceFiles()) != len(roots) {
+		t.Fatalf("loaded %d source files, want %d", len(p.SourceFiles()), len(roots))
+	}
+	return p
+}
+
+func noCycleDepthOneReports(t *testing.T, p *program.Program, root rule_tester.Root, name string, options, settings map[string]interface{}, demand rule.EditDemand) []rule.RuleDiagnostic {
+	t.Helper()
+	file := p.GetSourceFile(tspath.ResolvePath(root.Dir, name))
+	if file == nil {
+		t.Fatalf("no-cycle depth-one fixture is missing %s", name)
+	}
+	var reports []rule.RuleDiagnostic
+	ctx := (rule.RuleContext{SourceFile: file, Settings: settings}).WithProgram(p).WithDiagnosticConsumer(
+		no_cycle.NoCycleRule.Name, rule.SeverityWarning,
+		rule.DiagnosticConsumer{Demand: demand, Report: func(diagnostic rule.RuleDiagnostic) { reports = append(reports, diagnostic) }},
+	)
+	no_cycle.NoCycleRule.Run(ctx, []any{options})
+	for _, diagnostic := range reports {
+		if diagnostic.FixesPtr != nil || diagnostic.Suggestions != nil {
+			t.Fatal("import/no-cycle offered an edit")
+		}
+	}
+	return reports
+}
+
+func assertNoCycleDepthOneReports(t *testing.T, reports []rule.RuleDiagnostic, want []string) {
+	t.Helper()
+	var got []string
+	for _, diagnostic := range reports {
+		if diagnostic.Message.Id != "cycle" || diagnostic.Message.Description != messageDetected {
+			t.Fatalf("unexpected direct-cycle message: %v", diagnostic.Message)
+		}
+		got = append(got, diagnostic.SourceFile.Text()[diagnostic.Range.Pos():diagnostic.Range.End()])
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("reported source ranges = %q, want %q", got, want)
+	}
 }


### PR DESCRIPTION
## Summary

`import/no-cycle` repeatedly evaluates ignored/external paths for incoming references while building its graph. It also builds the entire graph and computes strongly connected components for `maxDepth: 1`, even when a query only needs to check whether the initial target imports the source directly.

Classify each file once, collect references in that pass, and convert targets after the complete included-file index is available. For depth one, query direct return edges on demand and cache target sets and ordered positive/negative candidates within the Program. Preserve settings isolation, syntax kinds, dynamic-edge filtering before deduplication, source order, diagnostic ranges, and messages. The general SCC/BFS search remains unchanged.

### Go benchmarks

Measured against main `242ce472cee9f971571804de6321b32f3b8902a3` with Go 1.26.5 on darwin/arm64. Both variants used identical temporary benchmark inputs. Twelve adjacent A/B pairs, alternating AB/BA, `GOMAXPROCS=18`, `-benchtime=200ms -count=1 -cpu=18 -benchmem`; each command began with CPU idle at least 70%. All eligible samples were retained. Construction cases warm the shared reference cache and rebuild the rule graph; rule cases measure warm per-file execution. Program creation is outside the measured section.

Times below are geometric means. Changes and per-case 95% intervals use paired log ratios with 20,000 whole-pair bootstrap samples; intervals are not adjusted for multiple comparisons. An interval crossing zero does not establish equivalence.

| Case | Before ns/op | After ns/op | Paired change [95% CI] |
| --- | ---: | ---: | ---: |
| Build/Default | 161,316.03 | 95,916.33 | -40.54% [-43.76, -37.97] |
| Build/IgnorePatterns | 1,848,430.88 | 194,955.78 | -89.45% [-90.02, -88.96] |
| Build/IgnoreExternal | 775,101.31 | 128,581.72 | -83.41% [-84.07, -82.75] |
| Build/ExcludedFiles | 2,031,203.93 | 200,031.32 | -90.15% [-90.44, -89.85] |
| Build/AllowDynamic | 197,077.53 | 146,308.53 | -25.76% [-29.38, -19.54] |
| Rule/Direct | 361.96 | 362.41 | +0.12% [-1.78, +2.98] |
| Rule/DirectAutofixDemand | 362.97 | 361.16 | -0.50% [-2.36, +1.69] |
| Rule/DirectSuggestionDemand | 364.12 | 360.77 | -0.92% [-3.30, +1.49] |
| Rule/LongCycle | 7,982.61 | 8,032.09 | +0.62% [-2.37, +3.99] |
| Rule/DenseCycle | 23,017.08 | 23,051.20 | +0.15% [-1.07, +1.48] |
| Rule/Acyclic | 310.25 | 305.30 | -1.59% [-2.50, -0.54] |
| Rule/ImportFree | 103.75 | 100.05 | -3.56% [-6.43, -0.49] |
| Rule/MaxDepth | 384.57 | 366.40 | -4.72% [-12.63, +0.22] |
| Rule/AllowDynamic | 330.66 | 326.49 | -1.26% [-6.28, +2.66] |

In the new-base warm Rule cases above, allocation counts and bytes do not increase. IgnorePatterns construction drops from 26,953 to 2,566 allocations/op. Separate same-binary controls against `b3aa8ae0` covering sparse graphs, unresolved imports, dense graphs, and regular-expression filters caught an extra per-file map lookup in an earlier candidate; the final two-pass construction removes it. Against that b3aa8ae0 control, sparse construction is statistically inconclusive, while unresolved/dense/filter cases improve.

Depth-one allocation tradeoff: earlier six-sample synthetic measurements against `b3aa8ae0` used the same depth-one implementation. These are historical medians, not the new-base paired results above:

| Depth-one case | Before ns/op | After ns/op | Before → after B/op | Before → after allocs/op |
| --- | ---: | ---: | ---: | ---: |
| Cold single file with 4,096 unrelated files | 1,846,270 | 8,880 | 3,753,600 → 2,648 | 32,879 → 43 |
| Cold batch of 512 importers sharing a hub | 1,145,411.5 | 1,171,033 | 1,176,596 → 1,270,266.5 | 15,420 → 16,472 |
| Warm batch of 512 importers sharing a hub | 332,678 | 267,049 | 123,056 → 135,368 | 5,128 → 5,128 |

The cache adds about 8%/10% allocation bytes in these cold/warm hub batches; these are bytes allocated per operation, not peak RSS or retained heap. The historical cold hub timing increased 2.24% and was not remeasured in the final paired set. The optimization therefore targets graph construction and bounded local queries; it does not promise that every graph or batch is faster.

### Validation

- `go test ./internal/plugins/import/rules/no_cycle -count=3`
- `go test -race ./internal/plugins/import/rules/no_cycle -count=1`
- `go test ./internal/linter ./internal/program/loader -run '^(TestSourceOnlyProgramRunsProgramIndexedImportRule|TestRootProgramSupportsCrossFileImportRules)$' -count=1`
- `pnpm --filter @rslint/core build:bin`
- `CI=true pnpm --dir packages/rslint-test-tools exec rs test run tests/eslint-plugin-import/rules/no-cycle.test.ts`
- `golangci-lint run --new-from-merge-base=origin/main ./internal/plugins/import/rules/no_cycle`
- `pnpm run check-spell internal/plugins/import/rules/no_cycle/graph.go internal/plugins/import/rules/no_cycle/no_cycle.go internal/plugins/import/rules/no_cycle/no_cycle_extras_test.go`
- `pnpm run format:check` and `git diff --check`

All passed. Regression coverage includes ignored files, unresolved targets, settings/syntax cache isolation, source ordering and mixed dynamic/static references, depth boundaries, concurrent queries, edit demand, and exact diagnostic ranges. A filesystem probe with a positive control verifies excluded targets do not trigger lazy AMD resolution. Temporary benchmark sources were removed before delivery.

## Related Links

<!--- Provide links of related issues or pages -->

None.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required): no public behavior or configuration changes.

