### PR TITLE
feat: port rule unicorn/prefer-date-now

### DIFF
--- a/internal/plugins/unicorn/all.go
+++ b/internal/plugins/unicorn/all.go
@@ -36,6 +36,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_array_flat_map"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_array_some"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_blob_reading_methods"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_date_now"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_node_protocol"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_number_properties"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_set_has"
@@ -85,6 +86,7 @@ func GetAllRules() []rule.Rule {
 		prefer_array_flat_map.PreferArrayFlatMapRule,
 		prefer_array_some.PreferArraySomeRule,
 		prefer_blob_reading_methods.PreferBlobReadingMethodsRule,
+		prefer_date_now.PreferDateNowRule,
 		prefer_node_protocol.PreferNodeProtocolRule,
 		prefer_number_properties.PreferNumberPropertiesRule,
 		prefer_set_has.PreferSetHasRule,

--- a/internal/plugins/unicorn/rules/prefer_date_now/prefer_date_now.go
+++ b/internal/plugins/unicorn/rules/prefer_date_now/prefer_date_now.go
@@ -1,0 +1,109 @@
+package prefer_date_now
+
+import (
+	"github.com/microsoft/TypeScript/tsc/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/unicornutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+var preferDateMessage = rule.RuleMessage{
+	Id:          "prefer-date",
+	Description: "Prefer `Date.now()` over `new Date()`.",
+}
+
+func isNewDate(node *ast.Node) bool {
+	if node == nil || !ast.IsNewExpression(node) || len(node.Arguments()) != 0 {
+		return false
+	}
+	callee := utils.ESTreeRuntimeExpression(node.Expression())
+	return callee != nil && ast.IsIdentifier(callee) && callee.Text() == "Date"
+}
+
+// https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/rules/prefer-date-now.js
+var PreferDateNowRule = rule.Rule{
+	Name:   "unicorn/prefer-date-now",
+	Schema: rule.EmptyArraySchema,
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		report := func(node, replacement *ast.Node, message rule.RuleMessage) {
+			ctx.ReportNodeWithDeferredFixes(node, message, func() []rule.RuleFix {
+				fixes := []rule.RuleFix{rule.RuleFixReplace(ctx.SourceFile, replacement, "Date.now()")}
+				if replacement.Kind == ast.KindPrefixUnaryExpression {
+					fixes = append(fixes, unicornutil.SpaceAroundKeywordFixes(ctx.SourceFile, replacement)...)
+				}
+				return fixes
+			})
+		}
+		reportDate := func(node *ast.Node) {
+			node = utils.ESTreeRuntimeExpression(node)
+			if isNewDate(node) {
+				report(node, node, preferDateMessage)
+			}
+		}
+
+		zeroArguments := 0
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				if method, ok := unicornutil.MatchDotMethodCall(node, unicornutil.DotMethodCallOptions{
+					Methods:         []string{"getTime", "valueOf"},
+					ArgumentsLength: &zeroArguments,
+				}); ok && isNewDate(utils.ESTreeRuntimeExpression(method.Object)) {
+					report(method.Property, node, rule.RuleMessage{
+						Id:          "prefer-date-now-over-methods",
+						Description: "Prefer `Date.now()` over `Date#" + method.Property.Text() + "()`.",
+					})
+					return
+				}
+
+				if ast.IsOptionalChainRoot(node) || len(node.Arguments()) != 1 {
+					return
+				}
+				callee := utils.ESTreeCallCallee(node.Expression())
+				if callee == nil || !ast.IsIdentifier(callee) {
+					return
+				}
+				date := utils.ESTreeRuntimeExpression(node.Arguments()[0])
+				if !isNewDate(date) {
+					return
+				}
+				switch callee.Text() {
+				case "Number":
+					report(node, node, rule.RuleMessage{
+						// Preserve the upstream message ID, including "data".
+						Id:          "prefer-date-now-over-number-data-object",
+						Description: "Prefer `Date.now()` over `Number(new Date())`.",
+					})
+				case "BigInt":
+					report(date, date, preferDateMessage)
+				}
+			},
+			ast.KindPrefixUnaryExpression: func(node *ast.Node) {
+				unary := node.AsPrefixUnaryExpression()
+				if unary.Operator != ast.KindPlusToken && unary.Operator != ast.KindMinusToken {
+					return
+				}
+				date := utils.ESTreeRuntimeExpression(unary.Operand)
+				if !isNewDate(date) {
+					return
+				}
+				if unary.Operator == ast.KindPlusToken {
+					report(node, node, preferDateMessage)
+				} else {
+					report(date, date, preferDateMessage)
+				}
+			},
+			ast.KindBinaryExpression: func(node *ast.Node) {
+				binary := node.AsBinaryExpression()
+				switch binary.OperatorToken.Kind {
+				case ast.KindMinusToken, ast.KindAsteriskToken, ast.KindSlashToken,
+					ast.KindPercentToken, ast.KindAsteriskAsteriskToken:
+					reportDate(binary.Left)
+					reportDate(binary.Right)
+				case ast.KindMinusEqualsToken, ast.KindAsteriskEqualsToken, ast.KindSlashEqualsToken,
+					ast.KindPercentEqualsToken, ast.KindAsteriskAsteriskEqualsToken:
+					reportDate(binary.Right)
+				}
+			},
+		}
+	},
+}

--- a/internal/plugins/unicorn/rules/prefer_date_now/prefer_date_now.go
+++ b/internal/plugins/unicorn/rules/prefer_date_now/prefer_date_now.go
@@ -48,9 +48,11 @@ var PreferDateNowRule = rule.Rule{
 					Methods:         []string{"getTime", "valueOf"},
 					ArgumentsLength: &zeroArguments,
 				}); ok && isNewDate(utils.ESTreeRuntimeExpression(method.Object)) {
+					methodName := method.Property.Text()
 					report(method.Property, node, rule.RuleMessage{
 						Id:          "prefer-date-now-over-methods",
-						Description: "Prefer `Date.now()` over `Date#" + method.Property.Text() + "()`.",
+						Description: "Prefer `Date.now()` over `Date#" + methodName + "()`.",
+						Data:        map[string]string{"method": methodName},
 					})
 					return
 				}

--- a/internal/plugins/unicorn/rules/prefer_date_now/prefer_date_now.md
+++ b/internal/plugins/unicorn/rules/prefer_date_now/prefer_date_now.md
@@ -1,0 +1,45 @@
+# prefer-date-now
+
+## Rule Details
+
+Prefer `Date.now()` when reading the current timestamp. This avoids creating
+a `Date` object only to convert it into the number of milliseconds since the
+Unix Epoch.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+const timestamp = new Date().getTime();
+const value = new Date().valueOf();
+const number = Number(new Date());
+const coerced = +new Date();
+const elapsed = new Date() - start;
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+const timestamp = Date.now();
+const value = Date.now();
+const number = Date.now();
+const coerced = Date.now();
+const elapsed = Date.now() - start;
+```
+
+The rule also checks unary minus, `BigInt(new Date())`, and the numeric
+operators `-`, `*`, `/`, `%`, and `**`, including their assignment forms.
+Automatic fixes preserve the surrounding conversion or arithmetic operation.
+
+Only argument-free `new Date()` expressions are checked. Date construction
+with arguments, optional method calls, computed method names, addition, and
+bitwise operations are left unchanged. The rule is syntax-based: a locally
+declared constructor named `Date` is treated the same as the built-in.
+
+## Options
+
+This rule has no options.
+
+## Original Documentation
+
+- [eslint-plugin-unicorn: prefer-date-now](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/docs/rules/prefer-date-now.md)
+- [Source code](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/rules/prefer-date-now.js)

--- a/internal/plugins/unicorn/rules/prefer_date_now/prefer_date_now.md
+++ b/internal/plugins/unicorn/rules/prefer_date_now/prefer_date_now.md
@@ -6,6 +6,8 @@ Prefer `Date.now()` when reading the current timestamp. This avoids creating
 a `Date` object only to convert it into the number of milliseconds since the
 Unix Epoch.
 
+This rule is enabled in the Unicorn recommended preset.
+
 Examples of **incorrect** code for this rule:
 
 ```javascript

--- a/internal/plugins/unicorn/rules/prefer_date_now/prefer_date_now_extras_test.go
+++ b/internal/plugins/unicorn/rules/prefer_date_now/prefer_date_now_extras_test.go
@@ -76,8 +76,26 @@ func TestPreferDateNowExtras(t *testing.T) {
 }
 
 func TestPreferDateNowEditDemand(t *testing.T) {
-	const source = `function clock(){return(/** @type {number} */ (+new Date))in {}}`
-	const fixedSource = `function clock(){return (/** @type {number} */ (Date.now())) in {}}`
+	t.Run("keyword spacing", func(t *testing.T) {
+		testPreferDateNowEditDemand(t,
+			`function clock(){return(/** @type {number} */ (+new Date))in {}}`,
+			`function clock(){return (/** @type {number} */ (Date.now())) in {}}`,
+			rule.RuleMessage{Id: dateMessageID, Description: "Prefer `Date.now()` over `new Date()`."},
+		)
+	})
+	for _, method := range []string{"getTime", "valueOf"} {
+		t.Run(method, func(t *testing.T) {
+			testPreferDateNowEditDemand(t, "new Date()."+method+"()", "Date.now()", rule.RuleMessage{
+				Id:          methodMessageID,
+				Description: "Prefer `Date.now()` over `Date#" + method + "()`.",
+				Data:        map[string]string{"method": method},
+			})
+		})
+	}
+}
+
+func testPreferDateNowEditDemand(t *testing.T, source, fixedSource string, message rule.RuleMessage) {
+	t.Helper()
 	root := fixtures.GetRootDir()
 	fileName := tspath.ResolvePath(root.Dir, "edit-demand.js")
 	fs := utils.NewOverlayVFS(root.FS, map[string]string{fileName: source})
@@ -112,6 +130,9 @@ func TestPreferDateNowEditDemand(t *testing.T) {
 		diagnostics[demand] = got[0]
 	}
 	base := diagnostics[rule.EditDemandNone]
+	if !reflect.DeepEqual(base.Message, message) {
+		t.Fatalf("message = %#v, want %#v", base.Message, message)
+	}
 	for demand, diagnostic := range diagnostics {
 		metadata := diagnostic
 		metadata.FixesPtr = nil

--- a/internal/plugins/unicorn/rules/prefer_date_now/prefer_date_now_extras_test.go
+++ b/internal/plugins/unicorn/rules/prefer_date_now/prefer_date_now_extras_test.go
@@ -1,0 +1,144 @@
+package prefer_date_now_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/microsoft/TypeScript/tsc/shim/ast"
+	"github.com/microsoft/TypeScript/tsc/shim/tspath"
+	"github.com/web-infra-dev/rslint/internal/linter"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_date_now"
+	"github.com/web-infra-dev/rslint/internal/program"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+func TestPreferDateNowExtras(t *testing.T) {
+	valid := []rule_tester.ValidTestCase{
+		{Code: `new Date()?.getTime()`},
+		{Code: `new Date().valueOf?.()`},
+		{Code: `(new Date()?.getTime)()`},
+		{Code: `Number?.(new Date())`},
+		{Code: `BigInt?.(new Date())`},
+		{Code: `Number(...[new Date()])`},
+		{Code: `new Date(0).getTime(); Number(new Date(0)); foo -= new Date(0); new Date(0) * 2;`},
+		{Code: `!new Date(); ~new Date(); void new Date(); new Date() === 0; foo = new Date();`},
+		{Code: `class Clock { #getTime() {} read() { return new Date().#getTime(); } }`},
+		// Authored TypeScript wrappers remain visible to ESTree selectors.
+		{Code: `+(new Date() as Date)`, FileName: "file.ts"},
+		{Code: `-(new Date() satisfies Date)`, FileName: "file.ts"},
+		{Code: `new Date()!.getTime()`, FileName: "file.ts"},
+		{Code: `(Number as Function)(new Date())`, FileName: "file.ts"},
+		{Code: `new (Date as DateConstructor)().getTime()`, FileName: "file.ts"},
+		{Code: `Number(new Date() as Date)`, FileName: "file.ts"},
+		{Code: `(new Date() as Date) * 2; foo -= new Date() as Date;`, FileName: "file.ts"},
+	}
+	invalid := []rule_tester.InvalidTestCase{
+		invalidCase(`new (Date)().getTime()`, `Date.now()`, methodMessageID, "getTime"),
+		invalidCase(`((new Date().getTime))()`, `Date.now()`, methodMessageID, "getTime"),
+		invalidCase(`(Number)((new Date()))`, `Date.now()`, numberMessageID, "(Number)((new Date()))"),
+		invalidCase(`BigInt((new Date()))`, `BigInt((Date.now()))`, dateMessageID, "new Date()"),
+		invalidCase(`function clock(Date, Number) { return Number(new Date()); }`, `function clock(Date, Number) { return Date.now(); }`, numberMessageID, "Number(new Date())"),
+		invalidCase(`async function clock() { return await+new Date; }`, `async function clock() { return await Date.now(); }`, dateMessageID, "+new Date"),
+		// Upstream inserts keyword spacing outside the parenthesized range too.
+		invalidCase(`function clock() { return(+new Date); }`, `function clock() { return (Date.now()); }`, dateMessageID, "+new Date"),
+		invalidCase(`function clock() { throw+new Date; }`, `function clock() { throw Date.now(); }`, dateMessageID, "+new Date"),
+		invalidCase(`const timestamp = +/* keep outside? */(new Date);`, `const timestamp = Date.now();`, dateMessageID, "+/* keep outside? */(new Date)"),
+		invalidCase(`const 时钟 = "😀"; new Date().getTime();`, `const 时钟 = "😀"; Date.now();`, methodMessageID, "getTime"),
+		invalidCase("const timestamp = Number(\n  new Date()\n);", "const timestamp = Date.now();", numberMessageID, "Number(\n  new Date()\n)"),
+		invalidCase("const timestamp = new Date()\n  .getTime();", "const timestamp = Date.now();", methodMessageID, "getTime"),
+		// JavaScript JSDoc casts are transparent, unlike authored TS assertions.
+		invalidCase(`+(/** @type {Date} */ (new Date()))`, `Date.now()`, dateMessageID, "+(/** @type {Date} */ (new Date()))"),
+		invalidCase(`new (/** @type {DateConstructor} */ (Date))().getTime()`, `Date.now()`, methodMessageID, "getTime"),
+		// The full parenthesized range includes synthetic JSDoc cast wrappers.
+		invalidCase(`function clock(){return(/** @type {number} */ (+new Date));}`, `function clock(){return (/** @type {number} */ (Date.now()));}`, dateMessageID, "+new Date"),
+		invalidCase(`function clock(){return(/** @type {number} */ (+new Date))in {}}`, `function clock(){return (/** @type {number} */ (Date.now())) in {}}`, dateMessageID, "+new Date"),
+		invalidCase(`function clock(){return(/** @satisfies {number} */ (+new Date));}`, `function clock(){return (/** @satisfies {number} */ (Date.now()));}`, dateMessageID, "+new Date"),
+	}
+	for _, operator := range []string{"-", "*", "/", "%", "**"} {
+		invalid = append(invalid, invalidCase(
+			"const elapsed = new Date() "+operator+" new Date();",
+			"const elapsed = Date.now() "+operator+" Date.now();",
+			dateMessageID, "new Date()", "new Date()"))
+	}
+	// Type arguments and JSX containers do not change the runtime call shape.
+	tsCase := invalidCase(`new Date<string>().getTime<number>()`, `Date.now()`, methodMessageID, "getTime")
+	tsCase.FileName = "file.ts"
+	invalid = append(invalid, tsCase)
+	jsxCase := invalidCase(`const Clock = () => <time>{new Date().getTime()}</time>;`, `const Clock = () => <time>{Date.now()}</time>;`, methodMessageID, "getTime")
+	jsxCase.FileName = "file.tsx"
+	jsxCase.Tsx = true
+	invalid = append(invalid, jsxCase)
+
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &prefer_date_now.PreferDateNowRule, valid, invalid)
+}
+
+func TestPreferDateNowEditDemand(t *testing.T) {
+	const source = `function clock(){return(/** @type {number} */ (+new Date))in {}}`
+	const fixedSource = `function clock(){return (/** @type {number} */ (Date.now())) in {}}`
+	root := fixtures.GetRootDir()
+	fileName := tspath.ResolvePath(root.Dir, "edit-demand.js")
+	fs := utils.NewOverlayVFS(root.FS, map[string]string{fileName: source})
+	host := utils.CreateCompilerHost(root.Dir, fs)
+	compilerProgram, err := utils.CreateProgram(true, fs, root.Dir, "tsconfig.json", host)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if compilerProgram.GetSourceFile(fileName) == nil {
+		t.Fatal("missing edit-demand source file")
+	}
+	diagnostics := make(map[rule.EditDemand]rule.RuleDiagnostic)
+	for _, demand := range []rule.EditDemand{rule.EditDemandNone, rule.EditDemandAutofix, rule.EditDemandSuggestion, rule.EditDemandAll} {
+		var got []rule.RuleDiagnostic
+		linter.LintSingleFile(linter.LintSingleFileOptions{
+			Program: program.NewFromCompiler(compilerProgram), File: fileName,
+			GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+				return []rule.ConfiguredRule{{
+					Name: prefer_date_now.PreferDateNowRule.Name, Severity: rule.SeverityError,
+					Run: func(ctx rule.RuleContext) rule.RuleListeners {
+						return prefer_date_now.PreferDateNowRule.Run(ctx, nil)
+					},
+				}}
+			},
+			Consumer: rule.DiagnosticConsumer{Demand: demand, Report: func(diagnostic rule.RuleDiagnostic) {
+				got = append(got, diagnostic)
+			}},
+		})
+		if len(got) != 1 {
+			t.Fatalf("demand %d: got %d diagnostics, want 1", demand, len(got))
+		}
+		diagnostics[demand] = got[0]
+	}
+	base := diagnostics[rule.EditDemandNone]
+	for demand, diagnostic := range diagnostics {
+		metadata := diagnostic
+		metadata.FixesPtr = nil
+		metadata.Suggestions = nil
+		if !reflect.DeepEqual(metadata, base) {
+			t.Errorf("demand %d changed diagnostic metadata", demand)
+		}
+		if diagnostic.Suggestions != nil {
+			t.Errorf("demand %d unexpectedly produced suggestions", demand)
+		}
+		if demand == rule.EditDemandNone || demand == rule.EditDemandSuggestion {
+			if diagnostic.FixesPtr != nil {
+				t.Errorf("demand %d unexpectedly produced fixes", demand)
+			}
+			continue
+		}
+		if diagnostic.FixesPtr == nil || !reflect.DeepEqual(diagnostic.FixesPtr, diagnostics[rule.EditDemandAll].FixesPtr) {
+			t.Fatalf("demand %d has missing or inconsistent fixes", demand)
+		}
+	}
+	// Applying fixes sorts their slices in place. Compare all demands before
+	// doing so, regardless of the map's iteration order.
+	for _, demand := range []rule.EditDemand{rule.EditDemandAutofix, rule.EditDemandAll} {
+		diagnostic := diagnostics[demand]
+		output, unapplied, fixed := linter.ApplyRuleFixes(source, []rule.RuleDiagnostic{diagnostic})
+		if !fixed || len(unapplied) != 0 || output != fixedSource {
+			t.Errorf("demand %d: fixed = %v, unapplied = %d, output = %q", demand, fixed, len(unapplied), output)
+		}
+	}
+}

--- a/internal/plugins/unicorn/rules/prefer_date_now/prefer_date_now_upstream_test.go
+++ b/internal/plugins/unicorn/rules/prefer_date_now/prefer_date_now_upstream_test.go
@@ -1,0 +1,136 @@
+package prefer_date_now_test
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf16"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_date_now"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+const (
+	dateMessageID   = "prefer-date"
+	methodMessageID = "prefer-date-now-over-methods"
+	numberMessageID = "prefer-date-now-over-number-data-object"
+)
+
+func invalidCase(code, output, messageID string, targets ...string) rule_tester.InvalidTestCase {
+	result := rule_tester.InvalidTestCase{Code: code, FileName: "file.js", Output: []string{output}}
+	searchFrom := 0
+	for _, target := range targets {
+		offset := strings.Index(code[searchFrom:], target)
+		if offset < 0 || target == "" {
+			panic("missing diagnostic target: " + target)
+		}
+		start := searchFrom + offset
+		end := start + len(target)
+		searchFrom = end
+		position := func(offset int) (int, int) {
+			prefix := code[:offset]
+			lineStart := strings.LastIndex(prefix, "\n") + 1
+			return strings.Count(prefix, "\n") + 1, len(utf16.Encode([]rune(prefix[lineStart:]))) + 1
+		}
+		line, column := position(start)
+		endLine, endColumn := position(end)
+		message := "Prefer `Date.now()` over `new Date()`."
+		switch messageID {
+		case methodMessageID:
+			message = "Prefer `Date.now()` over `Date#" + target + "()`."
+		case numberMessageID:
+			message = "Prefer `Date.now()` over `Number(new Date())`."
+		}
+		result.Errors = append(result.Errors, rule_tester.InvalidTestCaseError{
+			MessageId: messageID, Message: message,
+			Line: line, Column: column, EndLine: endLine, EndColumn: endColumn,
+		})
+	}
+	if len(result.Errors) == 0 {
+		panic("invalid case requires diagnostic targets")
+	}
+	return result
+}
+
+// Every case from eslint-plugin-unicorn v74.0.0/test/prefer-date-now.js.
+func TestPreferDateNowUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &prefer_date_now.PreferDateNowRule,
+		[]rule_tester.ValidTestCase{
+			{Code: `const ts = Date.now()`},
+			// Constructor shape and arguments.
+			{Code: `+Date()`},
+			{Code: `+ Date`},
+			{Code: `+ new window.Date()`},
+			{Code: `+ new Moments()`},
+			{Code: `+ new Date(0)`},
+			{Code: `+ new Date(...[])`},
+			// Method calls.
+			{Code: `new Date.getTime()`},
+			{Code: `valueOf()`},
+			{Code: `new Date()[getTime]()`},
+			{Code: `new Date()["valueOf"]()`},
+			{Code: `new Date().notListed(0)`},
+			{Code: `new Date().getTime(0)`},
+			{Code: `new Date().valueOf(...[])`},
+			// Number and BigInt calls.
+			{Code: `new Number(new Date())`},
+			{Code: `window.BigInt(new Date())`},
+			{Code: `toNumber(new Date())`},
+			{Code: `BigInt()`},
+			{Code: `Number(new Date(), extraArgument)`},
+			{Code: `BigInt([...new Date()])`},
+			// Unary, assignment and binary expressions.
+			{Code: `throw new Date()`},
+			{Code: `typeof new Date()`},
+			{Code: `const foo = () => {return new Date()}`},
+			{Code: `foo += new Date()`},
+			{Code: `function * foo() {yield new Date()}`},
+			{Code: `new Date() + new Date()`},
+			{Code: `foo = new Date() | 0`},
+			{Code: `foo &= new Date()`},
+			{Code: `foo = new Date() >> 0`},
+		},
+		[]rule_tester.InvalidTestCase{
+			invalidCase(`const ts = new Date().getTime();`, `const ts = Date.now();`, methodMessageID, "getTime"),
+			invalidCase(`const ts = (new Date).getTime();`, `const ts = Date.now();`, methodMessageID, "getTime"),
+			invalidCase(`const ts = (new Date()).getTime();`, `const ts = Date.now();`, methodMessageID, "getTime"),
+			invalidCase(`const ts = new Date().valueOf();`, `const ts = Date.now();`, methodMessageID, "valueOf"),
+			invalidCase(`const ts = (new Date).valueOf();`, `const ts = Date.now();`, methodMessageID, "valueOf"),
+			invalidCase(`const ts = (new Date()).valueOf();`, `const ts = Date.now();`, methodMessageID, "valueOf"),
+			invalidCase(`const ts = /* 1 */ Number(/* 2 */ new /* 3 */ Date( /* 4 */ ) /* 5 */) /* 6 */`, `const ts = /* 1 */ Date.now() /* 6 */`, numberMessageID, "Number(/* 2 */ new /* 3 */ Date( /* 4 */ ) /* 5 */)"),
+			invalidCase(`const tsBigInt = /* 1 */ BigInt(/* 2 */ new /* 3 */ Date( /* 4 */ ) /* 5 */) /* 6 */`, `const tsBigInt = /* 1 */ BigInt(/* 2 */ Date.now() /* 5 */) /* 6 */`, dateMessageID, "new /* 3 */ Date( /* 4 */ )"),
+			invalidCase(`const ts = + /* 1 */ new Date;`, `const ts = Date.now();`, dateMessageID, "+ /* 1 */ new Date"),
+			invalidCase(`const ts = - /* 1 */ new Date();`, `const ts = - /* 1 */ Date.now();`, dateMessageID, "new Date()"),
+			invalidCase(`const ts = +(new Date());`, `const ts = Date.now();`, dateMessageID, "+(new Date())"),
+			invalidCase(`const ts = -(new Date());`, `const ts = -(Date.now());`, dateMessageID, "new Date()"),
+			invalidCase(`const ts = new Date() - 0`, `const ts = Date.now() - 0`, dateMessageID, "new Date()"),
+			invalidCase(`const foo = bar - new Date`, `const foo = bar - Date.now()`, dateMessageID, "new Date"),
+			invalidCase(`const foo = new Date() * bar`, `const foo = Date.now() * bar`, dateMessageID, "new Date()"),
+			invalidCase(`const ts = new Date() / 1`, `const ts = Date.now() / 1`, dateMessageID, "new Date()"),
+			invalidCase(`const ts = new Date() % Infinity`, `const ts = Date.now() % Infinity`, dateMessageID, "new Date()"),
+			invalidCase(`const ts = new Date() ** 1`, `const ts = Date.now() ** 1`, dateMessageID, "new Date()"),
+			invalidCase(`const zero = (new Date(/* 1 */) /* 2 */) /* 3 */ - /* 4 */new Date`, `const zero = (Date.now() /* 2 */) /* 3 */ - /* 4 */Date.now()`, dateMessageID, "new Date(/* 1 */)", "new Date"),
+			invalidCase(`foo -= new Date()`, `foo -= Date.now()`, dateMessageID, "new Date()"),
+			invalidCase(`foo *= new Date()`, `foo *= Date.now()`, dateMessageID, "new Date()"),
+			invalidCase(`foo /= new Date`, `foo /= Date.now()`, dateMessageID, "new Date"),
+			invalidCase(`foo %= new Date()`, `foo %= Date.now()`, dateMessageID, "new Date()"),
+			invalidCase(`foo **= new Date()`, `foo **= Date.now()`, dateMessageID, "new Date()"),
+			invalidCase(`function foo(){return+new Date}`, `function foo(){return Date.now()}`, dateMessageID, "+new Date"),
+			invalidCase(`function foo(){return-new Date}`, `function foo(){return-Date.now()}`, dateMessageID, "new Date"),
+		})
+}
+
+func TestPreferDateNowUpstreamDocumentation(t *testing.T) {
+	// eslint-plugin-unicorn v74.0.0/docs/rules/prefer-date-now.md.
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &prefer_date_now.PreferDateNowRule,
+		[]rule_tester.ValidTestCase{
+			{Code: `const foo = Date.now();`},
+			{Code: `const foo = Date.now() * 2;`},
+		}, []rule_tester.InvalidTestCase{
+			invalidCase(`const foo = new Date().getTime();`, `const foo = Date.now();`, methodMessageID, "getTime"),
+			invalidCase(`const foo = new Date().valueOf();`, `const foo = Date.now();`, methodMessageID, "valueOf"),
+			invalidCase(`const foo = +new Date;`, `const foo = Date.now();`, dateMessageID, "+new Date"),
+			invalidCase(`const foo = Number(new Date());`, `const foo = Date.now();`, numberMessageID, "Number(new Date())"),
+			invalidCase(`const foo = new Date() * 2;`, `const foo = Date.now() * 2;`, dateMessageID, "new Date()"),
+		})
+}

--- a/internal/plugins/unicorn/unicornutil/fix_spacing.go
+++ b/internal/plugins/unicorn/unicornutil/fix_spacing.go
@@ -35,7 +35,14 @@ func SpaceAroundKeywordFixes(sourceFile *ast.SourceFile, node *ast.Node) []rule.
 		return nil
 	}
 
-	outer := utils.OutermostParenthesizedExpression(node)
+	// JSDoc casts insert wrappers that ESTree does not expose. Cross those
+	// wrappers as well as parentheses to find the complete source range.
+	outer := node
+	for outer.Parent != nil &&
+		(ast.IsParenthesizedExpression(outer.Parent) || utils.IsJSDocTypeCastWrapper(outer.Parent)) &&
+		outer.Parent.Expression() == outer {
+		outer = outer.Parent
+	}
 	textRange := utils.TrimNodeTextRange(sourceFile, outer)
 	var fixes []rule.RuleFix
 

--- a/internal/plugins/unicorn/unicornutil/unicornutil_test.go
+++ b/internal/plugins/unicorn/unicornutil/unicornutil_test.go
@@ -211,10 +211,12 @@ func TestShouldAddParenthesesToMemberExpressionObject(t *testing.T) {
 
 func TestSpaceAroundKeywordFixesUsesESTreeTokenClasses(t *testing.T) {
 	tests := []struct {
-		name      string
-		code      string
-		target    string
-		wantFixes int
+		name       string
+		code       string
+		target     string
+		javascript bool
+		wantFixes  int
+		wantOutput string
 	}{
 		{
 			name:   "TypeScript as stays identifier-like",
@@ -227,28 +229,87 @@ func TestSpaceAroundKeywordFixesUsesESTreeTokenClasses(t *testing.T) {
 			target: "consume(value)",
 		},
 		{
-			name:      "ECMAScript keyword after",
-			code:      "const result = consume(value)instanceof Array;",
-			target:    "consume(value)",
-			wantFixes: 1,
+			name:       "ECMAScript keyword after",
+			code:       "const result = consume(value)instanceof Array;",
+			target:     "consume(value)",
+			wantFixes:  1,
+			wantOutput: "const result = consume(value) instanceof Array;",
 		},
 		{
-			name:      "contextual of before",
-			code:      "for (const item of[].concat(value)) {}",
-			target:    "[].concat(value)",
-			wantFixes: 1,
+			name:       "contextual of before",
+			code:       "for (const item of[].concat(value)) {}",
+			target:     "[].concat(value)",
+			wantFixes:  1,
+			wantOutput: "for (const item of [].concat(value)) {}",
 		},
 		{
-			name:      "contextual await before",
-			code:      "async function consume() { await[].concat(value); }",
-			target:    "[].concat(value)",
-			wantFixes: 1,
+			name:       "contextual await before",
+			code:       "async function consume() { await[].concat(value); }",
+			target:     "[].concat(value)",
+			wantFixes:  1,
+			wantOutput: "async function consume() { await [].concat(value); }",
+		},
+		{
+			name:       "JSDoc type cast inside parentheses",
+			code:       "function clock(){return(/** @type {number} */ (consume(value)));}",
+			target:     "consume(value)",
+			javascript: true,
+			wantFixes:  1,
+			wantOutput: "function clock(){return (/** @type {number} */ (consume(value)));}",
+		},
+		{
+			name:       "JSDoc type cast between keywords",
+			code:       "function clock(){return(/** @type {number} */ (consume(value)))in {};}",
+			target:     "consume(value)",
+			javascript: true,
+			wantFixes:  2,
+			wantOutput: "function clock(){return (/** @type {number} */ (consume(value))) in {};}",
+		},
+		{
+			name:       "JSDoc satisfies cast inside parentheses",
+			code:       "function clock(){return(/** @satisfies {number} */ (consume(value)));}",
+			target:     "consume(value)",
+			javascript: true,
+			wantFixes:  1,
+			wantOutput: "function clock(){return (/** @satisfies {number} */ (consume(value)));}",
+		},
+		{
+			name:       "nested JSDoc casts",
+			code:       "function clock(){return(/** @type {number} */ (/** @satisfies {number} */ (consume(value))));}",
+			target:     "consume(value)",
+			javascript: true,
+			wantFixes:  1,
+			wantOutput: "function clock(){return (/** @type {number} */ (/** @satisfies {number} */ (consume(value))));}",
+		},
+		{
+			name:       "existing JSDoc keyword spacing",
+			code:       "function clock(){return (/** @type {number} */ (consume(value))) in {};}",
+			target:     "consume(value)",
+			javascript: true,
+		},
+		{
+			name:   "authored TypeScript as is a boundary",
+			code:   "function clock(){return(consume(value) as number);}",
+			target: "consume(value)",
+		},
+		{
+			name:   "authored TypeScript satisfies is a boundary",
+			code:   "function clock(){return(consume(value) satisfies number);}",
+			target: "consume(value)",
+		},
+		{
+			name:   "authored TypeScript non-null assertion is a boundary",
+			code:   "function clock(){return(consume(value)!);}",
+			target: "consume(value)",
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			sourceFile := parseTestSource(test.code)
+			if test.javascript {
+				sourceFile = parseTestJavaScript(test.code)
+			}
 			node := findTestCall(t, sourceFile, test.target)
 			fixes := SpaceAroundKeywordFixes(sourceFile, node)
 			if len(fixes) != test.wantFixes {
@@ -260,6 +321,18 @@ func TestSpaceAroundKeywordFixesUsesESTreeTokenClasses(t *testing.T) {
 					t.Fatalf("SpaceAroundKeywordFixes(%q) inserted %q, want one space",
 						test.code, fix.Text)
 				}
+			}
+			output := test.code
+			for i := len(fixes) - 1; i >= 0; i-- {
+				fix := fixes[i]
+				output = output[:fix.Range.Pos()] + fix.Text + output[fix.Range.End():]
+			}
+			wantOutput := test.wantOutput
+			if wantOutput == "" {
+				wantOutput = test.code
+			}
+			if output != wantOutput {
+				t.Fatalf("SpaceAroundKeywordFixes(%q) produced %q, want %q", test.code, output, wantOutput)
 			}
 		})
 	}

--- a/packages/rslint-test-tools/rstack.config.mts
+++ b/packages/rslint-test-tools/rstack.config.mts
@@ -745,6 +745,7 @@ define.test({
     './tests/eslint-plugin-unicorn/rules/prefer-array-flat-map.test.ts',
     './tests/eslint-plugin-unicorn/rules/prefer-array-some.test.ts',
     './tests/eslint-plugin-unicorn/rules/prefer-blob-reading-methods.test.ts',
+    './tests/eslint-plugin-unicorn/rules/prefer-date-now.test.ts',
     './tests/eslint-plugin-unicorn/rules/prefer-node-protocol.test.ts',
     './tests/eslint-plugin-unicorn/rules/prefer-number-properties.test.ts',
     './tests/eslint-plugin-unicorn/rules/prefer-set-has.test.ts',

--- a/packages/rslint-test-tools/tests/cli/js-config/presets.test.ts
+++ b/packages/rslint-test-tools/tests/cli/js-config/presets.test.ts
@@ -181,5 +181,6 @@ describe('defineConfig and config presets', () => {
     );
     expect(rec.rules?.['unicorn/no-exports-in-scripts']).toBe('error');
     expect(rec.rules?.['unicorn/no-await-expression-member']).toBe('error');
+    expect(rec.rules?.['unicorn/prefer-date-now']).toBe('error');
   });
 });

--- a/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/prefer-date-now.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/prefer-date-now.test.ts
@@ -1,0 +1,163 @@
+import { RuleTester } from '../rule-tester';
+
+const dateMessage = 'Prefer `Date.now()` over `new Date()`.';
+const invalid = (
+  code: string,
+  output: string,
+  messageId = 'prefer-date',
+  message = dateMessage,
+  count = 1,
+) => ({
+  code,
+  filename: 'file.js',
+  output,
+  errors: Array.from({ length: count }, () => ({ messageId, message })),
+});
+const method = (code: string, output: string, name: string) =>
+  invalid(
+    code,
+    output,
+    'prefer-date-now-over-methods',
+    `Prefer \`Date.now()\` over \`Date#${name}()\`.`,
+  );
+const number = (code: string, output: string) =>
+  invalid(
+    code,
+    output,
+    'prefer-date-now-over-number-data-object',
+    'Prefer `Date.now()` over `Number(new Date())`.',
+  );
+
+// Complete upstream suite and documentation examples:
+// https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/test/prefer-date-now.js
+// https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/docs/rules/prefer-date-now.md
+new RuleTester().run('prefer-date-now', null as never, {
+  valid: [
+    'const ts = Date.now()',
+    // Constructor shape and arguments.
+    '+Date()',
+    '+ Date',
+    '+ new window.Date()',
+    '+ new Moments()',
+    '+ new Date(0)',
+    '+ new Date(...[])',
+    // Method calls.
+    'new Date.getTime()',
+    'valueOf()',
+    'new Date()[getTime]()',
+    'new Date()["valueOf"]()',
+    'new Date().notListed(0)',
+    'new Date().getTime(0)',
+    'new Date().valueOf(...[])',
+    // Number and BigInt calls.
+    'new Number(new Date())',
+    'window.BigInt(new Date())',
+    'toNumber(new Date())',
+    'BigInt()',
+    'Number(new Date(), extraArgument)',
+    'BigInt([...new Date()])',
+    // Unary, assignment and binary expressions.
+    'throw new Date()',
+    'typeof new Date()',
+    'const foo = () => {return new Date()}',
+    'foo += new Date()',
+    'function * foo() {yield new Date()}',
+    'new Date() + new Date()',
+    'foo = new Date() | 0',
+    'foo &= new Date()',
+    'foo = new Date() >> 0',
+    // Documentation.
+    'const foo = Date.now();',
+    'const foo = Date.now() * 2;',
+  ].map((code) => ({ code, filename: 'file.js' })),
+  invalid: [
+    method(
+      'const ts = new Date().getTime();',
+      'const ts = Date.now();',
+      'getTime',
+    ),
+    method(
+      'const ts = (new Date).getTime();',
+      'const ts = Date.now();',
+      'getTime',
+    ),
+    method(
+      'const ts = (new Date()).getTime();',
+      'const ts = Date.now();',
+      'getTime',
+    ),
+    method(
+      'const ts = new Date().valueOf();',
+      'const ts = Date.now();',
+      'valueOf',
+    ),
+    method(
+      'const ts = (new Date).valueOf();',
+      'const ts = Date.now();',
+      'valueOf',
+    ),
+    method(
+      'const ts = (new Date()).valueOf();',
+      'const ts = Date.now();',
+      'valueOf',
+    ),
+    number(
+      'const ts = /* 1 */ Number(/* 2 */ new /* 3 */ Date( /* 4 */ ) /* 5 */) /* 6 */',
+      'const ts = /* 1 */ Date.now() /* 6 */',
+    ),
+    invalid(
+      'const tsBigInt = /* 1 */ BigInt(/* 2 */ new /* 3 */ Date( /* 4 */ ) /* 5 */) /* 6 */',
+      'const tsBigInt = /* 1 */ BigInt(/* 2 */ Date.now() /* 5 */) /* 6 */',
+    ),
+    invalid('const ts = + /* 1 */ new Date;', 'const ts = Date.now();'),
+    invalid(
+      'const ts = - /* 1 */ new Date();',
+      'const ts = - /* 1 */ Date.now();',
+    ),
+    invalid('const ts = +(new Date());', 'const ts = Date.now();'),
+    invalid('const ts = -(new Date());', 'const ts = -(Date.now());'),
+    invalid('const ts = new Date() - 0', 'const ts = Date.now() - 0'),
+    invalid('const foo = bar - new Date', 'const foo = bar - Date.now()'),
+    invalid('const foo = new Date() * bar', 'const foo = Date.now() * bar'),
+    invalid('const ts = new Date() / 1', 'const ts = Date.now() / 1'),
+    invalid(
+      'const ts = new Date() % Infinity',
+      'const ts = Date.now() % Infinity',
+    ),
+    invalid('const ts = new Date() ** 1', 'const ts = Date.now() ** 1'),
+    invalid(
+      'const zero = (new Date(/* 1 */) /* 2 */) /* 3 */ - /* 4 */new Date',
+      'const zero = (Date.now() /* 2 */) /* 3 */ - /* 4 */Date.now()',
+      'prefer-date',
+      dateMessage,
+      2,
+    ),
+    invalid('foo -= new Date()', 'foo -= Date.now()'),
+    invalid('foo *= new Date()', 'foo *= Date.now()'),
+    invalid('foo /= new Date', 'foo /= Date.now()'),
+    invalid('foo %= new Date()', 'foo %= Date.now()'),
+    invalid('foo **= new Date()', 'foo **= Date.now()'),
+    invalid(
+      'function foo(){return+new Date}',
+      'function foo(){return Date.now()}',
+    ),
+    invalid(
+      'function foo(){return-new Date}',
+      'function foo(){return-Date.now()}',
+    ),
+    // Documentation.
+    method(
+      'const foo = new Date().getTime();',
+      'const foo = Date.now();',
+      'getTime',
+    ),
+    method(
+      'const foo = new Date().valueOf();',
+      'const foo = Date.now();',
+      'valueOf',
+    ),
+    invalid('const foo = +new Date;', 'const foo = Date.now();'),
+    number('const foo = Number(new Date());', 'const foo = Date.now();'),
+    invalid('const foo = new Date() * 2;', 'const foo = Date.now() * 2;'),
+  ],
+});

--- a/packages/rslint/src/config/presets/unicorn.ts
+++ b/packages/rslint/src/config/presets/unicorn.ts
@@ -229,7 +229,7 @@ const recommended: RslintConfigEntry = {
     // 'unicorn/prefer-classlist-toggle': 'error', // not implemented
     // 'unicorn/prefer-code-point': 'error', // not implemented
     // 'unicorn/prefer-continue': 'error', // not implemented
-    // 'unicorn/prefer-date-now': 'error', // not implemented
+    'unicorn/prefer-date-now': 'error',
     // 'unicorn/prefer-default-parameters': 'error', // not implemented
     // 'unicorn/prefer-direct-iteration': 'error', // not implemented
     // 'unicorn/prefer-dispose': 'off', // not implemented


### PR DESCRIPTION
## Summary

Port `unicorn/prefer-date-now` from eslint-plugin-unicorn v74.0.0.

The rule prefers `Date.now()` over creating a `Date` object solely for its numeric timestamp, with automatic fixes for method calls, numeric conversions, and arithmetic expressions.

This change also:

- Registers the rule in the Unicorn catalog and adds the JS integration suite.
- Adds the complete upstream test suite, regression coverage, and rule documentation.
- Fixes keyword spacing through JSDoc cast wrappers in the shared Unicorn fixer, with coverage for its existing consumer.

## Validation

- Targeted Go tests, scoped Go lint, formatting, and spelling checks passed.
- All 116 differential cases matched upstream v74.0.0.
- JS integration and rule catalog checks were not completed locally and remain to be verified in CI.

## Related Links

- Tracking issue: #1309
- [Upstream documentation](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/docs/rules/prefer-date-now.md)
- [Upstream source](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/rules/prefer-date-now.js)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
