### PR TITLE
feat(tsgo): add config subcommand for final compiler options

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -1536,6 +1536,16 @@ String plugin declarations select bundled Go plugin namespaces. Live third-party
 - **WASM Playground**: `packages/rslint-wasm` runs the API server in a browser worker
 - **Rust Client**: `crates/tsgo-client` consumes `cmd/tsgo`
 
+`cmd/tsgo` dispatches two one-shot subcommands, each parsing its own options.
+`project --api --config <path>` returns the existing binary project information;
+the Rust client selects this command, and flag-only invocations remain compatible.
+`config --config <path>` resolves tsconfig inheritance and prints
+`FinalCompilerOptions` directly as JSON for JavaScript consumers to `JSON.parse`.
+This command includes defaults and implied values for the exported option subset,
+without creating a Program or checking source code. Parsing errors go to stderr
+with a nonzero exit code. Both commands default to `tsconfig.json` in the working
+directory and use the same pinned compiler without its JavaScript API.
+
 ### Future Enhancements
 
 The current architecture already leaves room for:

--- a/cmd/tsgo/config.go
+++ b/cmd/tsgo/config.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/microsoft/TypeScript/tsc/shim/core"
+	"github.com/microsoft/TypeScript/tsc/shim/tsoptions"
+	"github.com/microsoft/TypeScript/tsc/shim/tspath"
+	"github.com/microsoft/TypeScript/tsc/shim/vfs/cachedvfs"
+	"github.com/microsoft/TypeScript/tsc/shim/vfs/osvfs"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// FinalCompilerOptions contains resolved values for consumers checking compiler
+// assumptions, including defaults and implied options.
+type FinalCompilerOptions struct {
+	Target                       string `json:"target"`
+	Strict                       bool   `json:"strict"`
+	NoImplicitAny                bool   `json:"noImplicitAny"`
+	NoImplicitThis               bool   `json:"noImplicitThis"`
+	StrictNullChecks             bool   `json:"strictNullChecks"`
+	StrictFunctionTypes          bool   `json:"strictFunctionTypes"`
+	StrictBindCallApply          bool   `json:"strictBindCallApply"`
+	StrictPropertyInitialization bool   `json:"strictPropertyInitialization"`
+	StrictBuiltinIteratorReturn  bool   `json:"strictBuiltinIteratorReturn"`
+	UseUnknownInCatchVariables   bool   `json:"useUnknownInCatchVariables"`
+	VerbatimModuleSyntax         bool   `json:"verbatimModuleSyntax"`
+	IsolatedModules              bool   `json:"isolatedModules"`
+	UseDefineForClassFields      bool   `json:"useDefineForClassFields"`
+	NoUncheckedIndexedAccess     bool   `json:"noUncheckedIndexedAccess"`
+}
+
+func finalCompilerOptions(options *core.CompilerOptions) FinalCompilerOptions {
+	return FinalCompilerOptions{
+		Target:                       strings.ToLower(options.GetEmitScriptTarget().String()),
+		Strict:                       options.GetStrictOptionValue(core.TSUnknown),
+		NoImplicitAny:                options.GetStrictOptionValue(options.NoImplicitAny),
+		NoImplicitThis:               options.GetStrictOptionValue(options.NoImplicitThis),
+		StrictNullChecks:             options.GetStrictOptionValue(options.StrictNullChecks),
+		StrictFunctionTypes:          options.GetStrictOptionValue(options.StrictFunctionTypes),
+		StrictBindCallApply:          options.GetStrictOptionValue(options.StrictBindCallApply),
+		StrictPropertyInitialization: options.GetStrictOptionValue(options.StrictPropertyInitialization),
+		StrictBuiltinIteratorReturn:  options.GetStrictOptionValue(options.StrictBuiltinIteratorReturn),
+		UseUnknownInCatchVariables:   options.GetStrictOptionValue(options.UseUnknownInCatchVariables),
+		VerbatimModuleSyntax:         options.VerbatimModuleSyntax.IsTrue(),
+		IsolatedModules:              options.GetIsolatedModules(),
+		UseDefineForClassFields:      options.GetUseDefineForClassFields(),
+		NoUncheckedIndexedAccess:     options.NoUncheckedIndexedAccess.IsTrue(),
+	}
+}
+
+func runConfig(args []string, stdout, stderr io.Writer) int {
+	flags := flag.NewFlagSet("config", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	var configPath string
+	flags.StringVar(&configPath, "config", "tsconfig.json", "path to tsconfig.json, relative to the working directory")
+	flags.Usage = func() {
+		fmt.Fprintln(stderr, "Usage: tsgo config [options]")
+		flags.PrintDefaults()
+	}
+	if err := flags.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if flags.NArg() != 0 {
+		fmt.Fprintln(stderr, "unexpected positional arguments:", strings.Join(flags.Args(), " "))
+		return 2
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	cwd = tspath.NormalizePath(cwd)
+	configPath = tspath.ResolvePath(cwd, configPath)
+	host := utils.CreateCompilerHost(cwd, cachedvfs.From(osvfs.FS()))
+	config, diagnostics := tsoptions.GetParsedCommandLineOfConfigFile(configPath, &core.CompilerOptions{}, nil, host, nil)
+	if config != nil {
+		diagnostics = append(diagnostics, config.GetConfigFileParsingDiagnostics()...)
+	}
+	if len(diagnostics) > 0 {
+		for _, diagnostic := range diagnostics {
+			path := configPath
+			if diagnostic.File() != nil {
+				path = diagnostic.File().FileName()
+			}
+			fmt.Fprintf(stderr, "%s: TS%d: %s\n", path, diagnostic.Code(), diagnostic.String())
+		}
+		return 1
+	}
+	encoder := json.NewEncoder(stdout)
+	if err := encoder.Encode(finalCompilerOptions(config.CompilerOptions())); err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	return 0
+}

--- a/cmd/tsgo/main.go
+++ b/cmd/tsgo/main.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
+	"fmt"
+	"io"
 	"log"
 	"os"
 	"strings"
@@ -147,19 +150,60 @@ func printDiagnostics(diagnostics []Diagnostics, fileMap map[string]int32) {
 	log.Println()
 }
 func runMain() int {
-	var (
-		config   string
-		help     bool
-		api_mode bool
-	)
-	flag.StringVar(&config, "config", "", "path to tsconfig.json")
-	flag.BoolVar(&help, "help", false, "show help")
-	flag.BoolVar(&api_mode, "api", false, "api mode")
-	flag.Parse()
-	if help {
-		flag.Usage()
+	return run(os.Args[1:], os.Stdout, os.Stderr)
+}
+
+func run(args []string, stdout, stderr io.Writer) int {
+	usage := func() {
+		fmt.Fprintln(stderr, "Usage: tsgo <project|config> [options]")
+		fmt.Fprintln(stderr, "  project  Load AST, types, symbols, and diagnostics (--api emits CBOR)")
+		fmt.Fprintln(stderr, "  config   Resolve final compiler options as JSON without type checking")
+	}
+	if len(args) == 0 {
+		usage()
 		return 0
 	}
+	switch args[0] {
+	case "project":
+		return runProject(args[1:], stdout, stderr)
+	case "config":
+		return runConfig(args[1:], stdout, stderr)
+	case "--help", "-help", "-h":
+		usage()
+		return 0
+	default:
+		// Flag-only invocations remain compatible with existing tsgo clients.
+		if strings.HasPrefix(args[0], "-") {
+			return runProject(args, stdout, stderr)
+		}
+		fmt.Fprintf(stderr, "unknown command %q\n", args[0])
+		usage()
+		return 2
+	}
+}
+
+func runProject(args []string, stdout, stderr io.Writer) int {
+	flags := flag.NewFlagSet("project", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	var config string
+	var apiMode bool
+	flags.StringVar(&config, "config", "tsconfig.json", "path to tsconfig.json, relative to the working directory")
+	flags.BoolVar(&apiMode, "api", false, "emit project information as CBOR")
+	flags.Usage = func() {
+		fmt.Fprintln(stderr, "Usage: tsgo project [options]")
+		flags.PrintDefaults()
+	}
+	if err := flags.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if flags.NArg() != 0 {
+		fmt.Fprintln(stderr, "unexpected positional arguments:", strings.Join(flags.Args(), " "))
+		return 2
+	}
+
 	program, err := CreateProgram(config)
 	if err != nil {
 		log.Printf("error creating program: %v", err)
@@ -232,7 +276,7 @@ func runMain() int {
 	}
 	checkResult.Diagnostics = getDiagnostics(diagnostics, &fileMap)
 
-	if !api_mode {
+	if !apiMode {
 		// Print diagnostics in human-readable format
 		printDiagnostics(checkResult.Diagnostics, fileMap)
 		if len(checkResult.Diagnostics) > 0 {
@@ -246,7 +290,7 @@ func runMain() int {
 		log.Printf("error marshaling checkResult: %v", err)
 		return 1
 	}
-	_, err = os.Stdout.Write(result)
+	_, err = stdout.Write(result)
 	if err != nil {
 		log.Printf("error writing result to stdout: %v", err)
 		return 1

--- a/crates/tsgo-client/src/client.rs
+++ b/crates/tsgo-client/src/client.rs
@@ -49,7 +49,7 @@ pub enum ProtocolError {
 impl Client {
     pub fn builder(exe: &OsStr, options: Options) -> Builder {
         let mut cmd = process::Command::new(exe);
-        cmd.arg("--api");
+        cmd.args(["project", "--api"]);
         Client::with_command(cmd, options)
     }
 

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -746,3 +746,4 @@ prerender
 reparses
 batgo
 Swatinem
+CBOR


### PR DESCRIPTION
## Summary

Add `tsgo config --config <path>` so JavaScript consumers can obtain final compiler options through `JSON.parse(stdout)` without loading project ASTs, running type checking, or depending on the TypeScript JavaScript API. The command resolves inheritance using the pinned compiler and exports the selected options with their defaults and implied values, including explicit overrides such as `strictNullChecks: false`. Configuration parsing errors go to stderr with a nonzero exit code.

Move existing project information retrieval to `tsgo project --api`, with each subcommand parsing its own options. Preserve flag-only invocations for existing clients and update the Rust builder to select `project --api`; no Rust configuration API or dependency is added.

## Validation

- `go test ./cmd/tsgo` passed.
- `cargo test -p tsgo-client test_tsgo_integration_simple_project` passed.
- Node CLI smoke checks passed for direct JSON parsing, inherited and implied options, explicit false values, invalid source code, missing configuration, subcommand argument handling, and legacy project invocation.
- `pnpm run format:check` and `pnpm run check-spell` with explicit changed-file paths passed; Go and Rust formatting checks passed.
- Go lint was not run because `golangci-lint` is not installed locally. Configuration checks were exercised manually; this PR does not add checked-in regression tests.

## Related Links

None.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).