### PR TITLE
fix(react): ignore abstract methods in no-is-mounted

### DIFF
--- a/internal/plugins/react/rules/no_is_mounted/no_is_mounted.go
+++ b/internal/plugins/react/rules/no_is_mounted/no_is_mounted.go
@@ -12,7 +12,10 @@ import (
 // Property nor MethodDefinition in ESTree.
 func isPropertyOrMethodDefinition(node *ast.Node) bool {
 	if ast.IsMethodOrAccessor(node) {
-		return true
+		// @typescript-eslint/parser exposes abstract class members as
+		// TSAbstractMethodDefinition rather than MethodDefinition, so they do
+		// not satisfy upstream's ancestor check.
+		return !ast.HasSyntacticModifier(node, ast.ModifierFlagsAbstract)
 	}
 	switch node.Kind {
 	case ast.KindPropertyAssignment,

--- a/internal/plugins/react/rules/no_is_mounted/no_is_mounted_extras_test.go
+++ b/internal/plugins/react/rules/no_is_mounted/no_is_mounted_extras_test.go
@@ -1,0 +1,32 @@
+package no_is_mounted
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoIsMountedExtras(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoIsMountedRule, []rule_tester.ValidTestCase{
+		{Code: `abstract class C { abstract [this.isMounted()](): void; }`, Tsx: true},
+		{Code: `abstract class C { abstract get [this.isMounted()](): string; }`, Tsx: true},
+		{Code: `abstract class C { abstract set [this.isMounted()](value: string); }`, Tsx: true},
+	}, []rule_tester.InvalidTestCase{
+		{
+			Code: `declare class C { [this.isMounted()](): void; }`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noIsMounted", Line: 1, Column: 20, EndLine: 1, EndColumn: 34},
+			},
+		},
+		{
+			Code: `class C { [this.isMounted()](): void; [this.isMounted()]() {} }`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noIsMounted", Line: 1, Column: 12, EndLine: 1, EndColumn: 26},
+				{MessageId: "noIsMounted", Line: 1, Column: 40, EndLine: 1, EndColumn: 54},
+			},
+		},
+	})
+}


### PR DESCRIPTION
## Summary

- Exclude TypeScript abstract class methods/accessors from `react/no-is-mounted`'s MethodDefinition ancestor check.
- Add extras coverage for abstract method/getter/setter signatures while keeping `declare class` and overload signature behavior covered.
