### PR TITLE
ci: reuse a bounded Go build cache on macOS

### DIFF
--- a/.github/scripts/trim-go-cache.mjs
+++ b/.github/scripts/trim-go-cache.mjs
@@ -1,0 +1,40 @@
+import { readdirSync, statSync, unlinkSync } from 'node:fs';
+import { join } from 'node:path';
+
+const [cachePath, limitMiB] = process.argv.slice(2);
+const limit = Number(limitMiB) * 1024 * 1024;
+if (!cachePath || !Number.isSafeInteger(limit) || limit <= 0) {
+  throw new Error('Usage: trim-go-cache.mjs <cache-path> <positive-limit-MiB>');
+}
+
+const files = [];
+function collect(directory) {
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) {
+      collect(path);
+    } else if (entry.isFile()) {
+      const { size, mtimeMs } = statSync(path);
+      files.push({ path, size, mtimeMs });
+    }
+  }
+}
+collect(cachePath);
+
+let size = files.reduce((total, file) => total + file.size, 0);
+const originalSize = size;
+// Go updates cache modification times on use (at most once per hour). Missing entries are
+// rebuilt normally, so discard the least recently used files first.
+files.sort((a, b) => a.mtimeMs - b.mtimeMs);
+let removed = 0;
+for (const file of files) {
+  if (size <= limit) break;
+  unlinkSync(file.path);
+  size -= file.size;
+  removed++;
+}
+
+const toMiB = (bytes) => (bytes / 1024 / 1024).toFixed(1);
+console.log(
+  `Go build cache: ${toMiB(originalSize)} MiB -> ${toMiB(size)} MiB; removed ${removed} files (limit ${limitMiB} MiB)`,
+);

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,4 @@
+# cspell:ignore GOCACHE logicalcpu memsize
 name: CI
 
 on:
@@ -56,6 +57,28 @@ jobs:
           go-version: ${{ matrix.go-version }}
           cache-name: ci-test-go
 
+      - name: Configure Go build cache (macOS)
+        if: runner.os == 'macOS'
+        id: go-build-cache
+        run: |
+          echo "GOCACHE=$RUNNER_TEMP/rslint-go-build" >> "$GITHUB_ENV"
+          go version
+          sysctl hw.logicalcpu hw.memsize
+          echo "GOMAXPROCS=${GOMAXPROCS:-unset}"
+          df -h "$RUNNER_TEMP"
+
+      # Restore after setup-go has cleaned the runner's old build cache.
+      # Actions cache scopes PR writes to the PR; main supplies the fallback.
+      - name: Restore Go build cache (macOS)
+        if: runner.os == 'macOS'
+        id: restore-go-build-cache
+        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: ${{ runner.temp }}/rslint-go-build
+          key: ci-test-go-build-v1-${{ matrix.runner }}-${{ runner.arch }}-${{ matrix.go-version }}-${{ github.sha }}
+          restore-keys: |
+            ci-test-go-build-v1-${{ matrix.runner }}-${{ runner.arch }}-${{ matrix.go-version }}-
+
       - name: Verify compiler shim layout
         run: go test github.com/microsoft/TypeScript/tsc/shim/checker
 
@@ -97,10 +120,31 @@ jobs:
             if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           }
 
+      - name: Unit Test (macOS)
+        if: runner.os == 'macOS'
+        run: /usr/bin/time -l go test -count=1 ./cmd/... ./internal/...
+
       # Fallback for any runner without a dedicated step above.
       - name: Unit Test
-        if: matrix.runner != 'rspack-ubuntu-22.04-large' && matrix.runner != 'rspack-windows-2022-large'
+        if: runner.os != 'macOS' && matrix.runner != 'rspack-ubuntu-22.04-large' && matrix.runner != 'rspack-windows-2022-large'
         run: go test -count=1 ./cmd/... ./internal/...
+
+      - name: Trim Go build cache (macOS)
+        if: runner.os == 'macOS' && steps.restore-go-build-cache.outputs.cache-hit != 'true'
+        id: trim-go-build-cache
+        continue-on-error: true
+        run: node .github/scripts/trim-go-cache.mjs "$GOCACHE" 4096
+
+      - name: Save Go build cache (macOS)
+        if: runner.os == 'macOS' && steps.trim-go-build-cache.outcome == 'success'
+        uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: ${{ runner.temp }}/rslint-go-build
+          key: ${{ steps.restore-go-build-cache.outputs.cache-primary-key }}
+
+      - name: Clean Go build cache (macOS)
+        if: always() && runner.os == 'macOS' && steps.go-build-cache.outcome == 'success'
+        run: go clean -cache
 
   lint:
     name: Lint&Check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,7 @@ jobs:
         id: go-build-cache
         run: |
           echo "GOCACHE=$RUNNER_TEMP/rslint-go-build" >> "$GITHUB_ENV"
+          echo "date=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
           go version
           sysctl hw.logicalcpu hw.memsize
           echo "GOMAXPROCS=${GOMAXPROCS:-unset}"
@@ -69,13 +70,14 @@ jobs:
 
       # Restore after setup-go has cleaned the runner's old build cache.
       # Actions cache scopes PR writes to the PR; main supplies the fallback.
+      # Refresh daily to avoid uploading a large snapshot for every commit.
       - name: Restore Go build cache (macOS)
         if: runner.os == 'macOS'
         id: restore-go-build-cache
         uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: ${{ runner.temp }}/rslint-go-build
-          key: ci-test-go-build-v1-${{ matrix.runner }}-${{ runner.arch }}-${{ matrix.go-version }}-${{ github.sha }}
+          key: ci-test-go-build-v1-${{ matrix.runner }}-${{ runner.arch }}-${{ matrix.go-version }}-${{ steps.go-build-cache.outputs.date }}
           restore-keys: |
             ci-test-go-build-v1-${{ matrix.runner }}-${{ runner.arch }}-${{ matrix.go-version }}-
 
@@ -133,7 +135,8 @@ jobs:
         if: runner.os == 'macOS' && steps.restore-go-build-cache.outputs.cache-hit != 'true'
         id: trim-go-build-cache
         continue-on-error: true
-        run: node .github/scripts/trim-go-cache.mjs "$GOCACHE" 4096
+        # A cold CLI build already produces about 32 GiB before compression.
+        run: node .github/scripts/trim-go-cache.mjs "$GOCACHE" 32768
 
       - name: Save Go build cache (macOS)
         if: runner.os == 'macOS' && steps.trim-go-build-cache.outcome == 'success'


### PR DESCRIPTION
## Summary

Reuse daily snapshots of the macOS Go build cache through GitHub Actions, capped at 32 GiB before compression and cleaned after each job. Keep fresh test execution with `-count=1` and log CPU, memory, and test resource usage.

## Related Links

[Slow macOS Go job](https://github.com/web-infra-dev/rslint/actions/runs/34210816784/job/102011472594)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).