### PR TITLE
chore: bump tsgo packages to 0.0.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "tsgo-client"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "bitflags",
  "cbor4ii",

--- a/crates/tsgo-client/Cargo.toml
+++ b/crates/tsgo-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tsgo-client"
-version = "0.0.11"
+version = "0.0.12"
 edition = "2024"
 description = "TypeScript Go client library"
 license = "MIT"

--- a/npm/tsgo/darwin-arm64/package.json
+++ b/npm/tsgo/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/tsgo-server-darwin-arm64",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "license": "MIT",
   "description": "tsgo server binary for darwin arm64",
   "bugs": "https://github.com/web-infra-dev/rslint/issues",

--- a/npm/tsgo/darwin-x64/package.json
+++ b/npm/tsgo/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/tsgo-server-darwin-x64",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "license": "MIT",
   "description": "tsgo server binary for darwin x64",
   "bugs": "https://github.com/web-infra-dev/rslint/issues",

--- a/npm/tsgo/linux-arm64/package.json
+++ b/npm/tsgo/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/tsgo-server-linux-arm64",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "license": "MIT",
   "description": "tsgo server binary for linux arm64",
   "bugs": "https://github.com/web-infra-dev/rslint/issues",

--- a/npm/tsgo/linux-x64/package.json
+++ b/npm/tsgo/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/tsgo-server-linux-x64",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "license": "MIT",
   "description": "tsgo server binary for linux x64",
   "bugs": "https://github.com/web-infra-dev/rslint/issues",

--- a/npm/tsgo/win32-arm64/package.json
+++ b/npm/tsgo/win32-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/tsgo-server-win32-arm64",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "license": "MIT",
   "description": "tsgo server binary for windows arm64",
   "bugs": "https://github.com/web-infra-dev/rslint/issues",

--- a/npm/tsgo/win32-x64/package.json
+++ b/npm/tsgo/win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/tsgo-server-win32-x64",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "license": "MIT",
   "description": "tsgo server binary for windows x64",
   "bugs": "https://github.com/web-infra-dev/rslint/issues",

--- a/packages/tsgo/package.json
+++ b/packages/tsgo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rslint/tsgo-server",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "TypeScript Go semantic server",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary

Bump `tsgo-client`, `@rslint/tsgo-server`, and all six platform packages from `0.0.11` to `0.0.12`, keeping `Cargo.lock` in sync.

The main update in this release is #2109 (e93f3b6d034c0c69c910aec4b89b03ed277f0642), already merged into `main`:
- Add `tsgo config --config tsconfig.json` to output resolved compiler options as JSON, including defaults and implied options, without type checking.
- Add the explicit `project` subcommand and update the Rust client to invoke `project --api`, while retaining legacy flag-only invocations.

## Related Links

- #2109
- https://github.com/web-infra-dev/rslint/commit/e93f3b6d034c0c69c910aec4b89b03ed277f0642

## Validation

- Release metadata validation via `readTsgoReleaseState()` / `validateTsgoReleaseState()`: passed for `0.0.12`.
- `pnpm run format:check`: passed.
- `pnpm run check-spell --config /tmp/rslint-tsgo-0012-cspell.json Cargo.lock crates/tsgo-client/Cargo.toml npm/tsgo/darwin-arm64/package.json npm/tsgo/darwin-x64/package.json npm/tsgo/linux-arm64/package.json npm/tsgo/linux-x64/package.json npm/tsgo/win32-arm64/package.json npm/tsgo/win32-x64/package.json packages/tsgo/package.json`: passed using a temporary config extending the repository config and accepting the existing Rust dependency names `thiserror`, `bitflags`, and `insta`. The default check flagged only those existing names.
- `git diff --check`: passed.
- Language tests were not run because this PR only changes version metadata.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).