### PR TITLE
feat: add node/no-exports-assign rule

### DIFF
--- a/internal/plugins/node/all.go
+++ b/internal/plugins/node/all.go
@@ -2,9 +2,13 @@ package node_plugin
 
 import (
 	"github.com/web-infra-dev/rslint/internal/plugins/node/rules/hashbang"
+	"github.com/web-infra-dev/rslint/internal/plugins/node/rules/no_exports_assign"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
 
 func GetAllRules() []rule.Rule {
-	return []rule.Rule{hashbang.HashbangRule}
+	return []rule.Rule{
+		hashbang.HashbangRule,
+		no_exports_assign.NoExportsAssignRule,
+	}
 }

--- a/internal/plugins/node/rules/no_exports_assign/no_exports_assign.go
+++ b/internal/plugins/node/rules/no_exports_assign/no_exports_assign.go
@@ -1,0 +1,108 @@
+package no_exports_assign
+
+import (
+	"github.com/microsoft/TypeScript/tsc/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+	"github.com/web-infra-dev/rslint/internal/utils/scope"
+)
+
+// https://github.com/eslint-community/eslint-plugin-n/blob/v18.3.0/lib/rules/no-exports-assign.js
+var NoExportsAssignRule = rule.Rule{
+	Name:   "node/no-exports-assign",
+	Schema: rule.EmptyArraySchema,
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		exportsAccess := ctx.Globals.Access("exports")
+		// Module-local declarations cannot supply the global variable this
+		// rule requires. Globals already includes inline directives.
+		if exportsAccess != utils.GlobalAccessReadonly && exportsAccess != utils.GlobalAccessWritable &&
+			ctx.Refs.HasNonGlobalProgramScope() {
+			return nil
+		}
+
+		var scopes *scope.Manager
+		isGlobalIdentifier := func(node *ast.Node, name string) bool {
+			node = utils.ESTreeRuntimeExpression(node)
+			if node == nil || node.Kind != ast.KindIdentifier || node.Text() != name {
+				return false
+			}
+			// A direct program expression with no file-local declaration cannot
+			// be shadowed. RefStore distinguishes authored locals from tsgo's
+			// implicit CommonJS exports binding and JSDoc declarations.
+			// Once scopes are built, reuse them without another fast-path query.
+			if scopes != nil || !isDirectProgramExpression(node) ||
+				(ctx.SourceFile.Locals[name] != nil && !ctx.Refs.IsGlobalNameReference(node, name, scope.ReferenceDual.DeclarationMeaning())) {
+				// Upstream's syntactic lookup includes type-only declarations and
+				// sees function-body bindings from parameter defaults. Ordinary
+				// reference resolution alone cannot model these nested scopes.
+				if scopes == nil {
+					scopes = scope.Build(ctx.SourceFile, scope.Options{})
+				}
+				for current := scopes.Acquire(node); current != nil; current = current.Parent {
+					if len(current.Declarations(name)) != 0 {
+						return current == scopes.Global && !ctx.Refs.HasNonGlobalProgramScope()
+					}
+				}
+			}
+			access := ctx.Globals.Access(name)
+			return access == utils.GlobalAccessReadonly || access == utils.GlobalAccessWritable
+		}
+		isModuleExports := func(node *ast.Node) bool {
+			node = utils.ESTreeRuntimeExpression(node)
+			if node == nil || node.Kind != ast.KindPropertyAccessExpression || ast.IsOptionalChain(node) {
+				return false
+			}
+			member := node.AsPropertyAccessExpression()
+			return member.Name().Kind == ast.KindIdentifier && member.Name().Text() == "exports" &&
+				isGlobalIdentifier(member.Expression, "module")
+		}
+
+		return rule.RuleListeners{
+			ast.KindBinaryExpression: func(node *ast.Node) {
+				assignment := node.AsBinaryExpression()
+				if !ast.IsAssignmentOperator(assignment.OperatorToken.Kind) {
+					return
+				}
+				left := utils.ESTreeRuntimeExpression(assignment.Left)
+				if left == nil || left.Kind != ast.KindIdentifier || left.Text() != "exports" ||
+					utils.IsDefaultValueInDestructuringAssignment(node) || !isGlobalIdentifier(left, "exports") {
+					return
+				}
+				// module.exports = exports = {}
+				if parent := utils.ESTreeParent(node); parent != nil && ast.IsAssignmentExpression(parent, false) &&
+					!utils.IsDefaultValueInDestructuringAssignment(parent) {
+					outer := parent.AsBinaryExpression()
+					if utils.ESTreeRuntimeExpression(outer.Right) == node && isModuleExports(outer.Left) {
+						return
+					}
+				}
+				// exports = module.exports = {}
+				if right := utils.ESTreeRuntimeExpression(assignment.Right); ast.IsAssignmentExpression(right, false) &&
+					isModuleExports(right.AsBinaryExpression().Left) {
+					return
+				}
+				ctx.ReportNode(node, rule.RuleMessage{
+					Id:          "forbidden",
+					Description: "Unexpected assignment to 'exports' variable. Use 'module.exports' instead.",
+				})
+			},
+		}
+	},
+}
+
+// Limit the fast path to expressions whose ancestors cannot introduce a
+// lexical scope. Blocks, functions, classes, namespaces and patterns use the
+// shared ESLint scope model instead of TypeScript's broader top-level test.
+func isDirectProgramExpression(node *ast.Node) bool {
+	for parent := utils.ESTreeParent(node); parent != nil; parent = utils.ESTreeParent(parent) {
+		switch parent.Kind {
+		case ast.KindBinaryExpression, ast.KindPropertyAccessExpression:
+			continue
+		case ast.KindExpressionStatement:
+			return parent.Parent != nil && parent.Parent.Kind == ast.KindSourceFile
+		default:
+			return false
+		}
+	}
+	return false
+}

--- a/internal/plugins/node/rules/no_exports_assign/no_exports_assign.md
+++ b/internal/plugins/node/rules/no_exports_assign/no_exports_assign.md
@@ -1,0 +1,64 @@
+# no-exports-assign
+
+Disallow assignments to the global `exports` variable.
+
+The `node` plugin ports this rule from `eslint-plugin-n`.
+
+## Rule Details
+
+Assigning a new value to `exports` does not replace the value exported by a
+CommonJS module. Assign to `module.exports` instead.
+
+Examples of **incorrect** code:
+
+```javascript
+exports = {};
+exports = { foo: 1 };
+```
+
+Examples of **correct** code:
+
+```javascript
+module.exports = { foo: 1 };
+module.exports.foo = 1;
+exports.bar = 2;
+
+module.exports = exports = {};
+exports = module.exports = {};
+
+function update(exports) {
+  exports = {};
+}
+```
+
+The rule checks assignment expressions, including compound assignments. It
+allows a chained assignment when the immediately enclosing or right-hand
+assignment targets the global `module.exports`. Computed access such as
+`module['exports']` does not qualify for this exception.
+
+Only variables belonging to the global scope are checked. Local parameters,
+imports, and other local bindings named `exports` are allowed.
+
+## Options
+
+This rule has no options and provides no automatic fixes or suggestions.
+
+Enable the bundled `node` plugin. CommonJS files supply `exports` and `module`
+globals automatically; other source types can configure them explicitly:
+
+```javascript
+export default [
+  {
+    plugins: ['node'],
+    languageOptions: {
+      globals: { exports: 'writable', module: 'readonly' },
+    },
+    rules: { 'node/no-exports-assign': 'error' },
+  },
+];
+```
+
+## References
+
+- [Upstream documentation](https://github.com/eslint-community/eslint-plugin-n/blob/v18.3.0/docs/rules/no-exports-assign.md)
+- [Upstream source](https://github.com/eslint-community/eslint-plugin-n/blob/v18.3.0/lib/rules/no-exports-assign.js)

--- a/internal/plugins/node/rules/no_exports_assign/no_exports_assign_extras_test.go
+++ b/internal/plugins/node/rules/no_exports_assign/no_exports_assign_extras_test.go
@@ -1,0 +1,193 @@
+package no_exports_assign
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// These additional cases were checked against eslint-plugin-n v18.3.0 with
+// ESLint 10.9.0 and @typescript-eslint/parser 8.65.0.
+
+// Globals and source types.
+func TestNoExportsAssignGlobals(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoExportsAssignRule,
+		[]rule_tester.ValidTestCase{
+			{Code: "exports = {}"},
+			{Code: "exports = {}", Globals: map[string]any{"exports": "off", "module": "readonly"}},
+			{Code: "/* global exports: off */ exports = {}", Globals: exportsGlobals},
+			{Code: "/* global module: readonly */ exports = module.exports = {}", Globals: map[string]any{"exports": "writable"}},
+			{Code: "var exports; exports = {}", Globals: exportsGlobals},
+			{Code: "var exports; exports = {}", FileName: "input.cjs", TSConfig: "tsconfig.allowJs.json", LanguageOptions: rule.LanguageOptions{SourceType: "commonjs"}},
+			// tsgo's implicit exports symbol is not an authored local binding.
+			{Code: "exports = module.exports = factory(); exports.foo = 1;", FileName: "input.cjs", TSConfig: "tsconfig.allowJs.json", LanguageOptions: rule.LanguageOptions{SourceType: "commonjs"}},
+			{Code: "var module; exports = module.exports = {}", LanguageOptions: rule.LanguageOptions{SourceType: "script"}, Globals: exportsGlobals},
+		},
+		[]rule_tester.InvalidTestCase{
+			{Code: "exports = {}", Globals: map[string]any{"exports": "readonly"}, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 1, 1, 13)}},
+			{Code: "/* global exports: writable */ exports = {}", Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 32, 1, 44)}},
+			{Code: "exports = module.exports = {}", Globals: map[string]any{"exports": "writable"}, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 1, 1, 30)}},
+			{Code: "module.exports = exports = {}", Globals: map[string]any{"exports": "writable", "module": "off"}, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 18, 1, 30)}},
+			{Code: "var exports; exports = {}", LanguageOptions: rule.LanguageOptions{SourceType: "script"}, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 14, 1, 26)}},
+			{Code: "let exports; exports = {}", LanguageOptions: rule.LanguageOptions{SourceType: "script"}, Globals: map[string]any{"exports": "off"}, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 14, 1, 26)}},
+			{Code: "exports = {}", FileName: "input.cjs", TSConfig: "tsconfig.allowJs.json", LanguageOptions: rule.LanguageOptions{SourceType: "commonjs"}, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 1, 1, 13)}},
+			{Code: "exports = {}; module.exports = {};", FileName: "input.cjs", TSConfig: "tsconfig.allowJs.json", LanguageOptions: rule.LanguageOptions{SourceType: "commonjs"}, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 1, 1, 13)}},
+			{Code: "/** @typedef {object} exports */ exports = {};", FileName: "input.js", TSConfig: "tsconfig.allowJs.json", Globals: exportsGlobals, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 34, 1, 46)}},
+			{Code: "var exports; exports = {}", FileName: "input.cts", LanguageOptions: rule.LanguageOptions{SourceType: "commonjs"}, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 14, 1, 26)}},
+			{Code: "var module; exports = module.exports = {}", Globals: exportsGlobals, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 13, 1, 42)}},
+		},
+	)
+}
+
+// Lexical scope ownership, including upstream syntactic lookup.
+func TestNoExportsAssignScopes(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoExportsAssignRule,
+		[]rule_tester.ValidTestCase{
+			{Code: "{ let exports; exports = {}; }", Globals: exportsGlobals},
+			{Code: "function f() { exports = {}; var exports; }", Globals: exportsGlobals},
+			{Code: "function f(value = exports = {}) { var exports; }", Globals: exportsGlobals},
+			{Code: "const f = (exports) => { exports = {}; };", Globals: exportsGlobals},
+			{Code: "const f = function exports() { exports = {}; };", Globals: exportsGlobals},
+			{Code: "try {} catch (exports) { exports = {}; }", Globals: exportsGlobals},
+			{Code: "class exports { static value = (exports = {}); }", Globals: exportsGlobals},
+			{Code: "class Example { static { let exports; exports = {}; } }", Globals: exportsGlobals},
+			{Code: "function f() { interface exports {} exports = {}; }", Globals: exportsGlobals},
+			{Code: "import exports from \"pkg\"; exports = {};", Globals: exportsGlobals},
+		},
+		[]rule_tester.InvalidTestCase{
+			{Code: "function f(module) { exports = module.exports = {}; }", Globals: exportsGlobals, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 22, 1, 51)}},
+			{Code: "function f(module) { module.exports = exports = {}; }", Globals: exportsGlobals, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 39, 1, 51)}},
+			{Code: "class Example { [exports = {}](exports) {} }", Globals: exportsGlobals, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 18, 1, 30)}},
+			{Code: "function f() { type module = object; exports = module.exports = {}; }", Globals: exportsGlobals, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 38, 1, 67)}},
+		},
+	)
+}
+
+// ESTree wrappers and chained assignments.
+func TestNoExportsAssignExpressions(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoExportsAssignRule,
+		[]rule_tester.ValidTestCase{
+			{Code: "module.exports = ((exports) = {});", Globals: exportsGlobals},
+			{Code: "(exports) = ((module).exports = {});", Globals: exportsGlobals},
+			{Code: "exports = ((module.exports) = {});", Globals: exportsGlobals},
+			{Code: "module.exports += exports ||= {};", Globals: exportsGlobals},
+			{Code: "exports &&= module.exports ||= {};", Globals: exportsGlobals},
+			{Code: "this.exports = {}; exports[\"x\"] = {};", Globals: exportsGlobals},
+			{Code: "(exports as any) = {}; exports! = {}; (exports satisfies object) = {};", Globals: exportsGlobals},
+			{Code: "module.exports = /** @type {object} */ (exports = {});", FileName: "input.js", TSConfig: "tsconfig.allowJs.json", Globals: exportsGlobals},
+		},
+		[]rule_tester.InvalidTestCase{
+			{Code: "  ((exports) = {});", Globals: exportsGlobals, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 4, 1, 18)}},
+			{Code: "exports = (0, module.exports = {});", Globals: exportsGlobals, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 1, 1, 35)}},
+			{Code: "module.exports = (0, exports = {});", Globals: exportsGlobals, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 22, 1, 34)}},
+			{Code: "exports = exports = {};", Globals: exportsGlobals, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 1, 1, 23), forbiddenAt(1, 11, 1, 23)}},
+			{Code: "module.exports = exports = exports = {};", Globals: exportsGlobals, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 28, 1, 40)}},
+			{Code: "exports = module[\"exports\"] = {};", Globals: exportsGlobals, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 1, 1, 33)}},
+			{Code: "module[\"exports\"] = exports = {};", Globals: exportsGlobals, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 21, 1, 33)}},
+			{Code: "exports = other.exports = {};", Globals: exportsGlobals, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 1, 1, 29)}},
+			{Code: "module.foo = exports = {};", Globals: exportsGlobals, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 14, 1, 26)}},
+			{Code: "exports = module.exports;", Globals: exportsGlobals, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 1, 1, 25)}},
+			{Code: "exports = module?.exports;", Globals: exportsGlobals, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 1, 1, 26)}},
+			{Code: "class Example { #exports; f() { exports = this.#exports = {}; } }", Globals: exportsGlobals, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 33, 1, 61)}},
+			{Code: "exports = (module.exports = {}) as object;", Globals: exportsGlobals, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 1, 1, 42)}},
+			{Code: "module.exports = ((exports = {}) as object);", Globals: exportsGlobals, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 20, 1, 32)}},
+			{Code: "(module as any).exports = exports = {};", Globals: exportsGlobals, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 27, 1, 39)}},
+			{Code: "/** @type {object} */ (exports) = {};", FileName: "input.js", TSConfig: "tsconfig.allowJs.json", Globals: exportsGlobals, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 23, 1, 37)}},
+		},
+	)
+}
+
+// Assignment patterns and nested runtime assignments.
+func TestNoExportsAssignPatterns(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoExportsAssignRule,
+		[]rule_tester.ValidTestCase{
+			{Code: "exports++; --exports; [exports] = values; ({exports} = value);", Globals: exportsGlobals},
+			{Code: "[exports = {}] = values; ({value: exports = {}} = input);", Globals: exportsGlobals},
+			{Code: "for ([exports = {}] of values) {}", Globals: exportsGlobals},
+		},
+		[]rule_tester.InvalidTestCase{
+			{Code: "({ [exports = {}]: target } = input);", Globals: exportsGlobals, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 5, 1, 17)}},
+			{Code: "[target = (exports = {})] = values;", Globals: exportsGlobals, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 12, 1, 24)}},
+			// The enclosing default is an AssignmentPattern, not an allowed
+			// module.exports AssignmentExpression.
+			{Code: "[module.exports = (exports = {})] = values;", Globals: exportsGlobals, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 20, 1, 32)}},
+			{Code: "({value: module.exports = exports = {}} = input);", Globals: exportsGlobals, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 27, 1, 39)}},
+			{Code: "({ target = exports = {} } = input);", Globals: exportsGlobals, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 13, 1, 25)}},
+			{Code: "const view = <Widget value={(exports = {})} />;", FileName: "input.tsx", Globals: exportsGlobals, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 30, 1, 42)}},
+		},
+	)
+}
+
+// Multiline and UTF-16 diagnostic ranges.
+func TestNoExportsAssignRanges(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoExportsAssignRule,
+		[]rule_tester.ValidTestCase{
+			{Code: "// eslint-disable-next-line\nexports = {};", Globals: exportsGlobals},
+		},
+		[]rule_tester.InvalidTestCase{
+			{Code: "/* 😀 */\n  exports = {\n    café: \"😀\"\n  };", Globals: exportsGlobals, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(2, 3, 4, 4)}},
+			{Code: "const 文 = \"😀\"; exports = {};", Globals: exportsGlobals, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 17, 1, 29)}},
+			{Code: "/* eslint-disable */\nexports = {};\n/* eslint-enable */\nexports = {};", Globals: exportsGlobals, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(4, 1, 4, 13)}},
+		},
+	)
+}
+
+// Every assignment operator.
+func TestNoExportsAssignOperators(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoExportsAssignRule,
+		[]rule_tester.ValidTestCase{},
+		[]rule_tester.InvalidTestCase{
+			{Code: "exports = value;", Globals: exportsGlobals, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 1, 1, 16)}},
+			{Code: "exports += value;", Globals: exportsGlobals, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 1, 1, 17)}},
+			{Code: "exports -= value;", Globals: exportsGlobals, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 1, 1, 17)}},
+			{Code: "exports *= value;", Globals: exportsGlobals, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 1, 1, 17)}},
+			{Code: "exports /= value;", Globals: exportsGlobals, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 1, 1, 17)}},
+			{Code: "exports %= value;", Globals: exportsGlobals, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 1, 1, 17)}},
+			{Code: "exports **= value;", Globals: exportsGlobals, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 1, 1, 18)}},
+			{Code: "exports <<= value;", Globals: exportsGlobals, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 1, 1, 18)}},
+			{Code: "exports >>= value;", Globals: exportsGlobals, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 1, 1, 18)}},
+			{Code: "exports >>>= value;", Globals: exportsGlobals, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 1, 1, 19)}},
+			{Code: "exports |= value;", Globals: exportsGlobals, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 1, 1, 17)}},
+			{Code: "exports ^= value;", Globals: exportsGlobals, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 1, 1, 17)}},
+			{Code: "exports &= value;", Globals: exportsGlobals, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 1, 1, 17)}},
+			{Code: "exports &&= value;", Globals: exportsGlobals, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 1, 1, 18)}},
+			{Code: "exports ||= value;", Globals: exportsGlobals, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 1, 1, 18)}},
+			{Code: "exports ??= value;", Globals: exportsGlobals, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 1, 1, 18)}},
+		},
+	)
+}
+
+// Escaped names, TypeScript declaration spaces, decorators and runtime
+// assignments nested in patterns were compared with the pinned upstream rule.
+func TestNoExportsAssignAdditionalSyntax(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoExportsAssignRule,
+		[]rule_tester.ValidTestCase{
+			{Code: "exports = " + strings.ReplaceAll("module.exports", "o", "\\u006f") + " = {};", Globals: exportsGlobals},
+			{Code: "for (let exports of values) { exports = {}; }", Globals: exportsGlobals},
+			{Code: "namespace A { let exports; exports = {}; }", Globals: exportsGlobals},
+			{Code: "enum Example { exports = (exports = {}) }", Globals: exportsGlobals},
+			{Code: "class Example<exports> { method() { exports = {}; } }", Globals: exportsGlobals},
+			{Code: "function f<exports>() { exports = {}; }", Globals: exportsGlobals},
+			{Code: "export {}; declare global { var exports: object; } exports = {};"},
+			{Code: "class Example { method(@decorate(exports = {}) exports) {} }", Globals: exportsGlobals},
+		},
+		[]rule_tester.InvalidTestCase{
+			{Code: strings.ReplaceAll("exports = {};", "o", "\\u006f"), Globals: exportsGlobals, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 1, 1, 18)}},
+			{Code: "{ var exports; } exports = {};", LanguageOptions: rule.LanguageOptions{SourceType: "script"}, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 18, 1, 30)}},
+			{Code: "function exports() { exports = {}; }", LanguageOptions: rule.LanguageOptions{SourceType: "script"}, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 22, 1, 34)}},
+			{Code: "namespace A.B { exports = {}; }", Globals: exportsGlobals, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 17, 1, 29)}},
+			{Code: "namespace A { export const module = {}; exports = module.exports = {}; }", Globals: exportsGlobals, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 41, 1, 70)}},
+			{Code: "enum Example { Value = (exports = {}) }", Globals: exportsGlobals, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 25, 1, 37)}},
+			{Code: "@decorate(exports = {}) class Example {}", Globals: exportsGlobals, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 11, 1, 23)}},
+			{Code: "class Example { @decorate(exports = {}) method(exports) {} }", Globals: exportsGlobals, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 27, 1, 39)}},
+			{Code: "with (object) { exports = {}; }", FileName: "input.js", TSConfig: "tsconfig.allowJs.json", LanguageOptions: rule.LanguageOptions{SourceType: "script"}, Globals: exportsGlobals, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 17, 1, 29)}},
+			{Code: "[exports] = [(exports = {})];", Globals: exportsGlobals, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 15, 1, 27)}},
+			{Code: "function f({ value = (exports = {}) }) {}", Globals: exportsGlobals, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 23, 1, 35)}},
+			{Code: "for (exports = {};;) { break; }", Globals: exportsGlobals, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 6, 1, 18)}},
+			{Code: "for ([module.exports = exports = {}] of values) {}", Globals: exportsGlobals, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 24, 1, 36)}},
+		},
+	)
+}

--- a/internal/plugins/node/rules/no_exports_assign/no_exports_assign_upstream_test.go
+++ b/internal/plugins/node/rules/no_exports_assign/no_exports_assign_upstream_test.go
@@ -1,0 +1,55 @@
+package no_exports_assign
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+var exportsGlobals = map[string]any{"exports": "writable", "module": "readonly"}
+
+func forbiddenAt(line, column, endLine, endColumn int) rule_tester.InvalidTestCaseError {
+	return rule_tester.InvalidTestCaseError{
+		MessageId: "forbidden",
+		Message:   "Unexpected assignment to 'exports' variable. Use 'module.exports' instead.",
+		Line:      line, Column: column, EndLine: endLine, EndColumn: endColumn,
+	}
+}
+
+// Every case from https://github.com/eslint-community/eslint-plugin-n/blob/v18.3.0/tests/lib/rules/no-exports-assign.js
+func TestNoExportsAssignUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoExportsAssignRule,
+		[]rule_tester.ValidTestCase{
+			{Code: "module.exports.foo = 1", Globals: exportsGlobals},
+			{Code: "exports.bar = 1", Globals: exportsGlobals},
+			{Code: "module.exports = exports = {}", Globals: exportsGlobals},
+			{Code: "exports = module.exports = {}", Globals: exportsGlobals},
+			{Code: "function f(exports) { exports = {} }", Globals: exportsGlobals},
+		},
+		[]rule_tester.InvalidTestCase{
+			{Code: "exports = {}", Globals: exportsGlobals, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 1, 1, 13)}},
+		},
+	)
+}
+
+// Every JavaScript example from https://github.com/eslint-community/eslint-plugin-n/blob/v18.3.0/docs/rules/no-exports-assign.md
+// The documentation's rule-enabling comments are omitted; the tester enables the rule.
+func TestNoExportsAssignDocumentation(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoExportsAssignRule,
+		[]rule_tester.ValidTestCase{
+			{Code: `module.exports.foo = 1
+exports.bar = 2
+
+module.exports = {}
+
+// allows ` + "`exports = {}`" + ` if along with ` + "`module.exports =`" + `
+module.exports = exports = {}
+exports = module.exports = {}`, Globals: exportsGlobals},
+		},
+		[]rule_tester.InvalidTestCase{
+			{Code: "// This assigned object is not exported.\n// You need to use `module.exports = { ... }`.\nexports = {\n    foo: 1\n}", Globals: exportsGlobals, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(3, 1, 5, 2)}},
+			{Code: "exports = {}", Globals: exportsGlobals, Errors: []rule_tester.InvalidTestCaseError{forbiddenAt(1, 1, 1, 13)}},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstack.config.mts
+++ b/packages/rslint-test-tools/rstack.config.mts
@@ -169,6 +169,7 @@ define.test({
     './tests/eslint/rules/no-warning-comments.test.ts',
     // eslint-plugin-node
     './tests/eslint-plugin-node/rules/hashbang.test.ts',
+    './tests/eslint-plugin-node/rules/no-exports-assign.test.ts',
 
     // eslint-plugin-import
     './tests/eslint-plugin-import/rules/default.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-node/rule-tester.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-node/rule-tester.ts
@@ -3,13 +3,22 @@ import { afterAll, beforeAll, describe, expect, test } from 'rstack/test';
 import { lint } from '@rslint/core/internal';
 import { createTempDir, cleanupTempDir } from '../cli/js-config/helpers';
 
+interface ExpectedError {
+  messageId: string;
+  message: string;
+  line: number;
+  column: number;
+  endLine: number;
+  endColumn: number;
+}
+
 interface TestCase {
   name?: string;
   code: string;
   filename?: string;
   options?: unknown[];
   settings?: Record<string, unknown>;
-  errors?: string[];
+  errors?: (string | ExpectedError)[];
   output?: string;
 }
 
@@ -26,6 +35,15 @@ const packages = {
 };
 
 export class RuleTester {
+  constructor(
+    private readonly config: {
+      languageOptions?: {
+        globals?: Record<string, 'readonly' | 'writable' | 'off'>;
+        sourceType?: 'script' | 'module' | 'commonjs';
+      };
+    } = {},
+  ) {}
+
   run(
     name: string,
     _rule: unknown,
@@ -62,7 +80,10 @@ export class RuleTester {
               config: [
                 {
                   plugins: ['node'],
-                  languageOptions: { parserOptions: { projectService: false } },
+                  languageOptions: {
+                    ...this.config.languageOptions,
+                    parserOptions: { projectService: false },
+                  },
                   settings: item.settings,
                   rules: {
                     [`node/${name}`]: ['error', ...(item.options ?? [])],
@@ -75,8 +96,23 @@ export class RuleTester {
             expect(result.fileCount).toBe(1);
             expect(result.ruleCount).toBe(1);
             expect(result.diagnostics).toHaveLength(item.errors?.length ?? 0);
-            for (const [i, message] of (item.errors ?? []).entries()) {
+            for (const [i, expected] of (item.errors ?? []).entries()) {
               const diagnostic = result.diagnostics[i];
+              expect(diagnostic.ruleName).toBe(`node/${name}`);
+              expect(diagnostic.suggestions).toBeUndefined();
+              if (typeof expected !== 'string') {
+                expect(diagnostic.message).toBe(expected.message);
+                expect(diagnostic.messageId).toBe(expected.messageId);
+                expect(diagnostic.range).toEqual({
+                  start: { line: expected.line, column: expected.column },
+                  end: { line: expected.endLine, column: expected.endColumn },
+                });
+                expect(diagnostic.fixes).toBeUndefined();
+                continue;
+              }
+              // Hashbang's upstream string expectations describe a fix on
+              // the complete first line.
+              const message = expected;
               const messageId = message.includes('needs shebang')
                 ? 'expectedHashbangNode'
                 : message.includes('needs no shebang')
@@ -84,7 +120,6 @@ export class RuleTester {
                   : message.includes('Unicode BOM')
                     ? 'unexpectedBOM'
                     : 'expectedLF';
-              expect(diagnostic.ruleName).toBe(`node/${name}`);
               expect(diagnostic.message).toBe(message);
               expect(diagnostic.messageId).toBe(messageId);
               expect(diagnostic.range).toEqual({
@@ -98,7 +133,6 @@ export class RuleTester {
                 },
               });
               expect(diagnostic.fixes?.length).toBe(1);
-              expect(diagnostic.suggestions).toBeUndefined();
             }
             if (item.output !== undefined) {
               const fixed = await lint({ ...request, fix: true });

--- a/packages/rslint-test-tools/tests/eslint-plugin-node/rules/no-exports-assign.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-node/rules/no-exports-assign.test.ts
@@ -1,0 +1,72 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    globals: { exports: 'writable', module: 'readonly' },
+  },
+});
+
+const forbidden = {
+  messageId: 'forbidden',
+  message:
+    "Unexpected assignment to 'exports' variable. Use 'module.exports' instead.",
+  line: 1,
+  column: 1,
+  endLine: 1,
+  endColumn: 13,
+};
+
+// Every case from eslint-plugin-n v18.3.0:
+// https://github.com/eslint-community/eslint-plugin-n/blob/v18.3.0/tests/lib/rules/no-exports-assign.js
+ruleTester.run(
+  'no-exports-assign',
+  {},
+  {
+    valid: [
+      { name: 'module property', code: 'module.exports.foo = 1' },
+      { name: 'exports property', code: 'exports.bar = 1' },
+      {
+        name: 'outer module assignment',
+        code: 'module.exports = exports = {}',
+      },
+      {
+        name: 'inner module assignment',
+        code: 'exports = module.exports = {}',
+      },
+      {
+        name: 'shadowed parameter',
+        code: 'function f(exports) { exports = {} }',
+      },
+      // Correct example from the documentation at the same tag.
+      {
+        name: 'documentation: correct',
+        code: `module.exports.foo = 1
+exports.bar = 2
+
+module.exports = {}
+
+// allows \`exports = {}\` if along with \`module.exports =\`
+module.exports = exports = {}
+exports = module.exports = {}`,
+      },
+    ],
+    invalid: [
+      { name: 'global assignment', code: 'exports = {}', errors: [forbidden] },
+      // Both incorrect examples from the documentation at the same tag.
+      {
+        name: 'documentation: object is not exported',
+        code: `// This assigned object is not exported.
+// You need to use \`module.exports = { ... }\`.
+exports = {
+    foo: 1
+}`,
+        errors: [{ ...forbidden, line: 3, endLine: 5, endColumn: 2 }],
+      },
+      {
+        name: 'documentation: incorrect',
+        code: 'exports = {}',
+        errors: [forbidden],
+      },
+    ],
+  },
+);


### PR DESCRIPTION
## Summary

Refs #475.

Add the bundled `node/no-exports-assign` rule from eslint-plugin-n v18.3.0. It reports assignments such as `exports = {}` while preserving the allowed `module.exports = exports = {}` and `exports = module.exports = {}` chains. The rule has no options, fixes, or suggestions and uses the established `node/` namespace.

Reuse rslint's globals, RefStore, ESLint scope model, and ESTree wrapper/default-pattern helpers, plus tsgo's assignment checks and bound locals. Skip modules without an enabled global `exports` and avoid constructing scopes for direct program expressions with no authored binding; nested scopes retain upstream's syntactic lookup semantics.

Preserve all 6 upstream tests and 3 documentation examples, with 107 Go extras covering scope ownership, CommonJS synthetic bindings, type-only declarations, decorators, escaped identifiers, destructuring defaults, wrappers, UTF-16 ranges, and suppression directives. Extend the node JS tester to assert exact diagnostic IDs, messages, ranges, and absent edits.

### Validation

- `go test ./internal/plugins/node/rules/no_exports_assign -count=3`
- `go test ./internal/rules -run '^TestAllContainsEveryGoRuleExactlyOnce$'`
- `golangci-lint run --new-from-merge-base=origin/main ./internal/plugins/node ./internal/plugins/node/rules/no_exports_assign`
- Rebuilt the native binary, refreshed the schema dump, and built core JS/public option types.
- `CI=true pnpm --dir packages/rslint-test-tools exec rs test run tests/eslint-plugin-node/rules/no-exports-assign.test.ts tests/eslint-plugin-node/rules/hashbang.test.ts` — 78 tests passed. Reverified the new rule's 9 JS tests after the final Go implementation changed.
- Compared the pinned upstream rule using ESLint 10.9.0 and typescript-eslint/parser 8.65.0 against the source-only rslint API: 4 real CommonJS files (semver 5.7.2, semver 7.8.5, debug 4.4.3, ms 2.1.3), 1 known positive file, and all 107 additional cases. No differences in normalized paths/rule names, IDs, messages, severity, complete ranges, fixes, or suggestions. Every request asserted file and rule coverage.
- `pnpm run format:check`, spell-check with all changed text paths, and `git diff --check` passed.

## Related Links

- [Pinned upstream rule](https://github.com/eslint-community/eslint-plugin-n/blob/v18.3.0/lib/rules/no-exports-assign.js)
- [Pinned upstream tests](https://github.com/eslint-community/eslint-plugin-n/blob/v18.3.0/tests/lib/rules/no-exports-assign.js)
- [Pinned upstream documentation](https://github.com/eslint-community/eslint-plugin-n/blob/v18.3.0/docs/rules/no-exports-assign.md)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
