### PR TITLE
fix(react): align no-string-refs with upstream

### DIFF
--- a/internal/plugins/react/reactutil/component_class.go
+++ b/internal/plugins/react/reactutil/component_class.go
@@ -21,13 +21,23 @@ func IsCreateClassCall(call *ast.CallExpression, pragma, createClass string) boo
 	if call == nil {
 		return false
 	}
+	return isCreateClassCallee(call.Expression, pragma, createClass)
+}
+
+// isCreateClassCallee reports whether callee is `<createClass>` or
+// `<pragma>.<createClass>`. It is shared by CallExpression and NewExpression
+// handling because both node kinds expose a callee in ESTree.
+func isCreateClassCallee(callee *ast.Node, pragma, createClass string) bool {
+	if callee == nil {
+		return false
+	}
 	if pragma == "" {
 		pragma = DefaultReactPragma
 	}
 	if createClass == "" {
 		createClass = DefaultReactCreateClass
 	}
-	callee := ast.SkipParentheses(call.Expression)
+	callee = ast.SkipParentheses(callee)
 	switch callee.Kind {
 	case ast.KindIdentifier:
 		return callee.AsIdentifier().Text == createClass
@@ -302,11 +312,15 @@ func ExtendsReactPureComponent(classNode *ast.Node, pragma string) bool {
 }
 
 func isObjectArgumentOf(call *ast.CallExpression, obj *ast.Node) bool {
-	if call.Arguments == nil {
+	return call != nil && nodeListContains(call.Arguments, obj)
+}
+
+func nodeListContains(nodes *ast.NodeList, target *ast.Node) bool {
+	if nodes == nil {
 		return false
 	}
-	for _, arg := range call.Arguments.Nodes {
-		if arg == obj {
+	for _, arg := range nodes.Nodes {
+		if arg == target {
 			return true
 		}
 	}

--- a/internal/plugins/react/reactutil/component_detect.go
+++ b/internal/plugins/react/reactutil/component_detect.go
@@ -85,6 +85,12 @@ func GetParentReactComponentScopeBased(node *ast.Node, pragma, createClass strin
 		if !ast.IsFunctionLike(p) {
 			continue
 		}
+		// ESTree omits redundant parentheses. Walk through the wrappers
+		// retained by ts-go before inspecting the function's property.
+		functionValue := p
+		for functionValue.Parent != nil && functionValue.Parent.Kind == ast.KindParenthesizedExpression {
+			functionValue = functionValue.Parent
+		}
 		// `key: function() {...}` — FE wrapped in PropertyAssignment;
 		// its parent is the ObjectLiteralExpression.
 		// `key() {...}` shorthand — MethodDeclaration / GetAccessor /
@@ -94,7 +100,7 @@ func GetParentReactComponentScopeBased(node *ast.Node, pragma, createClass strin
 		case ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor:
 			objLit = p.Parent
 		default:
-			propEntry := p.Parent
+			propEntry := functionValue.Parent
 			if propEntry == nil || propEntry.Kind != ast.KindPropertyAssignment {
 				continue
 			}
@@ -108,15 +114,26 @@ func GetParentReactComponentScopeBased(node *ast.Node, pragma, createClass strin
 		for arg.Parent != nil && arg.Parent.Kind == ast.KindParenthesizedExpression {
 			arg = arg.Parent
 		}
-		callExpr := arg.Parent
-		if callExpr == nil || callExpr.Kind != ast.KindCallExpression {
+		callLike := arg.Parent
+		if callLike == nil {
 			continue
 		}
-		call := callExpr.AsCallExpression()
-		if !isObjectArgumentOf(call, arg) {
+		var callee *ast.Node
+		var arguments *ast.NodeList
+		switch callLike.Kind {
+		case ast.KindCallExpression:
+			call := callLike.AsCallExpression()
+			callee, arguments = call.Expression, call.Arguments
+		case ast.KindNewExpression:
+			newExpression := callLike.AsNewExpression()
+			callee, arguments = newExpression.Expression, newExpression.Arguments
+		default:
 			continue
 		}
-		if IsCreateClassCall(call, pragma, createClass) {
+		if !nodeListContains(arguments, arg) {
+			continue
+		}
+		if isCreateClassCallee(callee, pragma, createClass) {
 			return objLit
 		}
 	}

--- a/internal/plugins/react/reactutil/pragma.go
+++ b/internal/plugins/react/reactutil/pragma.go
@@ -1,6 +1,7 @@
 package reactutil
 
 import (
+	"encoding/json"
 	"regexp"
 	"strconv"
 	"strings"
@@ -86,10 +87,10 @@ func GetReactCreateClass(settings map[string]interface{}) string {
 var reactVersionRe = regexp.MustCompile(`(\d+)(?:\.(\d+))?(?:\.(\d+))?`)
 
 // ParseReactVersion returns the (major, minor, patch) triple of
-// `settings.react.version`. When the setting is missing, not a string, empty,
-// or not recognizable as a version, it defaults to (999, 999, 999) — matching
-// eslint-plugin-react's `getReactVersionFromContext`, which treats an absent
-// version as "latest".
+// `settings.react.version`. When version is absent, settings.react.defaultVersion
+// is used; an absent or unrecognizable fallback defaults to (999, 999, 999).
+// Numeric settings are stringified before parsing, matching
+// eslint-plugin-react's getReactVersionFromContext behavior.
 func ParseReactVersion(settings map[string]interface{}) (int, int, int) {
 	if settings == nil {
 		return 999, 999, 999
@@ -98,14 +99,70 @@ func ParseReactVersion(settings map[string]interface{}) (int, int, int) {
 	if !ok {
 		return 999, 999, 999
 	}
-	raw, _ := reactSettings["version"].(string)
-	raw = ecmascript.StringTrim(raw)
-	if raw == "" {
-		return 999, 999, 999
+	fallback := [3]int{999, 999, 999}
+	if rawDefault, ok := reactVersionSettingString(reactSettings["defaultVersion"]); ok {
+		if parsed, ok := parseReactVersionString(rawDefault); ok {
+			fallback = parsed
+		}
 	}
+	raw, ok := reactVersionSettingString(reactSettings["version"])
+	if !ok || raw == "detect" {
+		// Resolving "detect" against node_modules remains an intentional
+		// difference. Use the configured fallback when available.
+		return fallback[0], fallback[1], fallback[2]
+	}
+	parsed, ok := parseReactVersionString(raw)
+	if !ok {
+		return fallback[0], fallback[1], fallback[2]
+	}
+	return parsed[0], parsed[1], parsed[2]
+}
+
+func reactVersionSettingString(value any) (string, bool) {
+	switch value := value.(type) {
+	case string:
+		value = ecmascript.StringTrim(value)
+		return value, value != ""
+	case float64:
+		if value == 0 {
+			return "", false
+		}
+		return ecmascript.NumberToString(value), true
+	case float32:
+		if value == 0 {
+			return "", false
+		}
+		return ecmascript.NumberToString(float64(value)), true
+	case json.Number:
+		number, err := value.Float64()
+		if err != nil || number == 0 {
+			return "", false
+		}
+		return ecmascript.NumberToString(number), true
+	case int:
+		if value == 0 {
+			return "", false
+		}
+		return strconv.Itoa(value), true
+	case int64:
+		if value == 0 {
+			return "", false
+		}
+		return strconv.FormatInt(value, 10), true
+	case bool:
+		if !value {
+			return "", false
+		}
+		return "true", true
+	default:
+		return "", false
+	}
+}
+
+func parseReactVersionString(raw string) ([3]int, bool) {
 	m := reactVersionRe.FindStringSubmatch(raw)
 	if m == nil {
-		return 999, 999, 999
+		return [3]int{}, false
 	}
 	toInt := func(s string) int {
 		if s == "" {
@@ -117,7 +174,7 @@ func ParseReactVersion(settings map[string]interface{}) (int, int, int) {
 		}
 		return n
 	}
-	return toInt(m[1]), toInt(m[2]), toInt(m[3])
+	return [3]int{toInt(m[1]), toInt(m[2]), toInt(m[3])}, true
 }
 
 // ReactVersionLessThan reports whether `settings.react.version` is strictly

--- a/internal/plugins/react/reactutil/pragma_test.go
+++ b/internal/plugins/react/reactutil/pragma_test.go
@@ -1,6 +1,7 @@
 package reactutil
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/microsoft/TypeScript/tsc/shim/ast"
@@ -8,6 +9,41 @@ import (
 	"github.com/microsoft/TypeScript/tsc/shim/parser"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
+
+func TestParseReactVersion(t *testing.T) {
+	t.Parallel()
+
+	settings := func(values map[string]interface{}) map[string]interface{} {
+		return map[string]interface{}{"react": values}
+	}
+	for _, testCase := range []struct {
+		name     string
+		settings map[string]interface{}
+		want     [3]int
+	}{
+		{name: "absent defaults to latest", want: [3]int{999, 999, 999}},
+		{name: "explicit string", settings: settings(map[string]interface{}{"version": "18.2"}), want: [3]int{18, 2, 0}},
+		{name: "default version", settings: settings(map[string]interface{}{"defaultVersion": "18.2.0"}), want: [3]int{18, 2, 0}},
+		{name: "explicit version wins over default", settings: settings(map[string]interface{}{"version": "19.0.0", "defaultVersion": "18.2.0"}), want: [3]int{19, 0, 0}},
+		{name: "invalid explicit uses default", settings: settings(map[string]interface{}{"version": "invalid", "defaultVersion": "18.2.0"}), want: [3]int{18, 2, 0}},
+		{name: "numeric version", settings: settings(map[string]interface{}{"version": 17}), want: [3]int{17, 0, 0}},
+		{name: "decimal numeric version", settings: settings(map[string]interface{}{"version": 17.2}), want: [3]int{17, 2, 0}},
+		{name: "decoded numeric version", settings: settings(map[string]interface{}{"version": json.Number("17.2")}), want: [3]int{17, 2, 0}},
+		{name: "negative numeric version", settings: settings(map[string]interface{}{"version": -1, "defaultVersion": "18.2.0"}), want: [3]int{1, 0, 0}},
+		{name: "false version is absent", settings: settings(map[string]interface{}{"version": false, "defaultVersion": "18.2.0"}), want: [3]int{18, 2, 0}},
+		{name: "detect uses fallback", settings: settings(map[string]interface{}{"version": "detect", "defaultVersion": "18.2.0"}), want: [3]int{18, 2, 0}},
+		{name: "detect without fallback remains latest", settings: settings(map[string]interface{}{"version": "detect"}), want: [3]int{999, 999, 999}},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			major, minor, patch := ParseReactVersion(testCase.settings)
+			if got := [3]int{major, minor, patch}; got != testCase.want {
+				t.Fatalf("ParseReactVersion() = %v, want %v", got, testCase.want)
+			}
+		})
+	}
+}
 
 // TestJsxAnnotationInComment pins the port of upstream pragmaUtil's
 // `/@jsx\s+([^\s]+)/` to the cases where a compiled RE2 pattern would answer

--- a/internal/plugins/react/rules/no_render_return_value/no_render_return_value.go
+++ b/internal/plugins/react/rules/no_render_return_value/no_render_return_value.go
@@ -24,8 +24,6 @@ var (
 )
 
 func calleeObjectRe(settings map[string]interface{}) *regexp.Regexp {
-	settings = withDefaultReactVersion(settings)
-
 	// >= 15.0.0 — the default branch when version is unset (ParseReactVersion
 	// returns 999,999,999) and therefore ≥ 15.
 	if !reactutil.ReactVersionLessThan(settings, 15, 0, 0) {
@@ -42,37 +40,6 @@ func calleeObjectRe(settings map[string]interface{}) *regexp.Regexp {
 		return reReact
 	}
 	return reReactDOM
-}
-
-// withDefaultReactVersion mirrors eslint-plugin-react's version-setting
-// precedence for this rule: an explicit version wins, while defaultVersion is
-// used when version is absent. Non-string values are left to the existing
-// defensive version parser.
-func withDefaultReactVersion(settings map[string]interface{}) map[string]interface{} {
-	reactSettings, ok := settings["react"].(map[string]interface{})
-	if !ok {
-		return settings
-	}
-	if _, hasVersion := reactSettings["version"]; hasVersion {
-		return settings
-	}
-	defaultVersion, ok := reactSettings["defaultVersion"].(string)
-	if !ok || defaultVersion == "" {
-		return settings
-	}
-
-	resolvedReactSettings := make(map[string]interface{}, len(reactSettings)+1)
-	for key, value := range reactSettings {
-		resolvedReactSettings[key] = value
-	}
-	resolvedReactSettings["version"] = defaultVersion
-
-	resolvedSettings := make(map[string]interface{}, len(settings))
-	for key, value := range settings {
-		resolvedSettings[key] = value
-	}
-	resolvedSettings["react"] = resolvedReactSettings
-	return resolvedSettings
 }
 
 // matchedObjectName reports the Identifier text of the call's callee object

--- a/internal/plugins/react/rules/no_string_refs/no_string_refs.go
+++ b/internal/plugins/react/rules/no_string_refs/no_string_refs.go
@@ -21,11 +21,11 @@ var NoStringRefsRule = rule.Rule{
 			detectTemplateLiterals, _ = optsMap["noTemplateLiterals"].(bool)
 		}
 
-		pragma := reactutil.GetReactPragma(ctx.Settings)
+		pragma := reactutil.GetReactPragmaFromContext(ctx)
 		createClass := reactutil.GetReactCreateClass(ctx.Settings)
 		// `this.refs` is writable in React 18.3.0 and later, so only check on versions < 18.3.0.
-		// When `react.version` is absent the setting defaults to "latest" (999.999.999),
-		// which disables the check.
+		// When `react.version` is absent, `react.defaultVersion` is used before
+		// falling back to "latest" (999.999.999), which disables the check.
 		checkRefsUsage := reactutil.ReactVersionLessThan(ctx.Settings, 18, 3, 0)
 
 		reportStringRef := func(node *ast.Node) {

--- a/internal/plugins/react/rules/no_string_refs/no_string_refs.md
+++ b/internal/plugins/react/rules/no_string_refs/no_string_refs.md
@@ -65,15 +65,17 @@ var Hello = createReactClass({
 
 ## Settings
 
-- `settings.react.version` — when set to a version `>= 18.3.0`, `this.refs` accesses are not reported (they are writable on modern React). When unset, defaults to latest.
-- `settings.react.pragma` — used to recognize `<pragma>.createClass(...)` and classes extending `<pragma>.Component` / `<pragma>.PureComponent`. Defaults to `React`.
+- `settings.react.version` — when set to a version `>= 18.3.0`, `this.refs` accesses are not reported (they are writable on modern React). When unset, `settings.react.defaultVersion` is used, then latest.
+- `settings.react.pragma` — used to recognize `<pragma>.createClass(...)` and classes extending `<pragma>.Component` / `<pragma>.PureComponent`. Defaults to `React`; a file-level `@jsx` annotation takes precedence.
 - `settings.react.createClass` — the identifier used for ES5 component factories. Defaults to `createReactClass`.
 
 ## Differences from ESLint
 
 - **JSDoc `@extends` / `@augments` tags are not honored**. eslint-plugin-react has an `isExplicitComponent` path that treats a class as a React component when its JSDoc contains `@extends React.Component` or `@augments React.Component`, even without an `extends` clause. rslint only recognizes components through the actual `extends` clause; JSDoc-only component declarations are not flagged.
-- **`settings.react.version = "detect"` is not resolved**. eslint-plugin-react reads `react` from `node_modules` to auto-detect the version. rslint treats `"detect"` (and any non-numeric version string) as "latest" (999.999.999), which means `this.refs` is not reported in that mode. Set an explicit version string (e.g. `"18.2.0"`) to exercise the `< 18.3.0` gate.
-- **Semver range strings (`^18.0.0`, `~18.0.0`, `>=17 <19`, etc.) are interpreted loosely**. eslint-plugin-react passes the value to `semver.satisfies`, which throws on non-exact versions. rslint extracts the leading numeric triple (`^18.0.0` → `18.0.0`) and compares it directly. Prefer an exact version string for predictable behavior.
+- **`settings.react.version = "detect"` is not resolved from `node_modules`**. rslint uses `settings.react.defaultVersion` when provided and otherwise treats the version as latest. Set an explicit version string (e.g. `"18.2.0"`) for exact version-aware behavior.
+- **Semver range strings (`^18.0.0`, `~18.0.0`, `>=17 <19`, etc.) are interpreted differently**. eslint-plugin-react coerces the setting to one version before comparison, while rslint extracts the first numeric triple and compares it directly. Prefer an exact version string for predictable behavior.
+- **Computed identifier member names are not treated as literal property names**. eslint-plugin-react reads ESTree's `property.name` without checking `computed`, so it reports `this[refs]` and classifies `React[createClass](...)` when those identifiers happen to have the configured names. rslint does not assume their runtime values. Private `this.#refs` is likewise not the public legacy `this.refs` API and is not reported.
+- **Invalid `settings.react.createClass` values do not terminate linting**. eslint-plugin-react throws while initializing the rule; rslint treats the configured string as a non-matching factory name because the native rule API has no recoverable settings-error channel.
 
 ## Original Documentation
 

--- a/internal/plugins/react/rules/no_string_refs/no_string_refs_extras_test.go
+++ b/internal/plugins/react/rules/no_string_refs/no_string_refs_extras_test.go
@@ -1,0 +1,42 @@
+package no_string_refs
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoStringRefsRuleExtras(t *testing.T) {
+	legacy := map[string]interface{}{"react": map[string]interface{}{"version": "18.2.0"}}
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoStringRefsRule, []rule_tester.ValidTestCase{
+		// Intentional divergence: upstream checks ESTree `property.name` without
+		// checking `computed`, so these variable/private-key accesses are false
+		// positives there. Neither expression necessarily accesses React's public
+		// `refs` property.
+		{Code: `class Hello extends React.Component { componentDidMount() { const refs = "not-react-refs"; var c = this[refs]; } }`, Tsx: true, Settings: legacy},
+		{Code: `class Hello extends React.Component { #refs; componentDidMount() { var c = this.#refs; } }`, Tsx: true, Settings: legacy},
+		// Intentional divergence for the same reason: `createClass` is a variable
+		// key, not necessarily the configured property name.
+		{Code: `const createClass = "not-the-factory"; var Hello = React[createClass]({ componentDidMount() { var c = this.refs.foo; } });`, Tsx: true, Settings: map[string]interface{}{"react": map[string]interface{}{"version": "18.2.0", "createClass": "createClass"}}},
+		// A source annotation overrides settings in both directions.
+		{Code: `/** @jsx Preact.h */ class Hello extends Other.Component { componentDidMount() { var c = this.refs.foo; } }`, Tsx: true, Settings: map[string]interface{}{"react": map[string]interface{}{"version": "18.2.0", "pragma": "Other"}}},
+	}, []rule_tester.InvalidTestCase{
+		{Code: `/** @jsx Preact.h */ class Hello extends Preact.Component { componentDidMount() { var c = this.refs.foo; } }`, Tsx: true, Settings: map[string]interface{}{"react": map[string]interface{}{"version": "18.2.0", "pragma": "Other"}}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "thisRefsDeprecated", Line: 1, Column: 91}}},
+		{Code: `/** @jsx Preact.h */ var Hello = Preact.createClass({ componentDidMount() { var c = this.refs.foo; } });`, Tsx: true, Settings: map[string]interface{}{"react": map[string]interface{}{"version": "18.2.0", "pragma": "Other", "createClass": "createClass"}}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "thisRefsDeprecated", Line: 1, Column: 85}}},
+		{Code: `class Hello extends React.Component { componentDidMount() { var c = this.refs.foo; } }`, Tsx: true, Settings: map[string]interface{}{"react": map[string]interface{}{"defaultVersion": "18.2.0"}}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "thisRefsDeprecated", Line: 1, Column: 69}}},
+		{Code: `class Hello extends React.Component { componentDidMount() { var c = this.refs.foo; } }`, Tsx: true, Settings: map[string]interface{}{"react": map[string]interface{}{"version": "detect", "defaultVersion": "18.2.0"}}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "thisRefsDeprecated", Line: 1, Column: 69}}},
+		{Code: `class Hello extends React.Component { componentDidMount() { var c = this.refs.foo; } }`, Tsx: true, Settings: map[string]interface{}{"react": map[string]interface{}{"version": 17}}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "thisRefsDeprecated", Line: 1, Column: 69}}},
+		// String refs are deprecated on custom JSX components as well as intrinsic
+		// elements; the listener intentionally does not filter by tag kind.
+		{Code: `<Widget ref="instance" />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "stringInRefDeprecated", Line: 1, Column: 9}}},
+		{Code: `<UI.Widget ref={'instance'} />`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "stringInRefDeprecated", Line: 1, Column: 12}}},
+		// ESTree erases these parentheses while ts-go retains them.
+		{Code: `var Hello = createReactClass({ componentDidMount: (function() { var c = this.refs.foo; }) });`, Tsx: true, Settings: legacy, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "thisRefsDeprecated", Line: 1, Column: 73}}},
+		{Code: `var Hello = createReactClass({ componentDidMount: (() => this.refs.foo) });`, Tsx: true, Settings: legacy, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "thisRefsDeprecated", Line: 1, Column: 58}}},
+		// CallExpression and NewExpression both expose a callee in ESTree; the
+		// create-react-class factory also returns its constructor explicitly.
+		{Code: `var Hello = new createReactClass({ componentDidMount() { var c = this.refs.foo; } });`, Tsx: true, Settings: legacy, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "thisRefsDeprecated", Line: 1, Column: 66}}},
+		{Code: `var Hello = new React.createClass({ componentDidMount() { var c = this.refs.foo; } });`, Tsx: true, Settings: map[string]interface{}{"react": map[string]interface{}{"version": "18.2.0", "createClass": "createClass"}}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "thisRefsDeprecated", Line: 1, Column: 67}}},
+	})
+}

--- a/packages/rslint-test-tools/tests/eslint-plugin-react/rules/no-string-refs.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react/rules/no-string-refs.test.ts
@@ -2,11 +2,6 @@ import { RuleTester } from '../rule-tester';
 
 const ruleTester = new RuleTester();
 
-// NOTE: `this.refs` detection depends on `settings.react.version`, which the
-// shared JS rule-tester does not thread through to `lint()`. Those cases are
-// covered by the Go unit tests (`no_string_refs_test.go`). The JS suite here
-// focuses on the JSX `ref={...}` detection, which is version-independent.
-
 ruleTester.run('no-string-refs', {} as never, {
   valid: [
     // Callback ref is fine.
@@ -51,8 +46,79 @@ ruleTester.run('no-string-refs', {} as never, {
     { code: `<div ref={'hello'!} />;` },
     { code: `<div ref={('hello' as string)} />;` },
     { code: `<div ref={'hello' satisfies string} />;` },
+    // Intentional divergences from upstream: computed identifier and private
+    // names do not necessarily refer to React's public `refs` property.
+    {
+      code: `class App extends React.Component { method() { const refs = 'not-react-refs'; return this[refs]; } }`,
+      settings: { react: { version: '18.2.0' } },
+    },
+    {
+      code: `class App extends React.Component { #refs; method() { return this.#refs; } }`,
+      settings: { react: { version: '18.2.0' } },
+    },
+    {
+      code: `/** @jsx Preact.h */ class App extends Other.Component { method() { return this.refs; } }`,
+      settings: { react: { version: '18.2.0', pragma: 'Other' } },
+    },
   ],
   invalid: [
+    // Custom JSX components have the same string-ref semantics as intrinsic
+    // elements, including member-expression component names.
+    {
+      code: `<Widget ref="instance" />;`,
+      errors: [
+        { message: 'Using string literals in ref attributes is deprecated.' },
+      ],
+    },
+    {
+      code: `<UI.Widget ref={'instance'} />;`,
+      errors: [
+        { message: 'Using string literals in ref attributes is deprecated.' },
+      ],
+    },
+    {
+      code: `/** @jsx Preact.h */ class App extends Preact.Component { method() { return this.refs; } }`,
+      settings: { react: { version: '18.2.0', pragma: 'Other' } },
+      errors: [{ message: 'Using this.refs is deprecated.' }],
+    },
+    {
+      code: `/** @jsx Preact.h */ var App = Preact.createClass({ method() { return this.refs; } });`,
+      settings: {
+        react: {
+          version: '18.2.0',
+          pragma: 'Other',
+          createClass: 'createClass',
+        },
+      },
+      errors: [{ message: 'Using this.refs is deprecated.' }],
+    },
+    {
+      code: `class App extends React.Component { method() { return this.refs; } }`,
+      settings: { react: { defaultVersion: '18.2.0' } },
+      errors: [{ message: 'Using this.refs is deprecated.' }],
+    },
+    {
+      code: `class App extends React.Component { method() { return this.refs; } }`,
+      settings: {
+        react: { version: 'detect', defaultVersion: '18.2.0' },
+      },
+      errors: [{ message: 'Using this.refs is deprecated.' }],
+    },
+    {
+      code: `class App extends React.Component { method() { return this.refs; } }`,
+      settings: { react: { version: 17 } },
+      errors: [{ message: 'Using this.refs is deprecated.' }],
+    },
+    {
+      code: `var App = createReactClass({ method: (function() { return this.refs; }) });`,
+      settings: { react: { version: '18.2.0' } },
+      errors: [{ message: 'Using this.refs is deprecated.' }],
+    },
+    {
+      code: `var App = new createReactClass({ method() { return this.refs; } });`,
+      settings: { react: { version: '18.2.0' } },
+      errors: [{ message: 'Using this.refs is deprecated.' }],
+    },
     // String literal directly.
     {
       code: `


### PR DESCRIPTION
## Summary

- honor file-level `@jsx` pragmas when identifying class and legacy React components
- recognize parenthesized ES5 component methods and `new createReactClass(...)` forms
- centralize `settings.react.version` / `defaultVersion` parsing for React rules and coerce numeric versions consistently with upstream
- add Go and JS regression coverage, including string refs on custom JSX components

## Other differences not addressed

- Rslint does not report `this[refs]` or `this.#refs`. Upstream reads `MemberExpression.property.name` without checking whether the property is computed or private, but neither form necessarily accesses React's public `this.refs` property.
- Rslint does not classify `React[createClass](...)` as a component factory call because the computed identifier's runtime value is unknown.
- Invalid `settings.react.pragma` values fall back to `React`, matching upstream; invalid `settings.react.createClass` values remain non-matching instead of terminating native lint execution because native rules have no recoverable settings-error channel.
- Existing documented differences remain for JSDoc-only component detection, resolving `version: "detect"` from `node_modules`, and semver-range handling.
