### PR TITLE
fix(react): align no-render-return-value with upstream

### DIFF
--- a/internal/plugins/react/rules/no_render_return_value/no_render_return_value.go
+++ b/internal/plugins/react/rules/no_render_return_value/no_render_return_value.go
@@ -24,6 +24,8 @@ var (
 )
 
 func calleeObjectRe(settings map[string]interface{}) *regexp.Regexp {
+	settings = withDefaultReactVersion(settings)
+
 	// >= 15.0.0 — the default branch when version is unset (ParseReactVersion
 	// returns 999,999,999) and therefore ≥ 15.
 	if !reactutil.ReactVersionLessThan(settings, 15, 0, 0) {
@@ -40,6 +42,37 @@ func calleeObjectRe(settings map[string]interface{}) *regexp.Regexp {
 		return reReact
 	}
 	return reReactDOM
+}
+
+// withDefaultReactVersion mirrors eslint-plugin-react's version-setting
+// precedence for this rule: an explicit version wins, while defaultVersion is
+// used when version is absent. Non-string values are left to the existing
+// defensive version parser.
+func withDefaultReactVersion(settings map[string]interface{}) map[string]interface{} {
+	reactSettings, ok := settings["react"].(map[string]interface{})
+	if !ok {
+		return settings
+	}
+	if _, hasVersion := reactSettings["version"]; hasVersion {
+		return settings
+	}
+	defaultVersion, ok := reactSettings["defaultVersion"].(string)
+	if !ok || defaultVersion == "" {
+		return settings
+	}
+
+	resolvedReactSettings := make(map[string]interface{}, len(reactSettings)+1)
+	for key, value := range reactSettings {
+		resolvedReactSettings[key] = value
+	}
+	resolvedReactSettings["version"] = defaultVersion
+
+	resolvedSettings := make(map[string]interface{}, len(settings))
+	for key, value := range settings {
+		resolvedSettings[key] = value
+	}
+	resolvedSettings["react"] = resolvedReactSettings
+	return resolvedSettings
 }
 
 // matchedObjectName reports the Identifier text of the call's callee object
@@ -165,6 +198,22 @@ var NoRenderReturnValueRule = rule.Rule{
 // skipped so `(a) => (call())` reaches the same ArrowFunction.
 func consumesReturnValue(parent *ast.Node, call *ast.Node) bool {
 	switch parent.Kind {
+	case ast.KindComputedPropertyName:
+		computed := parent.AsComputedPropertyName()
+		if ast.SkipParentheses(computed.Expression) != call || parent.Parent == nil {
+			return false
+		}
+		owner := parent.Parent
+		switch owner.Kind {
+		case ast.KindPropertyAssignment,
+			ast.KindBindingElement:
+			return true
+		case ast.KindMethodDeclaration,
+			ast.KindGetAccessor,
+			ast.KindSetAccessor:
+			return owner.Parent != nil && owner.Parent.Kind == ast.KindObjectLiteralExpression
+		}
+		return false
 	case ast.KindVariableDeclaration,
 		ast.KindPropertyAssignment,
 		ast.KindReturnStatement:

--- a/internal/plugins/react/rules/no_render_return_value/no_render_return_value.md
+++ b/internal/plugins/react/rules/no_render_return_value/no_render_return_value.md
@@ -16,7 +16,8 @@ The rule flags `ReactDOM.render` calls whose return value is consumed — i.e.
 when the call sits in one of these positions:
 
 - Variable initializer (`var x = ReactDOM.render(...)`)
-- Object property value (`{ k: ReactDOM.render(...) }`)
+- Object property value or computed key (`{ k: ReactDOM.render(...) }`,
+  `{ [ReactDOM.render(...)]: value }`)
 - `return` argument (`return ReactDOM.render(...)`)
 - Arrow function expression body (`(a, b) => ReactDOM.render(a, b)`)
 - Right-hand side of an assignment (`x = ReactDOM.render(...)`)
@@ -40,7 +41,9 @@ ReactDOM.render(<App />, document.body, () => {
 
 ## React Version
 
-The callee object pattern depends on `settings.react.version`:
+The callee object pattern depends on `settings.react.version`. When `version`
+is omitted, `settings.react.defaultVersion` is used; when both are omitted, the
+rule assumes the latest React version.
 
 | Version range | Matched object(s) |
 | ------------- | ----------------- |
@@ -50,6 +53,19 @@ The callee object pattern depends on `settings.react.version`:
 
 Any other version (e.g. `0.0.1`) falls back to `ReactDOM`-only, matching
 upstream's default branch.
+
+## Differences from upstream
+
+- Rslint reports optional-chain forms such as
+  `var instance = ReactDOM?.render(<App />, root)`. The value still depends on
+  the call result when the call runs (and on `undefined` otherwise); upstream
+  skips it with modern ESTree parsers because they insert a `ChainExpression`
+  between the call and the consuming parent.
+- Rslint reports `ReactDOM.render(...)` used as a default value inside a
+  destructuring assignment, such as
+  `[instance = ReactDOM.render(<App />, root)] = values`. The default consumes
+  the call result when selected; upstream skips it because ESTree classifies
+  the inner `=` as an `AssignmentPattern` rather than an `AssignmentExpression`.
 
 ## Original Documentation
 

--- a/internal/plugins/react/rules/no_render_return_value/no_render_return_value_extras_test.go
+++ b/internal/plugins/react/rules/no_render_return_value/no_render_return_value_extras_test.go
@@ -1,0 +1,123 @@
+package no_render_return_value
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoRenderReturnValueExtras(t *testing.T) {
+	defaultReact013 := map[string]interface{}{
+		"react": map[string]interface{}{"defaultVersion": "0.13.0"},
+	}
+	explicitReact15 := map[string]interface{}{
+		"react": map[string]interface{}{
+			"version":        "15.0.0",
+			"defaultVersion": "0.13.0",
+		},
+	}
+
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoRenderReturnValueRule, []rule_tester.ValidTestCase{
+		{
+			Code:     `var instance = ReactDOM.render(<div />, document.body);`,
+			Tsx:      true,
+			Settings: defaultReact013,
+		},
+		{
+			Code:     `var instance = React.render(<div />, document.body);`,
+			Tsx:      true,
+			Settings: explicitReact15,
+		},
+		{
+			Code: `class Example {
+				[ReactDOM.render(<div />, document.body)]() {}
+				get [ReactDOM.render(<div />, document.body)]() { return true; }
+				set [ReactDOM.render(<div />, document.body)](value) {}
+				[ReactDOM.render(<div />, document.body)] = true;
+			}`,
+			Tsx: true,
+		},
+	}, []rule_tester.InvalidTestCase{
+		{
+			Code:     `var instance = React.render(<div />, document.body);`,
+			Tsx:      true,
+			Settings: defaultReact013,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noReturnValue", Message: "Do not depend on the return value from React.render"},
+			},
+		},
+		{
+			Code:     `var instance = ReactDOM.render(<div />, document.body);`,
+			Tsx:      true,
+			Settings: explicitReact15,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noReturnValue", Message: "Do not depend on the return value from ReactDOM.render"},
+			},
+		},
+		{
+			Code: `var value = {
+				[ReactDOM.render(<div />, document.body)]: true,
+			};`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noReturnValue", Line: 2, Column: 6},
+			},
+		},
+		{
+			Code: `var value = {
+				[ReactDOM.render(<div />, document.body)]() {},
+			};`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noReturnValue", Line: 2, Column: 6},
+			},
+		},
+		{
+			Code: `var value = {
+				get [ReactDOM.render(<div />, document.body)]() { return true; },
+				set [ReactDOM.render(<div />, document.body)](next) {},
+			};`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noReturnValue"},
+				{MessageId: "noReturnValue"},
+			},
+		},
+		{
+			Code: `var value;
+			({ [ReactDOM.render(<div />, document.body)]: value } = source);`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noReturnValue", Line: 2, Column: 8},
+			},
+		},
+		{
+			Code: `function read({
+				[ReactDOM.render(<div />, document.body)]: value,
+			}) {}`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noReturnValue", Line: 2, Column: 6},
+			},
+		},
+
+		// Intentional differences from upstream: both forms consume the call's
+		// result even though ESTree inserts a ChainExpression or classifies the
+		// inner assignment as an AssignmentPattern.
+		{
+			Code: `var instance = ReactDOM?.render(<div />, document.body);`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noReturnValue"},
+			},
+		},
+		{
+			Code: `var value; [value = ReactDOM.render(<div />, document.body)] = source;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noReturnValue"},
+			},
+		},
+	})
+}

--- a/packages/rslint-test-tools/tests/eslint-plugin-react/rules/no-render-return-value.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react/rules/no-render-return-value.test.ts
@@ -93,6 +93,19 @@ ruleTester.run('no-render-return-value', {} as never, {
       errors: [{ messageId: 'noReturnValue' }],
     },
 
+    // ---- Upstream: defaultVersion is used when version is omitted ----
+    {
+      code: `var instance = React.render(<div />, document.body);`,
+      settings: { react: { defaultVersion: '0.13.0' } },
+      errors: [{ messageId: 'noReturnValue' }],
+    },
+
+    // ---- Upstream: a computed property key consumes the render result ----
+    {
+      code: `var value = { [ReactDOM.render(<div />, document.body)]: true };`,
+      errors: [{ messageId: 'noReturnValue' }],
+    },
+
     // ---- Parens transparent ----
     {
       code: `var x = (ReactDOM.render(<div />, document.body));`,


### PR DESCRIPTION
## Summary

Align `react/no-render-return-value` with `eslint-plugin-react@7.37.5` in two cases:

- Honor `settings.react.defaultVersion` when `settings.react.version` is omitted, while keeping an explicit `version` authoritative.
- Report `ReactDOM.render(...)` when its return value is used as a computed object property key, including object properties, methods, accessors, and destructuring properties. Class computed members remain excluded because they are not ESTree `Property` nodes.

## Other differences not addressed

The review also found two cases where Rslint keeps its existing behavior because it better matches the purpose of the rule:

- Rslint reports optional-chain calls such as `var instance = ReactDOM?.render(...)`. The resulting value still depends on the call result when the call runs, or on `undefined` otherwise. Upstream skips this with modern ESTree parsers because a `ChainExpression` sits between the call and the consuming parent.
- Rslint reports `ReactDOM.render(...)` used as a default value inside a destructuring assignment, such as `[instance = ReactDOM.render(...)] = values`. The default consumes the return value when selected. Upstream skips it because ESTree classifies the inner `=` as an `AssignmentPattern`.

Both differences are explicitly described in the rule documentation and covered by regression tests.
