### PR TITLE
feat(rstest): add prefer-to-be rule

### DIFF
--- a/internal/plugins/jest/rules/prefer_to_be/prefer_to_be.go
+++ b/internal/plugins/jest/rules/prefer_to_be/prefer_to_be.go
@@ -50,25 +50,31 @@ func buildFixes(ctx rule.RuleContext, match shared.Match) []rule.RuleFix {
 		return nil
 	}
 
-	var renameFix rule.RuleFix
-	if match.Expect.MatcherEntry.Node.Kind == ast.KindIdentifier {
-		// Match replaceAccessorFixer exactly: an identifier accessor remains an
-		// identifier even in `expect(x)[toEqual](1)`.
-		renameFix = rule.RuleFixReplace(ctx.SourceFile, match.Expect.MatcherEntry.Node, replacement)
-	} else {
-		var ok bool
-		renameFix, ok = jestUtils.ReplaceMemberNameFix(
-			ctx,
-			&match.Expect.MatcherEntry,
-			replacement,
-		)
-		if !ok {
-			return nil
-		}
+	// NOTE: replaceAccessorFixer keeps an identifier accessor bare, which turns
+	// `expect(x)[toEqual](1)` into a reference to an undeclared `toBe`. A
+	// computed key is quoted instead so the fixed code still runs.
+	renameFix, ok := jestUtils.ReplaceMemberNameFix(
+		ctx,
+		&match.Expect.MatcherEntry,
+		replacement,
+	)
+	if !ok {
+		return nil
 	}
 	fixes := []rule.RuleFix{renameFix}
 
 	arguments := match.Expect.MatcherCall.Arguments()
+	if match.Kind != shared.KindToBe {
+		// NOTE: the dedicated matchers declare no type parameters, so type
+		// arguments written for toBe/toEqual have to go with the value
+		// arguments. Upstream leaves them behind and produces TS2558.
+		if typeArgumentsRange, hasTypeArguments := testFramework.CallTypeArgumentListRange(
+			ctx.SourceFile,
+			match.Expect.MatcherCall,
+		); hasTypeArguments {
+			fixes = append(fixes, rule.RuleFixRemoveRange(typeArgumentsRange))
+		}
+	}
 	if match.Kind != shared.KindToBe && len(arguments) > 0 {
 		argumentsRange, ok := testFramework.CallArgumentListRange(
 			ctx.SourceFile,

--- a/internal/plugins/jest/rules/prefer_to_be/prefer_to_be.go
+++ b/internal/plugins/jest/rules/prefer_to_be/prefer_to_be.go
@@ -1,267 +1,138 @@
 package prefer_to_be
 
 import (
-	"slices"
-
 	"github.com/microsoft/TypeScript/tsc/shim/ast"
-	"github.com/web-infra-dev/rslint/internal/plugins/jest/utils"
+	"github.com/microsoft/TypeScript/tsc/shim/core"
+	jestUtils "github.com/web-infra-dev/rslint/internal/plugins/jest/utils"
 	"github.com/web-infra-dev/rslint/internal/rule"
+	internalUtils "github.com/web-infra-dev/rslint/internal/utils"
+	testFramework "github.com/web-infra-dev/rslint/internal/utils/test_framework"
+	shared "github.com/web-infra-dev/rslint/internal/utils/test_framework/rules/prefer_to_be"
 )
 
-// Message Builders
-
-func buildUseToBeErrorMessage() rule.RuleMessage {
-	return rule.RuleMessage{
-		Id:          "useToBe",
-		Description: "Use `toBe` when expecting primitive literals",
+func message(kind shared.Kind) rule.RuleMessage {
+	switch kind {
+	case shared.KindToBe:
+		return rule.RuleMessage{Id: "useToBe", Description: "Use `toBe` when expecting primitive literals"}
+	case shared.KindNull:
+		return rule.RuleMessage{Id: "useToBeNull", Description: "Use `toBeNull` instead"}
+	case shared.KindNaN:
+		return rule.RuleMessage{Id: "useToBeNaN", Description: "Use `toBeNaN` instead"}
+	case shared.KindUndefined:
+		return rule.RuleMessage{Id: "useToBeUndefined", Description: "Use `toBeUndefined` instead"}
+	case shared.KindDefined:
+		return rule.RuleMessage{Id: "useToBeDefined", Description: "Use `toBeDefined` instead"}
+	default:
+		return rule.RuleMessage{}
 	}
 }
 
-func buildUseToBeUndefinedErrorMessage() rule.RuleMessage {
-	return rule.RuleMessage{
-		Id:          "useToBeUndefined",
-		Description: "Use `toBeUndefined` instead",
+func matcherName(kind shared.Kind) string {
+	switch kind {
+	case shared.KindToBe:
+		return "toBe"
+	case shared.KindNull:
+		return "toBeNull"
+	case shared.KindNaN:
+		return "toBeNaN"
+	case shared.KindUndefined:
+		return "toBeUndefined"
+	case shared.KindDefined:
+		return "toBeDefined"
+	default:
+		return ""
 	}
 }
 
-func buildUseToBeDefinedErrorMessage() rule.RuleMessage {
-	return rule.RuleMessage{
-		Id:          "useToBeDefined",
-		Description: "Use `toBeDefined` instead",
-	}
-}
-
-func buildUseToBeNullErrorMessage() rule.RuleMessage {
-	return rule.RuleMessage{
-		Id:          "useToBeNull",
-		Description: "Use `toBeNull` instead",
-	}
-}
-
-func buildUseToBeNaNErrorMessage() rule.RuleMessage {
-	return rule.RuleMessage{
-		Id:          "useToBeNaN",
-		Description: "Use `toBeNaN` instead",
-	}
-}
-
-type preferKind uint8
-
-const (
-	preferKindToBe preferKind = iota
-	preferKindNull
-	preferKindNaN
-	preferKindUndefined
-	preferKindDefined
-)
-
-// firstMatcherArgument returns expect(...).matcher(arg0)’s first argument
-// after peeling type assertions; nil if the matcher call has no arguments.
-func firstMatcherArgument(matcherCall *ast.Node) *ast.Node {
-	call := matcherCall.AsCallExpression()
-	if call == nil || call.Arguments == nil || len(call.Arguments.Nodes) == 0 {
+func buildFixes(ctx rule.RuleContext, match shared.Match) []rule.RuleFix {
+	replacement := matcherName(match.Kind)
+	if replacement == "" {
 		return nil
 	}
-	return utils.UnwrapBasicTypeAssertions(call.Arguments.Nodes[0])
-}
 
-func isNullLiteral(arg *ast.Node) bool {
-	return arg != nil && arg.Kind == ast.KindNullKeyword
-}
-
-func isIdentifier(arg *ast.Node, name string) bool {
-	return arg != nil && arg.Kind == ast.KindIdentifier && arg.AsIdentifier().Text == name
-}
-
-// shouldUseToBe reports whether arg is a primitive literal for which `toBe`
-// is preferred over `toEqual` / `toStrictEqual`. arg must already be
-// unwrapped (see firstMatcherArgument).
-func shouldUseToBe(arg *ast.Node) bool {
-	if arg == nil {
-		return false
-	}
-	if arg.Kind == ast.KindPrefixUnaryExpression {
-		unary := arg.AsPrefixUnaryExpression()
-		if unary.Operator == ast.KindMinusToken {
-			arg = utils.UnwrapBasicTypeAssertions(unary.Operand)
+	var renameFix rule.RuleFix
+	if match.Expect.MatcherEntry.Node.Kind == ast.KindIdentifier {
+		// Match replaceAccessorFixer exactly: an identifier accessor remains an
+		// identifier even in `expect(x)[toEqual](1)`.
+		renameFix = rule.RuleFixReplace(ctx.SourceFile, match.Expect.MatcherEntry.Node, replacement)
+	} else {
+		var ok bool
+		renameFix, ok = jestUtils.ReplaceMemberNameFix(
+			ctx,
+			&match.Expect.MatcherEntry,
+			replacement,
+		)
+		if !ok {
+			return nil
 		}
 	}
-	if arg == nil {
-		return false
+	fixes := []rule.RuleFix{renameFix}
+
+	arguments := match.Expect.MatcherCall.Arguments()
+	if match.Kind != shared.KindToBe && len(arguments) > 0 {
+		argumentsRange, ok := testFramework.CallArgumentListRange(
+			ctx.SourceFile,
+			match.Expect.MatcherCall,
+		)
+		if !ok {
+			return nil
+		}
+		// Match removeExtraArgumentsFixer: keep comments before the first
+		// argument, but remove the arguments, trailing comma and later trivia.
+		argumentsRange = core.NewTextRange(
+			internalUtils.TrimNodeTextRange(ctx.SourceFile, arguments[0]).Pos(),
+			argumentsRange.End(),
+		)
+		fixes = append(fixes, rule.RuleFixRemoveRange(argumentsRange))
 	}
-	switch arg.Kind {
-	case ast.KindStringLiteral,
-		ast.KindNumericLiteral,
-		ast.KindBigIntLiteral,
-		ast.KindTrueKeyword,
-		ast.KindFalseKeyword,
-		ast.KindNullKeyword,
-		ast.KindNoSubstitutionTemplateLiteral,
-		ast.KindTemplateExpression:
-		return true
-	default:
-		return false
+
+	if match.NotEntry != nil {
+		removeFixes, ok := jestUtils.RemoveMemberAccessorFixes(ctx, match.NotEntry)
+		if !ok {
+			return nil
+		}
+		fixes = append(fixes, removeFixes...)
 	}
+	return fixes
 }
 
-func appendRemoveNotModifierFix(
-	ctx rule.RuleContext,
-	fixes []rule.RuleFix,
-	jestFnCall *utils.ParsedJestFnCall,
-) ([]rule.RuleFix, bool) {
-	for _, modEntry := range jestFnCall.ModifierEntries {
-		if modEntry.Name != "not" || modEntry.Node == nil {
+func hasParenthesizedOptionalChainBoundary(entries []jestUtils.ParsedJestFnMemberEntry) bool {
+	for index := range entries {
+		_, accessor := testFramework.AccessorReceiverAndParent(&entries[index])
+		if accessor == nil || !ast.IsOptionalChain(accessor) {
 			continue
 		}
-
-		removeFixes, ok := utils.RemoveMemberAccessorFixes(ctx, &modEntry)
-		if !ok {
-			return nil, false
+		if parent := accessor.Parent; parent != nil && parent.Kind == ast.KindParenthesizedExpression {
+			return true
 		}
-		return append(fixes, removeFixes...), true
 	}
-	return nil, false
+	return false
 }
 
-// reportPreferToBe emits a diagnostic and an autofix replacing the matcher
-// chain with the canonical equivalent.
-//
-// stripNot removes a leading `.not` / `["not"]` segment when true (e.g.
-// `not.toBe(undefined)` → `toBeDefined()`).
-func reportPreferToBe(ctx rule.RuleContext, kind preferKind, jestFnCall *utils.ParsedJestFnCall, node *ast.Node, stripNot bool) {
-	n := len(jestFnCall.MemberEntries)
-	if n == 0 {
-		return
-	}
-
-	var newMatcher string
-	var msg rule.RuleMessage
-	dropArgs := true
-	switch kind {
-	case preferKindToBe:
-		newMatcher = "toBe"
-		msg = buildUseToBeErrorMessage()
-		dropArgs = false
-	case preferKindNull:
-		newMatcher = "toBeNull"
-		msg = buildUseToBeNullErrorMessage()
-	case preferKindNaN:
-		newMatcher = "toBeNaN"
-		msg = buildUseToBeNaNErrorMessage()
-	case preferKindUndefined:
-		newMatcher = "toBeUndefined"
-		msg = buildUseToBeUndefinedErrorMessage()
-	case preferKindDefined:
-		newMatcher = "toBeDefined"
-		msg = buildUseToBeDefinedErrorMessage()
-	default:
-		return
-	}
-
-	matcherEntry := jestFnCall.MemberEntries[n-1]
-	reportNode := matcherEntry.Node
-	if reportNode == nil {
-		reportNode = node
-	}
-	reportWithoutFix := func() {
-		ctx.ReportNode(reportNode, msg)
-	}
-
-	matcherCall := node.AsCallExpression()
-	if matcherCall == nil {
-		reportWithoutFix()
-		return
-	}
-	matcherExpr := matcherCall.Expression
-	if matcherExpr == nil {
-		reportWithoutFix()
-		return
-	}
-
-	// At most: rename matcher, replace (...)/[], strip `.not`.
-	fixes := make([]rule.RuleFix, 0, 3)
-	renameFix, ok := utils.ReplaceMemberNameFix(ctx, &matcherEntry, newMatcher)
-	if !ok {
-		reportWithoutFix()
-		return
-	}
-	fixes = append(fixes, renameFix)
-
-	if dropArgs {
-		callFix, ok := utils.ReplaceCallSuffixFix(ctx.SourceFile, node, "()")
-		if !ok {
-			reportWithoutFix()
-			return
-		}
-		fixes = append(fixes, callFix)
-	}
-
-	if stripNot {
-		var ok bool
-		fixes, ok = appendRemoveNotModifierFix(ctx, fixes, jestFnCall)
-		if !ok {
-			reportWithoutFix()
-			return
-		}
-	}
-
-	ctx.ReportNodeWithFixes(reportNode, msg, fixes...)
-}
-
-var PreferToBeRule = rule.Rule{
-	Name:   "jest/prefer-to-be",
-	Schema: rule.EmptyArraySchema,
-	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
-		return rule.RuleListeners{
-			ast.KindCallExpression: func(node *ast.Node) {
-				jestFnCall := utils.ParseJestFnCall(node, ctx)
-				if jestFnCall == nil || jestFnCall.Kind != utils.JestFnTypeExpect {
-					return
-				}
-
-				members := jestFnCall.Members
-				if len(members) == 0 {
-					return
-				}
-
-				matcherName := members[len(members)-1]
-				hasNot := slices.Contains(jestFnCall.Modifiers, "not")
-
-				if hasNot {
-					switch matcherName {
-					case "toBeUndefined":
-						reportPreferToBe(ctx, preferKindDefined, jestFnCall, node, true)
-						return
-					case "toBeDefined":
-						reportPreferToBe(ctx, preferKindUndefined, jestFnCall, node, true)
-						return
-					}
-				}
-
-				if !utils.EQUALITY_METHOD_NAMES[matcherName] {
-					return
-				}
-
-				firstArg := firstMatcherArgument(node)
-				if firstArg == nil {
-					return
-				}
-
-				switch {
-				case isNullLiteral(firstArg):
-					reportPreferToBe(ctx, preferKindNull, jestFnCall, node, false)
-				case isIdentifier(firstArg, "undefined"):
-					if hasNot {
-						reportPreferToBe(ctx, preferKindDefined, jestFnCall, node, true)
-					} else {
-						reportPreferToBe(ctx, preferKindUndefined, jestFnCall, node, false)
-					}
-				case isIdentifier(firstArg, "NaN"):
-					reportPreferToBe(ctx, preferKindNaN, jestFnCall, node, false)
-				case matcherName != "toBe" && shouldUseToBe(firstArg):
-					reportPreferToBe(ctx, preferKindToBe, jestFnCall, node, false)
-				}
-			},
-		}
+var PreferToBeRule = shared.NewRule(shared.Config{
+	Name:                   "jest/prefer-to-be",
+	AllowFractionalNumbers: true,
+	Message:                message,
+	Prepare: func(ctx rule.RuleContext) shared.Runtime {
+		return shared.Runtime{Parse: func(node *ast.Node) *shared.ExpectCall {
+			parsed := jestUtils.ParseJestFnCall(node, ctx)
+			if parsed == nil ||
+				parsed.Kind != jestUtils.JestFnTypeExpect ||
+				parsed.MatcherEntry == nil ||
+				hasParenthesizedOptionalChainBoundary(parsed.MemberEntries) {
+				return nil
+			}
+			matcherCall := testFramework.InvokedAccessorCall(parsed.MatcherEntry)
+			if matcherCall == nil {
+				return nil
+			}
+			return &shared.ExpectCall{
+				Matcher:      parsed.Matcher,
+				MatcherEntry: *parsed.MatcherEntry,
+				MatcherCall:  matcherCall,
+				Modifiers:    parsed.ModifierEntries,
+			}
+		}}
 	},
-}
+	BuildFixes: buildFixes,
+})

--- a/internal/plugins/jest/rules/prefer_to_be/prefer_to_be.md
+++ b/internal/plugins/jest/rules/prefer_to_be/prefer_to_be.md
@@ -56,5 +56,5 @@ expect(catchError()).toStrictEqual({ message: undefined });
 
 ## Original Documentation
 
-- [eslint-plugin-jest: prefer-to-be](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/docs/rules/prefer-to-be.md)
-- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/src/rules/prefer-to-be.ts)
+- [eslint-plugin-jest: prefer-to-be](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.1/docs/rules/prefer-to-be.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.1/src/rules/prefer-to-be.ts)

--- a/internal/plugins/jest/rules/prefer_to_be/prefer_to_be_extras_test.go
+++ b/internal/plugins/jest/rules/prefer_to_be/prefer_to_be_extras_test.go
@@ -1,0 +1,258 @@
+// TestPreferToBeExtras locks in branches and edge shapes that the upstream
+// test suite doesn't exercise. Each case carries an inline comment pointing at
+// the specific branch, Dimension 4 row or real-user regression it covers, so
+// future refactors cannot silently regress it without breaking a named lock-in.
+package prefer_to_be_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/microsoft/TypeScript/tsc/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/linter"
+	"github.com/web-infra-dev/rslint/internal/plugins/jest/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/prefer_to_be"
+	lintprogram "github.com/web-infra-dev/rslint/internal/program"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestPreferToBeExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&prefer_to_be.PreferToBeRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Dimension 4: type wrappers not followed by upstream ----
+			{Code: `expect(value).toEqual(null!);`},
+			{Code: `expect(value).toEqual(1 satisfies number);`},
+			// ---- Dimension 4: dynamic and non-string element access ----
+			{Code: `expect(value)[matcher](1);`},
+			{Code: `expect(value)[0](1);`},
+			{Code: `expect(value)[Symbol.iterator](1);`},
+			// ---- Dimension 4: graceful degradation for empty arguments ----
+			{Code: `expect(value).toEqual();`},
+			// ---- Dimension 4: parenthesized optional-chain boundaries ----
+			// ESTree exposes a ChainExpression here, so upstream's member walk
+			// stops instead of treating the outer call as a Jest assertion.
+			{Code: `(expect(value)?.toEqual)(1);`},
+			{Code: `(expect(value)?.not).toBeUndefined();`},
+			// ---- Dimension 4: object, array and regexp literals retain deep equality ----
+			{Code: `expect(value).toEqual({ value: 1 });`},
+			{Code: `expect(value).toEqual([1]);`},
+			{Code: `expect(value).toEqual(/value/);`},
+			// N/A: declaration/container forms; the rule targets call expressions.
+			// N/A: class/function nesting; each assertion is parsed independently.
+			// N/A: object spread, binding rest, empty bodies and overload signatures;
+			// none can occupy a matcher-argument expression inspected by this rule.
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: single and nested parenthesized arguments ----
+			{
+				Code:   `expect(value).toEqual(((1)));`,
+				Output: []string{`expect(value).toBe(((1)));`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBe", Line: 1, Column: 15}},
+			},
+			{
+				Code:   `expect(value).toEqual((null));`,
+				Output: []string{`expect(value).toBeNull();`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBeNull", Line: 1, Column: 15}},
+			},
+			{
+				Code:   `expect(value).toEqual((NaN));`,
+				Output: []string{`expect(value).toBeNaN();`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBeNaN", Line: 1, Column: 15}},
+			},
+			{
+				Code:   `expect(value).toEqual((undefined));`,
+				Output: []string{`expect(value).toBeUndefined();`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBeUndefined", Line: 1, Column: 15}},
+			},
+			// ---- Dimension 4: optional member and optional call chains ----
+			{
+				Code:   `expect(value)?.toEqual?.(1);`,
+				Output: []string{`expect(value)?.toBe?.(1);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBe", Line: 1, Column: 16}},
+			},
+			{
+				Code:   `expect(value)?.not.toBeUndefined?.();`,
+				Output: []string{`expect(value)?.toBeDefined?.();`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBeDefined", Line: 1, Column: 20}},
+			},
+			{
+				Code:   `expect("a string")["not"]["toBe"](undefined);`,
+				Output: []string{`expect("a string")['toBeDefined']();`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBeDefined", Line: 1, Column: 27}},
+			},
+			// ---- Dimension 4: type assertions are transparent ----
+			{
+				Code:   `expect(value).toEqual(<number>1);`,
+				Output: []string{`expect(value).toBe(<number>1);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBe", Line: 1, Column: 15}},
+			},
+			// ---- Dimension 4: string and template-literal accessor forms ----
+			{
+				Code:   "expect(value)[`toEqual`](1);",
+				Output: []string{"expect(value)['toBe'](1);"},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBe", Line: 1, Column: 15}},
+			},
+			// Locks in upstream's textual handling of computed identifier
+			// accessors, including its rewrite of the key identifier itself.
+			{
+				Code:   `const toEqual = 'toEqual'; expect(value)[toEqual](1);`,
+				Output: []string{`const toEqual = 'toEqual'; expect(value)[toBe](1);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBe", Line: 1, Column: 42}},
+			},
+			// ---- Dimension 4: same-kind nesting reports each independent assertion ----
+			{
+				Code: `expect(expect(value).toEqual(1)).toEqual(true);`,
+				Output: []string{
+					`expect(expect(value).toBe(1)).toBe(true);`,
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useToBe", Line: 1, Column: 34},
+					{MessageId: "useToBe", Line: 1, Column: 22},
+				},
+			},
+			// ---- Real-user: eslint-plugin-jest#1260 negative literal regression ----
+			{
+				Code:   `expect(value).toEqual(-1n);`,
+				Output: []string{`expect(value).toBe(-1n);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBe", Line: 1, Column: 15}},
+			},
+			// ---- Real-user: eslint-plugin-jest#1131 computed accessor regression ----
+			{
+				Code:   `expect(value)["toEqual"](false);`,
+				Output: []string{`expect(value)['toBe'](false);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBe", Line: 1, Column: 15}},
+			},
+			// ---- Real-user: eslint-plugin-jest#1282 trailing-comma regression ----
+			{
+				Code:   `expect(value).toEqual(undefined,);`,
+				Output: []string{`expect(value).toBeUndefined();`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBeUndefined", Line: 1, Column: 15}},
+			},
+			// Locks in removeExtraArgumentsFixer semantics: leading comments are
+			// outside the removed range, while trailing argument trivia is removed.
+			{
+				Code:   `expect(value).toEqual(/* keep */ null /* drop */);`,
+				Output: []string{`expect(value).toBeNull(/* keep */ );`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBeNull", Line: 1, Column: 15}},
+			},
+			// Locks in reportPreferToBe special-matcher branch: exact messages and ranges.
+			{
+				Code: `expect(value)
+  .toEqual(null);`,
+				Output: []string{`expect(value)
+  .toBeNull();`},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "useToBeNull", Message: "Use `toBeNull` instead",
+					Line: 2, Column: 4, EndLine: 2, EndColumn: 11,
+				}},
+			},
+			// Locks in not.toBeDefined arm: inversion removes not.
+			{
+				Code:   `expect(value).not.toBeDefined();`,
+				Output: []string{`expect(value).toBeUndefined();`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBeUndefined", Message: "Use `toBeUndefined` instead", Line: 1, Column: 19, EndLine: 1, EndColumn: 30}},
+			},
+			// Locks in reportPreferToBe's conditional argument removal for a
+			// no-argument matcher reached through the pre-equality branch.
+			{
+				Code:   `expect(value).not.toBeDefined('extra');`,
+				Output: []string{`expect(value).toBeUndefined();`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBeUndefined", Line: 1, Column: 19}},
+			},
+			// Locks in undefined-with-not arm: inversion becomes toBeDefined.
+			{
+				Code:   `expect(value).not.toEqual(undefined);`,
+				Output: []string{`expect(value).toBeDefined();`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBeDefined", Message: "Use `toBeDefined` instead", Line: 1, Column: 19, EndLine: 1, EndColumn: 26}},
+			},
+			// Locks in NaN arm: not is retained.
+			{
+				Code:   `expect(value).not.toEqual(NaN);`,
+				Output: []string{`expect(value).not.toBeNaN();`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBeNaN", Message: "Use `toBeNaN` instead", Line: 1, Column: 19, EndLine: 1, EndColumn: 26}},
+			},
+			// Locks in primitive arm: fractional numbers remain eligible for Jest.
+			{
+				Code:   `expect(value).toEqual(-0.3);`,
+				Output: []string{`expect(value).toBe(-0.3);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBe", Message: "Use `toBe` when expecting primitive literals", Line: 1, Column: 15, EndLine: 1, EndColumn: 22}},
+			},
+		},
+	)
+}
+
+func TestPreferToBeEditDemand(t *testing.T) {
+	t.Parallel()
+
+	helper := rule_tester.NewProgramHelper(fixtures.GetRootDir())
+	program, sourceFile, err := helper.CreateTestProgram(
+		`expect(value).not.toEqual(undefined);`,
+		"edit-demand.ts",
+		"tsconfig.json",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	run := func(demand rule.EditDemand) rule.RuleDiagnostic {
+		t.Helper()
+		var diagnostics []rule.RuleDiagnostic
+		linter.LintSingleFile(linter.LintSingleFileOptions{
+			Program:     lintprogram.NewFromCompiler(program),
+			File:        sourceFile.FileName(),
+			HasTypeInfo: true,
+			GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+				return []rule.ConfiguredRule{{
+					Name: prefer_to_be.PreferToBeRule.Name, Severity: rule.SeverityError,
+					Run: func(ctx rule.RuleContext) rule.RuleListeners {
+						return prefer_to_be.PreferToBeRule.Run(ctx, nil)
+					},
+				}}
+			},
+			Consumer: rule.DiagnosticConsumer{Demand: demand, Report: func(diagnostic rule.RuleDiagnostic) {
+				diagnostics = append(diagnostics, diagnostic)
+			}},
+		})
+		if len(diagnostics) != 1 {
+			t.Fatalf("demand %d: diagnostics = %d, want 1", demand, len(diagnostics))
+		}
+		return diagnostics[0]
+	}
+
+	diagnosticsOnly := run(rule.EditDemandNone)
+	autofixOnly := run(rule.EditDemandAutofix)
+	suggestionOnly := run(rule.EditDemandSuggestion)
+	allEdits := run(rule.EditDemandAll)
+
+	withoutEdits := func(diagnostic rule.RuleDiagnostic) rule.RuleDiagnostic {
+		diagnostic.FixesPtr = nil
+		diagnostic.Suggestions = nil
+		return diagnostic
+	}
+	want := withoutEdits(allEdits)
+	for demand, diagnostic := range map[rule.EditDemand]rule.RuleDiagnostic{
+		rule.EditDemandNone: diagnosticsOnly, rule.EditDemandAutofix: autofixOnly,
+		rule.EditDemandSuggestion: suggestionOnly,
+	} {
+		if got := withoutEdits(diagnostic); !reflect.DeepEqual(got, want) {
+			t.Errorf("demand %d diagnostic changed:\ngot  %#v\nwant %#v", demand, got, want)
+		}
+	}
+	if diagnosticsOnly.FixesPtr != nil || suggestionOnly.FixesPtr != nil {
+		t.Fatal("autofixes were materialized without being requested")
+	}
+	if autofixOnly.FixesPtr == nil || allEdits.FixesPtr == nil ||
+		!reflect.DeepEqual(*autofixOnly.FixesPtr, *allEdits.FixesPtr) {
+		t.Fatal("requested autofixes do not match all-edits output")
+	}
+	for _, diagnostic := range []rule.RuleDiagnostic{diagnosticsOnly, autofixOnly, suggestionOnly, allEdits} {
+		if diagnostic.Suggestions != nil {
+			t.Fatal("prefer-to-be unexpectedly materialized suggestions")
+		}
+	}
+}

--- a/internal/plugins/jest/rules/prefer_to_be/prefer_to_be_extras_test.go
+++ b/internal/plugins/jest/rules/prefer_to_be/prefer_to_be_extras_test.go
@@ -97,12 +97,34 @@ func TestPreferToBeExtras(t *testing.T) {
 				Output: []string{"expect(value)['toBe'](1);"},
 				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBe", Line: 1, Column: 15}},
 			},
-			// Locks in upstream's textual handling of computed identifier
-			// accessors, including its rewrite of the key identifier itself.
+			// Diverges from upstream: replaceAccessorFixer rewrites the key
+			// identifier in place, producing a reference to an undeclared
+			// `toBe`. A computed key is quoted so the fixed code still runs.
 			{
 				Code:   `const toEqual = 'toEqual'; expect(value)[toEqual](1);`,
-				Output: []string{`const toEqual = 'toEqual'; expect(value)[toBe](1);`},
+				Output: []string{`const toEqual = 'toEqual'; expect(value)['toBe'](1);`},
 				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBe", Line: 1, Column: 42}},
+			},
+			// Diverges from upstream: the dedicated matchers declare no type
+			// parameters, so type arguments are removed with the value
+			// arguments instead of leaving the assertion failing with TS2558.
+			{
+				Code:   `expect(null).toEqual<null>(null);`,
+				Output: []string{`expect(null).toBeNull();`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBeNull", Line: 1, Column: 14}},
+			},
+			{
+				Code:   `expect(value).toEqual<number>(1);`,
+				Output: []string{`expect(value).toBe<number>(1);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBe", Line: 1, Column: 15}},
+			},
+			// Diverges from upstream: an outer call in the same chain resolves
+			// back to this matcher call, which upstream reports twice at the
+			// same location.
+			{
+				Code:   `expect(promise).resolves.toEqual(null).then(done);`,
+				Output: []string{`expect(promise).resolves.toBeNull().then(done);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBeNull", Line: 1, Column: 26}},
 			},
 			// ---- Dimension 4: same-kind nesting reports each independent assertion ----
 			{

--- a/internal/plugins/jest/rules/prefer_to_be/prefer_to_be_upstream_test.go
+++ b/internal/plugins/jest/rules/prefer_to_be/prefer_to_be_upstream_test.go
@@ -1,3 +1,7 @@
+// TestPreferToBeUpstream migrates the full valid/invalid suite from upstream
+// eslint-plugin-jest@v29.16.1 src/rules/__tests__/prefer-to-be.test.ts 1:1.
+// Position assertions cover line/column for every invalid case. rslint-specific
+// lock-in cases live in prefer_to_be_extras_test.go.
 package prefer_to_be_test
 
 import (
@@ -8,7 +12,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
 
-func TestPreferToBeRule(t *testing.T) {
+func TestPreferToBeUpstream(t *testing.T) {
 	rule_tester.RunRuleTester(
 		fixtures.GetRootDir(),
 		"tsconfig.json",
@@ -31,6 +35,15 @@ func TestPreferToBeRule(t *testing.T) {
 			{Code: `expect(token).toStrictEqual(new RegExp('[abc]+', 'g'));`},
 			{Code: "expect(value).toEqual(dedent`my string`);"},
 			// prefer-to-be: null
+			{Code: `expect(null).toBeNull();`},
+			{Code: `expect(null).not.toBeNull();`},
+			{Code: `expect(null).toBe(1);`},
+			{Code: `expect(obj).toStrictEqual([ x, 1 ]);`},
+			{Code: `expect(obj).toStrictEqual({ x: 1 });`},
+			{Code: `expect(obj).not.toStrictEqual({ x: 1 });`},
+			{Code: `expect(value).toMatchSnapshot();`},
+			{Code: `expect(catchError()).toStrictEqual({ message: 'oh noes!' })`},
+			{Code: `expect("something");`},
 			{Code: `expect(null).not.toEqual();`},
 			{Code: `expect(null).toBe();`},
 			{Code: `expect(null).toMatchSnapshot();`},
@@ -47,11 +60,29 @@ func TestPreferToBeRule(t *testing.T) {
 			{Code: `expect(something).not.toBe(somethingElse)`},
 			{Code: `expect(something).not.toEqual(somethingElse)`},
 			{Code: `expect(undefined).toBe`},
+			{Code: `expect("something");`},
 			// prefer-to-be: NaN
 			{Code: `expect(NaN).toBeNaN();`},
 			{Code: `expect(true).not.toBeNaN();`},
-			{Code: `expect(value).toEqual(null!);`},
-			{Code: `expect(value).toEqual(1 satisfies number);`},
+			{Code: `expect({}).toEqual({});`},
+			{Code: `expect(something).toBe()`},
+			{Code: `expect(something).toBe(somethingElse)`},
+			{Code: `expect(something).toEqual(somethingElse)`},
+			{Code: `expect(something).not.toBe(somethingElse)`},
+			{Code: `expect(something).not.toEqual(somethingElse)`},
+			{Code: `expect(undefined).toBe`},
+			{Code: `expect("something");`},
+			// prefer-to-be: undefined vs defined
+			{Code: `expect(NaN).toBeNaN();`},
+			{Code: `expect(true).not.toBeNaN();`},
+			{Code: `expect({}).toEqual({});`},
+			{Code: `expect(something).toBe()`},
+			{Code: `expect(something).toBe(somethingElse)`},
+			{Code: `expect(something).toEqual(somethingElse)`},
+			{Code: `expect(something).not.toBe(somethingElse)`},
+			{Code: `expect(something).not.toEqual(somethingElse)`},
+			{Code: `expect(undefined).toBe`},
+			{Code: `expect("something");`},
 			// prefer-to-be: typescript edition
 			{Code: `(expect('Model must be bound to an array if the multiple property is true') as any).toHaveBeenTipped()`},
 		},
@@ -81,13 +112,6 @@ func TestPreferToBeRule(t *testing.T) {
 			{
 				Code:   `expect(value).toStrictEqual(1,);`,
 				Output: []string{`expect(value).toBe(1,);`},
-				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "useToBe", Line: 1, Column: 15},
-				},
-			},
-			{
-				Code:   `expect(value).toEqual((1));`,
-				Output: []string{`expect(value).toBe((1));`},
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "useToBe", Line: 1, Column: 15},
 				},
@@ -258,13 +282,6 @@ func TestPreferToBeRule(t *testing.T) {
 				},
 			},
 			{
-				Code:   `expect("a string")["not"]["toBe"](undefined);`,
-				Output: []string{`expect("a string")['toBeDefined']();`},
-				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "useToBeDefined", Line: 1, Column: 27},
-				},
-			},
-			{
 				Code:   `expect("a string").not.toEqual(undefined);`,
 				Output: []string{`expect("a string").toBeDefined();`},
 				Errors: []rule_tester.InvalidTestCaseError{
@@ -422,48 +439,6 @@ func TestPreferToBeRule(t *testing.T) {
 				Output: []string{`expect("a string").toBeUndefined();`},
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "useToBeUndefined", Line: 1, Column: 20},
-				},
-			},
-			{
-				Code:   `expect(value).toEqual((null));`,
-				Output: []string{`expect(value).toBeNull();`},
-				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "useToBeNull", Line: 1, Column: 15},
-				},
-			},
-			{
-				Code:   `expect(value).toEqual((NaN));`,
-				Output: []string{`expect(value).toBeNaN();`},
-				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "useToBeNaN", Line: 1, Column: 15},
-				},
-			},
-			{
-				Code:   `expect(value).toEqual((undefined));`,
-				Output: []string{`expect(value).toBeUndefined();`},
-				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "useToBeUndefined", Line: 1, Column: 15},
-				},
-			},
-			{
-				Code:   `expect("a string")[("not")].toBeUndefined();`,
-				Output: []string{`expect("a string").toBeDefined();`},
-				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "useToBeDefined"},
-				},
-			},
-			{
-				Code:   `expect("a string")?.["not"].toBeUndefined?.();`,
-				Output: []string{`expect("a string")?.toBeDefined?.();`},
-				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "useToBeDefined"},
-				},
-			},
-			{
-				Code:   `(expect("a string")?.["not"]).toBeUndefined();`,
-				Output: []string{},
-				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "useToBeDefined"},
 				},
 			},
 		},

--- a/internal/plugins/jest/utils/parse_jest_fn.go
+++ b/internal/plugins/jest/utils/parse_jest_fn.go
@@ -300,19 +300,7 @@ func isValidJestCall(name string, members []string) bool {
 }
 
 func UnwrapBasicTypeAssertions(node *ast.Node) *ast.Node {
-	for node != nil {
-		switch node.Kind {
-		case ast.KindParenthesizedExpression:
-			node = node.AsParenthesizedExpression().Expression
-		case ast.KindAsExpression:
-			node = node.AsAsExpression().Expression
-		case ast.KindTypeAssertionExpression:
-			node = node.AsTypeAssertion().Expression
-		default:
-			return node
-		}
-	}
-	return node
+	return testFramework.FollowTypeAssertionChain(node)
 }
 
 func UnwrapTypeAssertions(node *ast.Node) *ast.Node {

--- a/internal/plugins/rstest/all.go
+++ b/internal/plugins/rstest/all.go
@@ -45,6 +45,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/prefer_rs_mocked"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/prefer_strict_boolean_matchers"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/prefer_strict_equal"
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/prefer_to_be"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/prefer_to_be_falsy"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/prefer_to_be_truthy"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/prefer_todo"
@@ -106,6 +107,7 @@ func GetAllRules() []rule.Rule {
 		prefer_rs_mocked.PreferRsMockedRule,
 		prefer_strict_boolean_matchers.PreferStrictBooleanMatchersRule,
 		prefer_strict_equal.PreferStrictEqualRule,
+		prefer_to_be.PreferToBeRule,
 		prefer_to_be_falsy.PreferToBeFalsyRule,
 		prefer_to_be_truthy.PreferToBeTruthyRule,
 		prefer_todo.PreferTodoRule,

--- a/internal/plugins/rstest/rules/prefer_to_be/prefer_to_be.go
+++ b/internal/plugins/rstest/rules/prefer_to_be/prefer_to_be.go
@@ -1,0 +1,141 @@
+package prefer_to_be
+
+import (
+	"github.com/microsoft/TypeScript/tsc/shim/ast"
+	rstestUtils "github.com/web-infra-dev/rslint/internal/plugins/rstest/utils"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	internalUtils "github.com/web-infra-dev/rslint/internal/utils"
+	testFramework "github.com/web-infra-dev/rslint/internal/utils/test_framework"
+	shared "github.com/web-infra-dev/rslint/internal/utils/test_framework/rules/prefer_to_be"
+)
+
+func message(kind shared.Kind) rule.RuleMessage {
+	switch kind {
+	case shared.KindToBe:
+		return rule.RuleMessage{Id: "useToBe", Description: "Use `toBe` instead"}
+	case shared.KindNull:
+		return rule.RuleMessage{Id: "useToBeNull", Description: "Use `toBeNull()` instead"}
+	case shared.KindNaN:
+		return rule.RuleMessage{Id: "useToBeNaN", Description: "Use `toBeNaN()` instead"}
+	case shared.KindUndefined:
+		return rule.RuleMessage{Id: "useToBeUndefined", Description: "Use `toBeUndefined()` instead"}
+	case shared.KindDefined:
+		return rule.RuleMessage{Id: "useToBeDefined", Description: "Use `toBeDefined()` instead"}
+	default:
+		return rule.RuleMessage{}
+	}
+}
+
+func matcherName(kind shared.Kind) string {
+	switch kind {
+	case shared.KindToBe:
+		return "toBe"
+	case shared.KindNull:
+		return "toBeNull"
+	case shared.KindNaN:
+		return "toBeNaN"
+	case shared.KindUndefined:
+		return "toBeUndefined"
+	case shared.KindDefined:
+		return "toBeDefined"
+	default:
+		return ""
+	}
+}
+
+func buildFixes(ctx rule.RuleContext, match shared.Match) []rule.RuleFix {
+	replacement := matcherName(match.Kind)
+	if replacement == "" {
+		return nil
+	}
+
+	nameRange, nameText, ok := testFramework.AccessorReplacement(
+		ctx.SourceFile,
+		match.Expect.MatcherEntry.Node,
+		replacement,
+	)
+	if !ok {
+		return nil
+	}
+	fixes := []rule.RuleFix{rule.RuleFixReplaceRange(nameRange, nameText)}
+
+	if match.Kind != shared.KindToBe && len(match.Expect.MatcherCall.Arguments()) > 0 {
+		argumentsRange, ok := testFramework.CallArgumentListRange(
+			ctx.SourceFile,
+			match.Expect.MatcherCall,
+		)
+		if !ok || internalUtils.HasCommentInSpan(
+			ctx.Comments.All(),
+			argumentsRange.Pos(),
+			argumentsRange.End(),
+		) {
+			return nil
+		}
+		fixes = append(fixes, rule.RuleFixRemoveRange(argumentsRange))
+	}
+
+	if match.NotEntry != nil {
+		ranges, ok := testFramework.RemoveAccessorEntryRanges(
+			ctx.SourceFile,
+			ctx.Comments.All(),
+			match.NotEntry,
+		)
+		if !ok {
+			return nil
+		}
+		for _, textRange := range ranges {
+			fixes = append(fixes, rule.RuleFixRemoveRange(textRange))
+		}
+	}
+	return fixes
+}
+
+func isUnshadowedSpecialIdentifier(ctx rule.RuleContext, node *ast.Node, _ string) bool {
+	if ctx.Refs == nil {
+		return true
+	}
+	symbol := ctx.Refs.Resolve(node)
+	return symbol == nil || !internalUtils.IsRuntimeValueSymbolDeclaredInFile(symbol, ctx.SourceFile)
+}
+
+var PreferToBeRule = shared.NewRule(shared.Config{
+	Name:    "rstest/prefer-to-be",
+	Message: message,
+	// NOTE: Unlike @vitest/eslint-plugin, locally shadowed `undefined` and
+	// `NaN` are values chosen by the author, not the built-ins named by the
+	// dedicated matchers.
+	IsSpecialIdentifier: isUnshadowedSpecialIdentifier,
+	Prepare: func(ctx rule.RuleContext) shared.Runtime {
+		analysis := rstestUtils.GetRstestCallAnalysis(ctx)
+		return shared.Runtime{Parse: func(node *ast.Node) *shared.ExpectCall {
+			parsed := analysis.ParseExpectCall(node)
+			if parsed == nil ||
+				parsed.Reason != rstestUtils.RstestExpectParseReasonNone ||
+				parsed.Head == nil ||
+				parsed.Entry == rstestUtils.RstestExpectEntryElement ||
+				parsed.MatcherEntry == nil ||
+				len(parsed.Matchers) == 0 ||
+				parsed.Matchers[0].Kind != rstestUtils.RstestExpectMatcherCall ||
+				testFramework.IsComputedIdentifierAccessor(parsed.MatcherEntry.Node) {
+				return nil
+			}
+
+			matcherCall := testFramework.InvokedAccessorCall(parsed.MatcherEntry)
+			if matcherCall == nil {
+				return nil
+			}
+			return &shared.ExpectCall{
+				Matcher:      parsed.Matcher,
+				MatcherEntry: *parsed.MatcherEntry,
+				MatcherCall:  matcherCall,
+				Modifiers:    parsed.ModifierEntries,
+			}
+		}}
+	},
+	// NOTE: Unlike @vitest/eslint-plugin, the shared decision records `.not`
+	// for equality checks against undefined too. buildFixes therefore turns
+	// `not.toEqual(undefined)` into the equivalent `toBeDefined()`.
+	// AllowFractionalNumbers stays false: Rstest's Vitest matcher layer
+	// recommends toBeCloseTo for both positive and negative decimals.
+	BuildFixes: buildFixes,
+})

--- a/internal/plugins/rstest/rules/prefer_to_be/prefer_to_be.go
+++ b/internal/plugins/rstest/rules/prefer_to_be/prefer_to_be.go
@@ -59,6 +59,26 @@ func buildFixes(ctx rule.RuleContext, match shared.Match) []rule.RuleFix {
 	}
 	fixes := []rule.RuleFix{rule.RuleFixReplaceRange(nameRange, nameText)}
 
+	if match.Kind != shared.KindToBe {
+		// NOTE: unlike @vitest/eslint-plugin, type arguments are removed with
+		// the value arguments. toBeNull, toBeNaN, toBeUndefined and toBeDefined
+		// declare no type parameters, so keeping `toEqual<null>`'s type
+		// argument would leave the fixed assertion failing with TS2558.
+		if typeArgumentsRange, hasTypeArguments := testFramework.CallTypeArgumentListRange(
+			ctx.SourceFile,
+			match.Expect.MatcherCall,
+		); hasTypeArguments {
+			if internalUtils.HasCommentInSpan(
+				ctx.Comments.All(),
+				typeArgumentsRange.Pos(),
+				typeArgumentsRange.End(),
+			) {
+				return nil
+			}
+			fixes = append(fixes, rule.RuleFixRemoveRange(typeArgumentsRange))
+		}
+	}
+
 	if match.Kind != shared.KindToBe && len(match.Expect.MatcherCall.Arguments()) > 0 {
 		argumentsRange, ok := testFramework.CallArgumentListRange(
 			ctx.SourceFile,

--- a/internal/plugins/rstest/rules/prefer_to_be/prefer_to_be.md
+++ b/internal/plugins/rstest/rules/prefer_to_be/prefer_to_be.md
@@ -1,0 +1,36 @@
+# prefer-to-be
+
+## Rule Details
+
+This rule asks equality assertions to use the matcher that most directly states what is being checked. Primitive literals use `toBe()`, while `null`, `undefined` and `NaN` use their dedicated matchers. Negated undefined checks are normalized to the positive complementary matcher.
+
+Examples of **incorrect** code for this rule:
+
+```ts
+expect(status).toEqual('ready');
+expect(result).toStrictEqual(1);
+expect(value).toBe(null);
+expect(value).not.toEqual(undefined);
+expect(value).toStrictEqual(NaN);
+```
+
+Examples of **correct** code for this rule:
+
+```ts
+expect(status).toBe('ready');
+expect(result).toBe(1);
+expect(value).toBeNull();
+expect(value).toBeDefined();
+expect(value).toBeNaN();
+
+expect(result).toEqual({ value: 1 });
+expect(total).toBeCloseTo(0.3);
+```
+
+Fractional numeric literals are left alone. Rstest uses Vitest's assertion implementation, whose public API recommends `toBeCloseTo()` for floating-point comparisons; automatically changing `toEqual(0.3)` to `toBe(0.3)` would preserve exact equality while steering the test toward the wrong matcher.
+
+The rule recognizes Rstest globals, imports from Rstest packages, namespace and `require` bindings, `import.meta.rstest`, `expect.soft()`, `expect.poll()`, and the `expect` supplied by a [test context](https://rstest.rs/api/runtime-api/test-api/test#testcontext). Browser-only `expect.element()` assertions are excluded because their matcher set does not provide these value matchers. Chai-style assertions such as `expect(value).to.equal(1)` are also left alone. Locally declared values named `undefined` or `NaN` do not select the dedicated built-in matchers.
+
+## Autofix
+
+The autofix renames the matcher, removes arguments from dedicated no-argument matchers, and removes `.not` when a negated undefined check is rewritten to its positive complement. The authored accessor style is retained, so `["toEqual"]` becomes `["toBe"]`. If removing arguments would delete a comment, the diagnostic is emitted without a fix.

--- a/internal/plugins/rstest/rules/prefer_to_be/prefer_to_be_extras_test.go
+++ b/internal/plugins/rstest/rules/prefer_to_be/prefer_to_be_extras_test.go
@@ -111,6 +111,32 @@ func TestPreferToBeExtras(t *testing.T) {
 				Output: []string{"expect(value)[`toBe`](1);"},
 				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBe", Line: 1, Column: 15}},
 			},
+			// Diverges from @vitest/eslint-plugin: the dedicated matchers declare
+			// no type parameters, so type arguments go with the value arguments
+			// instead of leaving the fixed assertion failing with TS2558.
+			{
+				Code:   `expect(null).toEqual<null>(null);`,
+				Output: []string{`expect(null).toBeNull();`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBeNull", Line: 1, Column: 14}},
+			},
+			{
+				Code:   `expect(value).not.toBeDefined<never>();`,
+				Output: []string{`expect(value).toBeUndefined();`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBeUndefined", Line: 1, Column: 19}},
+			},
+			// toBe shares toEqual's single type parameter, so its type argument
+			// stays.
+			{
+				Code:   `expect(value).toEqual<number>(1);`,
+				Output: []string{`expect(value).toBe<number>(1);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBe", Line: 1, Column: 15}},
+			},
+			// A comment inside the removed type arguments withholds the fix, as
+			// it does inside the removed value arguments.
+			{
+				Code:   `expect(null).toEqual</* keep */ null>(null);`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBeNull", Line: 1, Column: 14}},
+			},
 			// ---- Dimension 4: a trailing call cannot replace matcher arguments ----
 			{
 				Code:   `expect(value).toEqual(1)();`,

--- a/internal/plugins/rstest/rules/prefer_to_be/prefer_to_be_extras_test.go
+++ b/internal/plugins/rstest/rules/prefer_to_be/prefer_to_be_extras_test.go
@@ -1,0 +1,360 @@
+// TestPreferToBeExtras locks in branches and edge shapes that the upstream
+// suite does not exercise: Rstest expect sources, every relevant tsgo wrapper,
+// safe-fix boundaries, semantic corrections and edit-demand behavior.
+package prefer_to_be
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/microsoft/TypeScript/tsc/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/linter"
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/fixtures"
+	lintprogram "github.com/web-infra-dev/rslint/internal/program"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestPreferToBeExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&PreferToBeRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Dimension 4: non-null and satisfies wrappers stay opaque ----
+			{Code: `expect(value).toEqual(null!);`},
+			{Code: `expect(value).toEqual(1 satisfies number);`},
+			// ---- Dimension 4: regexp/object/array values require deep equality ----
+			{Code: `expect(value).toEqual(/value/);`},
+			{Code: `expect(value).toStrictEqual({ value: 1 });`},
+			{Code: `expect(value).toEqual([1]);`},
+			// ---- Dimension 4: dynamic, numeric and symbol accessors are not names ----
+			{Code: `expect(value)[matcher](1);`},
+			{Code: `expect(value)[0](1);`},
+			{Code: `expect(value)[Symbol.iterator](1);`},
+			// ---- Dimension 4: empty matcher calls ----
+			{Code: `expect(value).toEqual();`},
+			{Code: `expect(value).to.equal(1);`},
+			{Code: `expect.toEqual(1);`},
+			{Code: `expect(value).resolves.rejects.toEqual(1);`},
+			// ---- Dimension 4: receiver type wrappers are parse boundaries ----
+			{Code: `(expect(value) as any).toEqual(1);`},
+			{Code: `expect(value)!.toEqual(1);`},
+			{Code: `(expect(value) satisfies Assertion).toEqual(1);`},
+			// ---- Rstest reality: element assertions do not expose these matchers ----
+			{Code: `expect.element(locator).toEqual(1);`},
+			// ---- Rstest reality: other assertion libraries and local shadows ----
+			{Code: `import { expect } from 'vitest'; expect(value).toEqual(1);`},
+			{Code: `import { expect } from '@jest/globals'; expect(value).toEqual(1);`},
+			{Code: `import { expect } from 'chai'; expect(value).toEqual(1);`},
+			{Code: `const expect = createExpect(); expect(value).toEqual(1);`},
+			{Code: `import { expect } from '@rstest/core'; function f(expect: any) { expect(value).toEqual(1); }`},
+			// ---- Rstest semantic correction: locally shadowed special values ----
+			{Code: `const undefined = 1; expect(value).toEqual(undefined);`},
+			{Code: `function f(NaN: number) { expect(value).toEqual(NaN); }`},
+			// ---- Vitest policy: positive and negative fractional literals ----
+			{Code: `expect(value).toEqual(0.3);`},
+			{Code: `expect(value).toEqual(-0.3);`},
+			// N/A: declaration/container and function/class forms; this rule
+			// inspects only parsed assertion calls.
+			// N/A: spread/rest in object or binding patterns, empty bodies and
+			// overload signatures cannot be matcher arguments of the inspected kind.
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: nested parentheses are transparent ----
+			{
+				Code:   `expect(value).toEqual(((1)));`,
+				Output: []string{`expect(value).toBe(((1)));`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBe", Line: 1, Column: 15}},
+			},
+			{
+				Code:   `expect(value).toEqual((undefined));`,
+				Output: []string{`expect(value).toBeUndefined();`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBeUndefined", Line: 1, Column: 15}},
+			},
+			// ---- Dimension 4: type assertions are transparent ----
+			{
+				Code:   `expect(value).toEqual(<number>1);`,
+				Output: []string{`expect(value).toBe(<number>1);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBe", Line: 1, Column: 15}},
+			},
+			// A type-only declaration does not shadow the runtime built-in.
+			{
+				Code:   `type NaN = number; expect(value).toEqual(NaN);`,
+				Output: []string{`type NaN = number; expect(value).toBeNaN();`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBeNaN", Line: 1, Column: 34}},
+			},
+			// ---- Dimension 4: optional chain flags and accessor forms ----
+			{
+				Code:   `expect(value)?.toEqual?.(1);`,
+				Output: []string{`expect(value)?.toBe?.(1);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBe", Line: 1, Column: 16}},
+			},
+			{
+				Code:   `(expect(value)).toEqual(1);`,
+				Output: []string{`(expect(value)).toBe(1);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBe", Line: 1, Column: 17}},
+			},
+			{
+				Code:   `(expect(value)?.toEqual)(1);`,
+				Output: []string{`(expect(value)?.toBe)(1);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBe", Line: 1, Column: 17}},
+			},
+			{
+				Code:   `expect(value)["toEqual"](1);`,
+				Output: []string{`expect(value)["toBe"](1);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBe", Line: 1, Column: 15}},
+			},
+			{
+				Code:   "expect(value)[`toEqual`](1);",
+				Output: []string{"expect(value)[`toBe`](1);"},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBe", Line: 1, Column: 15}},
+			},
+			// ---- Dimension 4: a trailing call cannot replace matcher arguments ----
+			{
+				Code:   `expect(value).toEqual(1)();`,
+				Output: []string{`expect(value).toBe(1)();`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBe", Line: 1, Column: 15}},
+			},
+			// ---- Dimension 3: comments outside edited arguments survive ----
+			{
+				Code:   `expect(value). /* keep */ toEqual(null);`,
+				Output: []string{`expect(value). /* keep */ toBeNull();`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBeNull", Line: 1, Column: 27}},
+			},
+			{
+				Code:   `expect(value).toEqual /* keep */ (null);`,
+				Output: []string{`expect(value).toBeNull /* keep */ ();`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBeNull", Line: 1, Column: 15}},
+			},
+			// ---- Dimension 3: comments inside removed arguments withhold fixes ----
+			{
+				Code:   `expect(value).toEqual(/* keep */ null);`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBeNull", Line: 1, Column: 15}},
+			},
+			{
+				Code:   `expect(value).not /* keep */ .toEqual(undefined);`,
+				Output: []string{`expect(value) /* keep */ .toBeDefined();`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBeDefined", Line: 1, Column: 31}},
+			},
+			// Locks in the upstream argument-count branch: only the first
+			// argument selects toBe, and toBe keeps the authored argument list.
+			{
+				Code:   `expect(value).toEqual(1, 2);`,
+				Output: []string{`expect(value).toBe(1, 2);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBe", Line: 1, Column: 15}},
+			},
+			// ---- Real-user: eslint-plugin-jest#1260 negative literal regression ----
+			{
+				Code:   `expect(value).toEqual(-1);`,
+				Output: []string{`expect(value).toBe(-1);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBe", Line: 1, Column: 15}},
+			},
+			// ---- Real-user: eslint-plugin-jest#1131 computed accessor regression ----
+			{
+				Code:   `expect(value)['toEqual'](false);`,
+				Output: []string{`expect(value)['toBe'](false);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBe", Line: 1, Column: 15}},
+			},
+			// ---- Real-user: eslint-plugin-jest#1282 trailing-comma regression ----
+			{
+				Code:   `expect(value).toEqual(null,);`,
+				Output: []string{`expect(value).toBeNull();`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBeNull", Line: 1, Column: 15}},
+			},
+			// ---- Rstest expect factories ----
+			{
+				Code:   `expect.soft(value).toEqual(1);`,
+				Output: []string{`expect.soft(value).toBe(1);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBe", Line: 1, Column: 20}},
+			},
+			{
+				Code:   `expect(value, 'status').toStrictEqual(1);`,
+				Output: []string{`expect(value, 'status').toBe(1);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBe", Line: 1, Column: 25}},
+			},
+			{
+				Code:   `await expect.poll(() => value).toEqual(1);`,
+				Output: []string{`await expect.poll(() => value).toBe(1);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBe", Line: 1, Column: 32}},
+			},
+			// ---- Rstest source resolution ----
+			{
+				Code: `import { expect as check } from '@rstest/core';
+check(value).toEqual(null);`,
+				Output: []string{`import { expect as check } from '@rstest/core';
+check(value).toBeNull();`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBeNull", Line: 2, Column: 14}},
+			},
+			{
+				Code: `import { expect } from 'rstack/test';
+expect(value).toEqual(1);`,
+				Output: []string{`import { expect } from 'rstack/test';
+expect(value).toBe(1);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBe", Line: 2, Column: 15}},
+			},
+			{
+				Code: `const { expect } = require('@rstest/core');
+expect(value).toEqual(1);`,
+				Output: []string{`const { expect } = require('@rstest/core');
+expect(value).toBe(1);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBe", Line: 2, Column: 15}},
+			},
+			{
+				Code: `import * as core from '@rstest/core';
+core.expect(value).toEqual(undefined);`,
+				Output: []string{`import * as core from '@rstest/core';
+core.expect(value).toBeUndefined();`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBeUndefined", Line: 2, Column: 20}},
+			},
+			{
+				Code:   `import.meta.rstest.expect(value).toStrictEqual(NaN);`,
+				Output: []string{`import.meta.rstest.expect(value).toBeNaN();`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBeNaN", Line: 1, Column: 34}},
+			},
+			{
+				Code: `const { expect: check } = import.meta.rstest;
+check(value).toEqual('ready');`,
+				Output: []string{`const { expect: check } = import.meta.rstest;
+check(value).toBe('ready');`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBe", Line: 2, Column: 14}},
+			},
+			{
+				Code: `import { expect } from '@rstest/playwright';
+expect(value).toEqual(true);`,
+				Output: []string{`import { expect } from '@rstest/playwright';
+expect(value).toBe(true);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBe", Line: 2, Column: 15}},
+			},
+			{
+				Code:   `test('x', ctx => ctx.expect(value).toEqual(1));`,
+				Output: []string{`test('x', ctx => ctx.expect(value).toBe(1));`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBe", Line: 1, Column: 36}},
+			},
+			{
+				Code:   `test('x', ({ expect }) => expect(value).toEqual(1));`,
+				Output: []string{`test('x', ({ expect }) => expect(value).toBe(1));`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBe", Line: 1, Column: 41}},
+			},
+			// ---- Dimension 4: nested assertions remain independent ----
+			{
+				Code:   `expect(expect(value).toEqual(1)).toEqual(true);`,
+				Output: []string{`expect(expect(value).toBe(1)).toBe(true);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "useToBe", Line: 1, Column: 34},
+					{MessageId: "useToBe", Line: 1, Column: 22},
+				},
+			},
+			// Locks in primitive-literal arm and its exact multiline range.
+			{
+				Code: `expect(value)
+  .toEqual('ready');`,
+				Output: []string{`expect(value)
+  .toBe('ready');`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBe", Message: "Use `toBe` instead", Line: 2, Column: 4, EndLine: 2, EndColumn: 11}},
+			},
+			// Locks in not.toBeDefined arm: inversion removes not.
+			{
+				Code:   `expect(value).not.toBeDefined();`,
+				Output: []string{`expect(value).toBeUndefined();`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBeUndefined", Message: "Use `toBeUndefined()` instead", Line: 1, Column: 19, EndLine: 1, EndColumn: 30}},
+			},
+			// Locks in the special-matcher argument-removal branch.
+			{
+				Code:   `expect(value).not.toBeDefined('extra');`,
+				Output: []string{`expect(value).toBeUndefined();`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBeUndefined", Line: 1, Column: 19}},
+			},
+			// Locks in undefined-with-not arm and fixes an upstream Vitest semantic bug.
+			{
+				Code: `expect(value)
+  .not.toEqual(undefined);`,
+				Output: []string{`expect(value).toBeDefined();`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBeDefined", Message: "Use `toBeDefined()` instead", Line: 2, Column: 8, EndLine: 2, EndColumn: 15}},
+			},
+			// Locks in null and NaN arms: not remains semantically meaningful.
+			{
+				Code:   `expect(value).not.toEqual(null);`,
+				Output: []string{`expect(value).not.toBeNull();`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBeNull", Message: "Use `toBeNull()` instead", Line: 1, Column: 19, EndLine: 1, EndColumn: 26}},
+			},
+			{
+				Code:   `expect(value).not.toEqual(NaN);`,
+				Output: []string{`expect(value).not.toBeNaN();`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBeNaN", Message: "Use `toBeNaN()` instead", Line: 1, Column: 19, EndLine: 1, EndColumn: 26}},
+			},
+		},
+	)
+}
+
+func TestPreferToBeEditDemand(t *testing.T) {
+	t.Parallel()
+
+	helper := rule_tester.NewProgramHelper(fixtures.GetRootDir())
+	program, sourceFile, err := helper.CreateTestProgram(
+		`expect(value).not.toEqual(undefined);`,
+		"edit-demand.ts",
+		"tsconfig.json",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	run := func(demand rule.EditDemand) rule.RuleDiagnostic {
+		t.Helper()
+		var diagnostics []rule.RuleDiagnostic
+		linter.LintSingleFile(linter.LintSingleFileOptions{
+			Program:     lintprogram.NewFromCompiler(program),
+			File:        sourceFile.FileName(),
+			HasTypeInfo: true,
+			GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+				return []rule.ConfiguredRule{{
+					Name: PreferToBeRule.Name, Severity: rule.SeverityError,
+					Run: func(ctx rule.RuleContext) rule.RuleListeners {
+						return PreferToBeRule.Run(ctx, nil)
+					},
+				}}
+			},
+			Consumer: rule.DiagnosticConsumer{Demand: demand, Report: func(diagnostic rule.RuleDiagnostic) {
+				diagnostics = append(diagnostics, diagnostic)
+			}},
+		})
+		if len(diagnostics) != 1 {
+			t.Fatalf("demand %d: diagnostics = %d, want 1", demand, len(diagnostics))
+		}
+		return diagnostics[0]
+	}
+
+	diagnosticsOnly := run(rule.EditDemandNone)
+	autofixOnly := run(rule.EditDemandAutofix)
+	suggestionOnly := run(rule.EditDemandSuggestion)
+	allEdits := run(rule.EditDemandAll)
+
+	withoutEdits := func(diagnostic rule.RuleDiagnostic) rule.RuleDiagnostic {
+		diagnostic.FixesPtr = nil
+		diagnostic.Suggestions = nil
+		return diagnostic
+	}
+	want := withoutEdits(allEdits)
+	for demand, diagnostic := range map[rule.EditDemand]rule.RuleDiagnostic{
+		rule.EditDemandNone: diagnosticsOnly, rule.EditDemandAutofix: autofixOnly,
+		rule.EditDemandSuggestion: suggestionOnly,
+	} {
+		if got := withoutEdits(diagnostic); !reflect.DeepEqual(got, want) {
+			t.Errorf("demand %d diagnostic changed:\ngot  %#v\nwant %#v", demand, got, want)
+		}
+	}
+	if diagnosticsOnly.FixesPtr != nil || suggestionOnly.FixesPtr != nil {
+		t.Fatal("autofixes were materialized without being requested")
+	}
+	if autofixOnly.FixesPtr == nil || allEdits.FixesPtr == nil ||
+		!reflect.DeepEqual(*autofixOnly.FixesPtr, *allEdits.FixesPtr) {
+		t.Fatal("requested autofixes do not match all-edits output")
+	}
+	for _, diagnostic := range []rule.RuleDiagnostic{diagnosticsOnly, autofixOnly, suggestionOnly, allEdits} {
+		if diagnostic.Suggestions != nil {
+			t.Fatal("prefer-to-be unexpectedly materialized suggestions")
+		}
+	}
+}

--- a/internal/plugins/rstest/rules/prefer_to_be/prefer_to_be_upstream_test.go
+++ b/internal/plugins/rstest/rules/prefer_to_be/prefer_to_be_upstream_test.go
@@ -1,0 +1,115 @@
+// TestPreferToBeUpstream migrates the full valid/invalid suite from upstream
+// @vitest/eslint-plugin@v1.6.27 tests/prefer-to-be.test.ts 1:1. Position
+// assertions cover line/column for every invalid case. Rstest-specific API
+// sources, semantic corrections and edge-shape lock-ins live in
+// prefer_to_be_extras_test.go.
+package prefer_to_be
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestPreferToBeUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&PreferToBeRule,
+		[]rule_tester.ValidTestCase{
+			{Code: `expect(null).toBeNull();`},
+			{Code: `expect(null).not.toBeNull();`},
+			{Code: `expect(null).toBe(-1);`},
+			{Code: `expect(null).toBe(1);`},
+			{Code: `expect(obj).toStrictEqual([ x, 1 ]);`},
+			{Code: `expect(obj).toStrictEqual({ x: 1 });`},
+			{Code: `expect(obj).not.toStrictEqual({ x: 1 });`},
+			{Code: `expect(value).toMatchSnapshot();`},
+			{Code: `expect(catchError()).toStrictEqual({ message: 'oh noes!' })`},
+			{Code: `expect("something");`},
+			{Code: `expect("hey").to.be.a("string");`},
+			{Code: `expect(token).toStrictEqual(/[abc]+/g);`},
+			{Code: `expect(token).toStrictEqual(new RegExp('[abc]+', 'g'));`},
+			{Code: `expect(0.1 + 0.2).toEqual(0.3);`},
+
+			{Code: `expect(NaN).toBeNaN();`},
+			{Code: `expect(true).not.toBeNaN();`},
+			{Code: `expect({}).toEqual({});`},
+			{Code: `expect(something).toBe()`},
+			{Code: `expect(something).toBe(somethingElse)`},
+			{Code: `expect(something).toEqual(somethingElse)`},
+			{Code: `expect(something).not.toBe(somethingElse)`},
+			{Code: `expect(something).not.toEqual(somethingElse)`},
+			{Code: `expect(undefined).toBe`},
+			{Code: `expect("something");`},
+
+			{Code: `expect(null).toBeNull();`},
+			{Code: `expect(null).not.toBeNull();`},
+			{Code: `expect(null).toBe(1);`},
+			{Code: `expect(obj).toStrictEqual([ x, 1 ]);`},
+			{Code: `expect(obj).toStrictEqual({ x: 1 });`},
+			{Code: `expect(obj).not.toStrictEqual({ x: 1 });`},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code:   `expect(value).toEqual("my string");`,
+				Output: []string{`expect(value).toBe("my string");`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBe", Line: 1, Column: 15}},
+			},
+			{
+				Code:   `expect("a string").not.toEqual(null);`,
+				Output: []string{`expect("a string").not.toBeNull();`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBeNull", Line: 1, Column: 24}},
+			},
+			{
+				Code:   `expect("a string").not.toStrictEqual(null);`,
+				Output: []string{`expect("a string").not.toBeNull();`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBeNull", Line: 1, Column: 24}},
+			},
+
+			{
+				Code:   `expect(NaN).toBe(NaN);`,
+				Output: []string{`expect(NaN).toBeNaN();`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBeNaN", Line: 1, Column: 13}},
+			},
+			{
+				Code:   `expect("a string").not.toBe(NaN);`,
+				Output: []string{`expect("a string").not.toBeNaN();`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBeNaN", Line: 1, Column: 24}},
+			},
+			{
+				Code:   `expect("a string").not.toStrictEqual(NaN);`,
+				Output: []string{`expect("a string").not.toBeNaN();`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBeNaN", Line: 1, Column: 24}},
+			},
+
+			{
+				Code:   `expect(null).toBe(null);`,
+				Output: []string{`expect(null).toBeNull();`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBeNull", Line: 1, Column: 14}},
+			},
+			{
+				Code:   `expect(null).toEqual(null);`,
+				Output: []string{`expect(null).toBeNull();`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBeNull", Line: 1, Column: 14}},
+			},
+			{
+				Code:   `expect("a string").not.toEqual(null as number);`,
+				Output: []string{`expect("a string").not.toBeNull();`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBeNull", Line: 1, Column: 24}},
+			},
+			{
+				Code:   `expect(undefined).toBe(undefined as unknown as string as any);`,
+				Output: []string{`expect(undefined).toBeUndefined();`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBeUndefined", Line: 1, Column: 19}},
+			},
+			{
+				Code:   `expect("a string").toEqual(undefined as number);`,
+				Output: []string{`expect("a string").toBeUndefined();`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBeUndefined", Line: 1, Column: 20}},
+			},
+		},
+	)
+}

--- a/internal/plugins/rstest/utils/matcher_edit.go
+++ b/internal/plugins/rstest/utils/matcher_edit.go
@@ -3,7 +3,6 @@ package utils
 import (
 	"github.com/microsoft/TypeScript/tsc/shim/ast"
 	"github.com/microsoft/TypeScript/tsc/shim/core"
-	"github.com/web-infra-dev/rslint/internal/utils"
 	testFramework "github.com/web-infra-dev/rslint/internal/utils/test_framework"
 )
 
@@ -25,23 +24,7 @@ import (
 // and stops at it. Parentheses around the callee are transparent, matching how
 // the chain was parsed in the first place.
 func MatcherCall(entry *ParsedRstestFnMemberEntry) *ast.Node {
-	_, accessor := testFramework.AccessorReceiverAndParent(entry)
-	if accessor == nil {
-		return nil
-	}
-
-	child := accessor
-	parent := accessor.Parent
-	for parent != nil && parent.Kind == ast.KindParenthesizedExpression {
-		child = parent
-		parent = parent.Parent
-	}
-	if parent == nil ||
-		parent.Kind != ast.KindCallExpression ||
-		parent.AsCallExpression().Expression != child {
-		return nil
-	}
-	return parent
+	return testFramework.InvokedAccessorCall(entry)
 }
 
 // FollowTypeAssertionChain unwraps `x as T` and `<T>x` wrappers, along with the
@@ -53,18 +36,7 @@ func MatcherCall(entry *ParsedRstestFnMemberEntry) *ast.Node {
 // so a value written `1 satisfies number` or `x!` keeps whatever wrapper it
 // was given.
 func FollowTypeAssertionChain(node *ast.Node) *ast.Node {
-	for node != nil {
-		node = ast.SkipParentheses(node)
-		switch node.Kind {
-		case ast.KindAsExpression:
-			node = node.AsAsExpression().Expression
-		case ast.KindTypeAssertionExpression:
-			node = node.AsTypeAssertion().Expression
-		default:
-			return node
-		}
-	}
-	return nil
+	return testFramework.FollowTypeAssertionChain(node)
 }
 
 // MatcherArgumentListRange returns the span between the matcher call's
@@ -85,40 +57,5 @@ func FollowTypeAssertionChain(node *ast.Node) *ast.Node {
 // its own closing parenthesis, so the last token of the call is the other end
 // of the span.
 func MatcherArgumentListRange(sourceFile *ast.SourceFile, call *ast.Node) (core.TextRange, bool) {
-	if call == nil || call.Kind != ast.KindCallExpression {
-		return core.TextRange{}, false
-	}
-	callee := call.AsCallExpression().Expression
-	if callee == nil {
-		return core.TextRange{}, false
-	}
-
-	start := callee.End()
-	// A type argument list may hold parentheses of its own, as in
-	// `toBe<(a: string) => void>(value)`.
-	if typeArguments := call.AsCallExpression().TypeArguments; typeArguments != nil {
-		start = max(start, typeArguments.End())
-	}
-
-	tokens := utils.TokensOfNode(sourceFile, call)
-	if len(tokens) == 0 {
-		return core.TextRange{}, false
-	}
-	closeParen := tokens[len(tokens)-1]
-	if closeParen.Kind != ast.KindCloseParenToken {
-		return core.TextRange{}, false
-	}
-
-	for _, token := range tokens {
-		if token.Start < start {
-			continue
-		}
-		if token.Kind == ast.KindOpenParenToken {
-			if token.End > closeParen.Start {
-				return core.TextRange{}, false
-			}
-			return core.NewTextRange(token.End, closeParen.Start), true
-		}
-	}
-	return core.TextRange{}, false
+	return testFramework.CallArgumentListRange(sourceFile, call)
 }

--- a/internal/utils/test_framework/call_edit.go
+++ b/internal/utils/test_framework/call_edit.go
@@ -1,0 +1,95 @@
+package test_framework
+
+import (
+	"github.com/microsoft/TypeScript/tsc/shim/ast"
+	"github.com/microsoft/TypeScript/tsc/shim/core"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// FollowTypeAssertionChain unwraps parentheses plus `as` and angle-bracket
+// type assertions. It deliberately stops at non-null and `satisfies`, matching
+// the assertion-chain helpers in eslint-plugin-jest and eslint-plugin-vitest.
+func FollowTypeAssertionChain(node *ast.Node) *ast.Node {
+	for node != nil {
+		node = ast.SkipParentheses(node)
+		switch node.Kind {
+		case ast.KindAsExpression:
+			node = node.AsAsExpression().Expression
+		case ast.KindTypeAssertionExpression:
+			node = node.AsTypeAssertion().Expression
+		default:
+			return node
+		}
+	}
+	return nil
+}
+
+// InvokedAccessorCall returns the call expression that directly invokes
+// entry's accessor, or nil when the accessor is not called.
+//
+// MemberEntry.Call is not sufficient for nested calls: GetMemberEntries marks
+// the last entry of a callee chain as invoked, so an outer call can overwrite
+// the matcher entry's Call field. Walking from the accessor always finds the
+// argument list owned by that matcher.
+func InvokedAccessorCall(entry *MemberEntry) *ast.Node {
+	_, accessor := AccessorReceiverAndParent(entry)
+	if accessor == nil {
+		return nil
+	}
+
+	child := accessor
+	parent := accessor.Parent
+	for parent != nil && parent.Kind == ast.KindParenthesizedExpression {
+		child = parent
+		parent = parent.Parent
+	}
+	if parent == nil ||
+		parent.Kind != ast.KindCallExpression ||
+		parent.AsCallExpression().Expression != child {
+		return nil
+	}
+	return parent
+}
+
+// CallArgumentListRange returns the span between a call's parentheses. The
+// range contains every argument, comma, comment and whitespace, but not the
+// parentheses themselves.
+func CallArgumentListRange(sourceFile *ast.SourceFile, call *ast.Node) (core.TextRange, bool) {
+	if call == nil || call.Kind != ast.KindCallExpression {
+		return core.TextRange{}, false
+	}
+	callExpression := call.AsCallExpression()
+	callee := callExpression.Expression
+	if callee == nil {
+		return core.TextRange{}, false
+	}
+
+	start := callee.End()
+	// A type argument list may contain parentheses of its own, so scanning has
+	// to begin after it.
+	if typeArguments := callExpression.TypeArguments; typeArguments != nil {
+		start = max(start, typeArguments.End())
+	}
+
+	tokens := utils.TokensOfNode(sourceFile, call)
+	if len(tokens) == 0 {
+		return core.TextRange{}, false
+	}
+	closeParen := tokens[len(tokens)-1]
+	if closeParen.Kind != ast.KindCloseParenToken {
+		return core.TextRange{}, false
+	}
+
+	for _, token := range tokens {
+		if token.Start < start {
+			continue
+		}
+		if token.Kind == ast.KindOpenParenToken {
+			if token.End > closeParen.Start {
+				return core.TextRange{}, false
+			}
+			return core.NewTextRange(token.End, closeParen.Start), true
+		}
+	}
+	return core.TextRange{}, false
+}

--- a/internal/utils/test_framework/call_edit.go
+++ b/internal/utils/test_framework/call_edit.go
@@ -3,6 +3,7 @@ package test_framework
 import (
 	"github.com/microsoft/TypeScript/tsc/shim/ast"
 	"github.com/microsoft/TypeScript/tsc/shim/core"
+	"github.com/microsoft/TypeScript/tsc/shim/scanner"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
@@ -92,4 +93,34 @@ func CallArgumentListRange(sourceFile *ast.SourceFile, call *ast.Node) (core.Tex
 		}
 	}
 	return core.TextRange{}, false
+}
+
+// CallTypeArgumentListRange returns the span covering a call's explicit type
+// argument list, angle brackets included. Matchers such as toBeNull take no
+// type parameters, so a fix that swaps the matcher name has to drop the type
+// arguments the previous matcher accepted.
+func CallTypeArgumentListRange(sourceFile *ast.SourceFile, call *ast.Node) (core.TextRange, bool) {
+	if call == nil || call.Kind != ast.KindCallExpression {
+		return core.TextRange{}, false
+	}
+	callExpression := call.AsCallExpression()
+	typeArguments := callExpression.TypeArguments
+	if typeArguments == nil || callExpression.Expression == nil {
+		return core.TextRange{}, false
+	}
+
+	start := callExpression.Expression.End()
+	if callExpression.QuestionDotToken != nil {
+		start = callExpression.QuestionDotToken.End()
+	}
+	openAngle := scanner.GetRangeOfTokenAtPosition(sourceFile, start)
+	closeAngle := scanner.GetRangeOfTokenAtPosition(sourceFile, typeArguments.End())
+
+	text := sourceFile.Text()
+	if openAngle.Pos() >= len(text) || text[openAngle.Pos()] != '<' ||
+		closeAngle.Pos() >= len(text) || text[closeAngle.Pos()] != '>' ||
+		closeAngle.End() <= openAngle.Pos() {
+		return core.TextRange{}, false
+	}
+	return core.NewTextRange(openAngle.Pos(), closeAngle.End()), true
 }

--- a/internal/utils/test_framework/call_edit_test.go
+++ b/internal/utils/test_framework/call_edit_test.go
@@ -1,0 +1,74 @@
+package test_framework
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+func TestFollowTypeAssertionChain(t *testing.T) {
+	tests := []struct {
+		code string
+		want string
+	}{
+		{code: `consume(((value as unknown) as string))`, want: `value`},
+		{code: `consume(<number>(value))`, want: `value`},
+		{code: `consume(value!)`, want: `value!`},
+		{code: `consume(value satisfies number)`, want: `value satisfies number`},
+	}
+
+	for _, test := range tests {
+		t.Run(test.code, func(t *testing.T) {
+			sourceFile, call := parseFirstCall(t, test.code)
+			arguments := call.Arguments()
+			if len(arguments) != 1 {
+				t.Fatalf("arguments = %d, want 1", len(arguments))
+			}
+			got := FollowTypeAssertionChain(arguments[0])
+			if text := utils.TrimmedNodeText(sourceFile, got); text != test.want {
+				t.Fatalf("unwrapped expression = %q, want %q", text, test.want)
+			}
+		})
+	}
+}
+
+func TestInvokedAccessorCall(t *testing.T) {
+	sourceFile, outerCall := parseFirstCall(t, `expect(value).toBe(true)()`)
+	entries := GetMemberEntries(outerCall)
+	if len(entries) == 0 {
+		t.Fatal("expected a member entry")
+	}
+
+	matcherCall := InvokedAccessorCall(&entries[len(entries)-1])
+	if matcherCall == nil {
+		t.Fatal("expected the matcher call")
+	}
+	if got := utils.TrimmedNodeText(sourceFile, matcherCall); got != `expect(value).toBe(true)` {
+		t.Fatalf("matcher call = %q", got)
+	}
+}
+
+func TestCallArgumentListRange(t *testing.T) {
+	tests := []struct {
+		name string
+		code string
+		want string
+	}{
+		{name: "arguments", code: `expect(value).toBe(1, 2,)`, want: `1, 2,`},
+		{name: "comments", code: `expect(value).toBe(/* keep */ 1)`, want: `/* keep */ 1`},
+		{name: "type arguments", code: `expect(value).toBe<(x: string) => void>(fn)`, want: `fn`},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			sourceFile, call := parseFirstCall(t, test.code)
+			textRange, ok := CallArgumentListRange(sourceFile, call)
+			if !ok {
+				t.Fatalf("CallArgumentListRange returned false for %q", test.code)
+			}
+			if got := test.code[textRange.Pos():textRange.End()]; got != test.want {
+				t.Fatalf("argument list = %q, want %q", got, test.want)
+			}
+		})
+	}
+}

--- a/internal/utils/test_framework/call_edit_test.go
+++ b/internal/utils/test_framework/call_edit_test.go
@@ -72,3 +72,36 @@ func TestCallArgumentListRange(t *testing.T) {
 		})
 	}
 }
+
+func TestCallTypeArgumentListRange(t *testing.T) {
+	tests := []struct {
+		name string
+		code string
+		want string
+	}{
+		{name: "single", code: `expect(value).toEqual<null>(null)`, want: `<null>`},
+		{name: "nested", code: `expect(value).toEqual<Array<null>>(null)`, want: `<Array<null>>`},
+		{name: "spaced", code: `expect(value).toEqual  < null > (null)`, want: `< null >`},
+		{name: "optional call", code: `expect(value).toEqual?.<null>(null)`, want: `<null>`},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			sourceFile, call := parseFirstCall(t, test.code)
+			textRange, ok := CallTypeArgumentListRange(sourceFile, call)
+			if !ok {
+				t.Fatalf("CallTypeArgumentListRange returned false for %q", test.code)
+			}
+			if got := test.code[textRange.Pos():textRange.End()]; got != test.want {
+				t.Fatalf("type argument list = %q, want %q", got, test.want)
+			}
+		})
+	}
+
+	t.Run("no type arguments", func(t *testing.T) {
+		sourceFile, call := parseFirstCall(t, `expect(value).toEqual(null)`)
+		if _, ok := CallTypeArgumentListRange(sourceFile, call); ok {
+			t.Fatal("CallTypeArgumentListRange returned true without type arguments")
+		}
+	})
+}

--- a/internal/utils/test_framework/rules/prefer_to_be/prefer_to_be.go
+++ b/internal/utils/test_framework/rules/prefer_to_be/prefer_to_be.go
@@ -1,0 +1,206 @@
+// Package prefer_to_be implements the matcher-independent decision tree shared
+// by Jest- and Rstest-flavoured prefer-to-be rules. Framework adapters own
+// expect-call parsing, diagnostic wording and source edits.
+package prefer_to_be
+
+import (
+	"math"
+	"strconv"
+
+	"github.com/microsoft/TypeScript/tsc/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	testFramework "github.com/web-infra-dev/rslint/internal/utils/test_framework"
+)
+
+type Kind uint8
+
+const (
+	KindToBe Kind = iota
+	KindNull
+	KindNaN
+	KindUndefined
+	KindDefined
+)
+
+type ExpectCall struct {
+	Matcher      string
+	MatcherEntry testFramework.MemberEntry
+	MatcherCall  *ast.Node
+	Modifiers    []testFramework.MemberEntry
+}
+
+type Runtime struct {
+	Parse func(*ast.Node) *ExpectCall
+}
+
+type Match struct {
+	Expect   *ExpectCall
+	Kind     Kind
+	NotEntry *testFramework.MemberEntry
+}
+
+type Config struct {
+	Name string
+
+	Prepare func(rule.RuleContext) Runtime
+	Message func(Kind) rule.RuleMessage
+	// BuildFixes is called only when autofixes are requested. Returning nil
+	// leaves the eager diagnostic intact without attaching an unsafe edit.
+	BuildFixes func(rule.RuleContext, Match) []rule.RuleFix
+
+	// AllowFractionalNumbers selects Jest's policy. Rstest leaves it false to
+	// follow Vitest and Rstest's recommendation to use toBeCloseTo for decimal
+	// literals. Negative decimals use the same policy as positive decimals.
+	AllowFractionalNumbers bool
+	// IsSpecialIdentifier can reject locally shadowed undefined/NaN names. A
+	// nil callback preserves eslint-plugin-jest's text-only upstream behavior.
+	IsSpecialIdentifier func(rule.RuleContext, *ast.Node, string) bool
+}
+
+var equalityMatchers = map[string]bool{
+	"toBe":          true,
+	"toEqual":       true,
+	"toStrictEqual": true,
+}
+
+func firstArgument(call *ExpectCall) *ast.Node {
+	if call == nil || call.MatcherCall == nil {
+		return nil
+	}
+	arguments := call.MatcherCall.Arguments()
+	if len(arguments) == 0 {
+		return nil
+	}
+	return testFramework.FollowTypeAssertionChain(arguments[0])
+}
+
+func findNot(modifiers []testFramework.MemberEntry) *testFramework.MemberEntry {
+	for index := range modifiers {
+		if modifiers[index].Name == "not" {
+			return &modifiers[index]
+		}
+	}
+	return nil
+}
+
+func isIdentifier(node *ast.Node, name string) bool {
+	return node != nil && node.Kind == ast.KindIdentifier && node.AsIdentifier().Text == name
+}
+
+func isFractionalNumericLiteral(node *ast.Node) bool {
+	if node == nil || node.Kind != ast.KindNumericLiteral {
+		return false
+	}
+	value, err := strconv.ParseFloat(node.AsNumericLiteral().Text, 64)
+	return err == nil && math.Floor(value) != math.Ceil(value)
+}
+
+func shouldUseToBe(argument *ast.Node, allowFractionalNumbers bool) bool {
+	if argument == nil {
+		return false
+	}
+	if argument.Kind == ast.KindPrefixUnaryExpression {
+		unary := argument.AsPrefixUnaryExpression()
+		if unary.Operator == ast.KindMinusToken {
+			// Upstream only peels the unary operator here. A type assertion
+			// nested inside it remains a non-literal; an assertion around the
+			// entire negative number was already removed by firstArgument.
+			argument = ast.SkipParentheses(unary.Operand)
+		}
+	}
+	if argument == nil || (!allowFractionalNumbers && isFractionalNumericLiteral(argument)) {
+		return false
+	}
+
+	switch argument.Kind {
+	case ast.KindStringLiteral,
+		ast.KindNumericLiteral,
+		ast.KindBigIntLiteral,
+		ast.KindTrueKeyword,
+		ast.KindFalseKeyword,
+		ast.KindNullKeyword,
+		ast.KindNoSubstitutionTemplateLiteral,
+		ast.KindTemplateExpression:
+		return true
+	default:
+		return false
+	}
+}
+
+func match(ctx rule.RuleContext, call *ExpectCall, config Config) (Match, bool) {
+	if call == nil || call.MatcherEntry.Node == nil || call.MatcherCall == nil {
+		return Match{}, false
+	}
+	notEntry := findNot(call.Modifiers)
+	if notEntry != nil {
+		switch call.Matcher {
+		case "toBeUndefined":
+			return Match{Expect: call, Kind: KindDefined, NotEntry: notEntry}, true
+		case "toBeDefined":
+			return Match{Expect: call, Kind: KindUndefined, NotEntry: notEntry}, true
+		}
+	}
+
+	if !equalityMatchers[call.Matcher] {
+		return Match{}, false
+	}
+	argument := firstArgument(call)
+	if argument == nil {
+		return Match{}, false
+	}
+
+	result := Match{Expect: call}
+	switch {
+	case argument.Kind == ast.KindNullKeyword:
+		result.Kind = KindNull
+	case isIdentifier(argument, "undefined") &&
+		(config.IsSpecialIdentifier == nil || config.IsSpecialIdentifier(ctx, argument, "undefined")):
+		if notEntry != nil {
+			result.Kind = KindDefined
+			result.NotEntry = notEntry
+		} else {
+			result.Kind = KindUndefined
+		}
+	case isIdentifier(argument, "NaN") &&
+		(config.IsSpecialIdentifier == nil || config.IsSpecialIdentifier(ctx, argument, "NaN")):
+		result.Kind = KindNaN
+	case call.Matcher != "toBe" && shouldUseToBe(argument, config.AllowFractionalNumbers):
+		result.Kind = KindToBe
+	default:
+		return Match{}, false
+	}
+	return result, true
+}
+
+func NewRule(config Config) rule.Rule {
+	return rule.Rule{
+		Name:   config.Name,
+		Schema: rule.EmptyArraySchema,
+		Run: func(ctx rule.RuleContext, _ []any) rule.RuleListeners {
+			runtime := config.Prepare(ctx)
+			return rule.RuleListeners{
+				ast.KindCallExpression: func(node *ast.Node) {
+					if runtime.Parse == nil || config.Message == nil {
+						return
+					}
+					matched, ok := match(ctx, runtime.Parse(node), config)
+					if !ok {
+						return
+					}
+
+					message := config.Message(matched.Kind)
+					ctx.ReportNodeWithDeferredFixes(
+						matched.Expect.MatcherEntry.Node,
+						message,
+						func() []rule.RuleFix {
+							if config.BuildFixes == nil {
+								return nil
+							}
+							return config.BuildFixes(ctx, matched)
+						},
+					)
+				},
+			}
+		},
+	}
+}

--- a/internal/utils/test_framework/rules/prefer_to_be/prefer_to_be.go
+++ b/internal/utils/test_framework/rules/prefer_to_be/prefer_to_be.go
@@ -178,6 +178,11 @@ func NewRule(config Config) rule.Rule {
 		Schema: rule.EmptyArraySchema,
 		Run: func(ctx rule.RuleContext, _ []any) rule.RuleListeners {
 			runtime := config.Prepare(ctx)
+			// A matcher call can be reached from more than one call expression
+			// in its own chain: the `.then()` of
+			// `expect(p).resolves.toEqual(1).then(done)` resolves back to the
+			// same `toEqual` call. Each assertion is reported once.
+			reported := map[*ast.Node]struct{}{}
 			return rule.RuleListeners{
 				ast.KindCallExpression: func(node *ast.Node) {
 					if runtime.Parse == nil || config.Message == nil {
@@ -187,6 +192,10 @@ func NewRule(config Config) rule.Rule {
 					if !ok {
 						return
 					}
+					if _, seen := reported[matched.Expect.MatcherCall]; seen {
+						return
+					}
+					reported[matched.Expect.MatcherCall] = struct{}{}
 
 					message := config.Message(matched.Kind)
 					ctx.ReportNodeWithDeferredFixes(

--- a/packages/rslint-test-tools/rstack.config.mts
+++ b/packages/rslint-test-tools/rstack.config.mts
@@ -677,6 +677,7 @@ define.test({
     './tests/rstest/rules/prefer-rs-mocked.test.ts',
     './tests/rstest/rules/prefer-strict-boolean-matchers.test.ts',
     './tests/rstest/rules/prefer-strict-equal.test.ts',
+    './tests/rstest/rules/prefer-to-be.test.ts',
     './tests/rstest/rules/prefer-to-be-falsy.test.ts',
     './tests/rstest/rules/prefer-to-be-truthy.test.ts',
     './tests/rstest/rules/prefer-todo.test.ts',

--- a/packages/rslint-test-tools/tests/rstest/rules/prefer-to-be.test.ts
+++ b/packages/rslint-test-tools/tests/rstest/rules/prefer-to-be.test.ts
@@ -1,0 +1,89 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('prefer-to-be', {} as never, {
+  valid: [
+    { code: `expect(null).toBeNull();` },
+    { code: `expect(null).not.toBeNull();` },
+    { code: `expect(null).toBe(-1);` },
+    { code: `expect(null).toBe(1);` },
+    { code: `expect(obj).toStrictEqual([ x, 1 ]);` },
+    { code: `expect(obj).toStrictEqual({ x: 1 });` },
+    { code: `expect(obj).not.toStrictEqual({ x: 1 });` },
+    { code: `expect(value).toMatchSnapshot();` },
+    { code: `expect(catchError()).toStrictEqual({ message: 'oh noes!' })` },
+    { code: `expect("something");` },
+    { code: `expect("hey").to.be.a("string");` },
+    { code: `expect(token).toStrictEqual(/[abc]+/g);` },
+    { code: `expect(token).toStrictEqual(new RegExp('[abc]+', 'g'));` },
+    { code: `expect(0.1 + 0.2).toEqual(0.3);` },
+    { code: `expect(NaN).toBeNaN();` },
+    { code: `expect(true).not.toBeNaN();` },
+    { code: `expect({}).toEqual({});` },
+    { code: `expect(something).toBe()` },
+    { code: `expect(something).toBe(somethingElse)` },
+    { code: `expect(something).toEqual(somethingElse)` },
+    { code: `expect(something).not.toBe(somethingElse)` },
+    { code: `expect(something).not.toEqual(somethingElse)` },
+    { code: `expect(undefined).toBe` },
+    { code: `expect("something");` },
+  ],
+  invalid: [
+    {
+      code: `expect(value).toEqual("my string");`,
+      output: `expect(value).toBe("my string");`,
+      errors: [{ messageId: 'useToBe' }],
+    },
+    {
+      code: `expect("a string").not.toEqual(null);`,
+      output: `expect("a string").not.toBeNull();`,
+      errors: [{ messageId: 'useToBeNull', column: 24, line: 1 }],
+    },
+    {
+      code: `expect("a string").not.toStrictEqual(null);`,
+      output: `expect("a string").not.toBeNull();`,
+      errors: [{ messageId: 'useToBeNull', column: 24, line: 1 }],
+    },
+    {
+      code: `expect(NaN).toBe(NaN);`,
+      output: `expect(NaN).toBeNaN();`,
+      errors: [{ messageId: 'useToBeNaN', column: 13, line: 1 }],
+    },
+    {
+      code: `expect("a string").not.toBe(NaN);`,
+      output: `expect("a string").not.toBeNaN();`,
+      errors: [{ messageId: 'useToBeNaN', column: 24, line: 1 }],
+    },
+    {
+      code: `expect("a string").not.toStrictEqual(NaN);`,
+      output: `expect("a string").not.toBeNaN();`,
+      errors: [{ messageId: 'useToBeNaN', column: 24, line: 1 }],
+    },
+    {
+      code: `expect(null).toBe(null);`,
+      output: `expect(null).toBeNull();`,
+      errors: [{ messageId: 'useToBeNull', column: 14, line: 1 }],
+    },
+    {
+      code: `expect(null).toEqual(null);`,
+      output: `expect(null).toBeNull();`,
+      errors: [{ messageId: 'useToBeNull', column: 14, line: 1 }],
+    },
+    {
+      code: `expect("a string").not.toEqual(null as number);`,
+      output: `expect("a string").not.toBeNull();`,
+      errors: [{ messageId: 'useToBeNull', column: 24, line: 1 }],
+    },
+    {
+      code: `expect(undefined).toBe(undefined as unknown as string as any);`,
+      output: `expect(undefined).toBeUndefined();`,
+      errors: [{ messageId: 'useToBeUndefined', column: 19, line: 1 }],
+    },
+    {
+      code: `expect("a string").toEqual(undefined as number);`,
+      output: `expect("a string").toBeUndefined();`,
+      errors: [{ messageId: 'useToBeUndefined', column: 20, line: 1 }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Add `rstest/prefer-to-be` to replace equality assertions with their clearest matcher. Primitive literals use `toBe()`, while `null`, `undefined`, and `NaN` use `toBeNull()`, `toBeUndefined()` / `toBeDefined()`, and `toBeNaN()`. The rule is registered in the Rstest plugin but stays out of the `recommended` preset, matching upstream.

Assertions resolve through the shared Rstest call analysis, covering globals, named and renamed imports, namespace and `require` forms, `rstack/test`, `import.meta.rstest`, Playwright, TestContext `expect`, and the `soft` and `poll` assertion factories. Chai assertions, browser-only `expect.element()` assertions, dynamic matcher names, foreign expect functions, and local shadows are ignored.

The matcher-independent decision tree now lives under `internal/utils/test_framework/rules/prefer_to_be` and is shared with the existing Jest rule. Matcher-call lookup, argument-list ranges, and basic TypeScript assertion unwrapping are also shared through `internal/utils/test_framework`. The Jest adapter retains the `eslint-plugin-jest@29.16.1` contract, including computed accessor fixes and parenthesized optional-chain boundaries, while both adapters construct autofixes only when requested.

## Credits

- Port from [`@vitest/eslint-plugin@1.6.27`'s `prefer-to-be` documentation](https://github.com/vitest-dev/eslint-plugin-vitest/blob/v1.6.27/docs/rules/prefer-to-be.md) and [source](https://github.com/vitest-dev/eslint-plugin-vitest/blob/v1.6.27/src/rules/prefer-to-be.ts).
- Align the shared Jest implementation with [`eslint-plugin-jest@29.16.1`'s `prefer-to-be` documentation](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.1/docs/rules/prefer-to-be.md) and [source](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.1/src/rules/prefer-to-be.ts).

## Intentional differences from upstream

- **Negative fractional numeric literals are left unchanged.** Upstream leaves positive fractional literals unchanged but reports negative ones after unwrapping the unary minus. Rstest applies the same floating-point policy in both directions because these assertions should use `toBeCloseTo()` when approximate comparison is intended.

- **Negated undefined equality assertions preserve their meaning.** `expect(value).not.toEqual(undefined)` is fixed to `expect(value).toBeDefined()` by removing `not`; upstream changes the matcher without removing the modifier.

- **Locally shadowed `undefined` and `NaN` are not treated as built-ins.** A local runtime declaration with either name prevents the rule from selecting the corresponding dedicated matcher.

- **Browser element assertions are excluded.** `expect.element()` exposes browser-element matchers rather than the value matchers targeted by this rule.

- **Autofixes preserve authored accessor spelling.** Quoted and template-literal accessors retain their delimiters instead of being normalized to single quotes.

- **Comments inside a removed argument list suppress the autofix.** The diagnostic is still reported, but Rstest does not delete the comment while converting the assertion to a no-argument matcher.

- **Parenthesized optional matcher calls are recognized.** Rstest treats `(expect(value)?.toEqual)(1)` as the same assertion as the unparenthesized optional-chain form.

- **Computed matcher accessors keep a valid key.** Upstream's `replaceAccessorFixer` rewrites an identifier accessor in place, so `expect(value)[toEqual](1)` becomes a reference to an undeclared `toBe`. The fix writes a quoted key instead.

- **Type arguments are removed with the value arguments.** `toBeNull`, `toBeNaN`, `toBeUndefined` and `toBeDefined` declare no type parameters, so `expect(null).toEqual<null>(null)` is fixed to `expect(null).toBeNull()`. Leaving the type argument behind fails with TS2558. `toBe` shares `toEqual`'s single type parameter, so its type argument stays.

- **Each assertion is reported once.** An outer call in the same chain resolves back to the matcher call, so upstream reports `expect(promise).resolves.toEqual(1).then(done)` twice at the same location.

## Related Links

Related #935

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

