### PR TITLE
feat(rstest): add rule prefer-comparison-matcher

### DIFF
--- a/internal/plugins/jest/rules/prefer_comparison_matcher/prefer_comparison_matcher.go
+++ b/internal/plugins/jest/rules/prefer_comparison_matcher/prefer_comparison_matcher.go
@@ -1,135 +1,49 @@
 package prefer_comparison_matcher
 
 import (
-	"slices"
-
 	"github.com/microsoft/TypeScript/tsc/shim/ast"
 	"github.com/microsoft/TypeScript/tsc/shim/core"
-	"github.com/microsoft/TypeScript/tsc/shim/scanner"
-	"github.com/web-infra-dev/rslint/internal/plugins/jest/utils"
+	jestUtils "github.com/web-infra-dev/rslint/internal/plugins/jest/utils"
 	"github.com/web-infra-dev/rslint/internal/rule"
-	internalUtils "github.com/web-infra-dev/rslint/internal/utils"
+	testFramework "github.com/web-infra-dev/rslint/internal/utils/test_framework"
+	shared "github.com/web-infra-dev/rslint/internal/utils/test_framework/rules/prefer_comparison_matcher"
 )
 
-type comparisonMatcher struct {
-	matcher        string
-	negatedMatcher string
-}
-
-var comparisonMatchers = map[ast.Kind]comparisonMatcher{
-	ast.KindGreaterThanToken:       {matcher: "toBeGreaterThan", negatedMatcher: "toBeLessThanOrEqual"},
-	ast.KindLessThanToken:          {matcher: "toBeLessThan", negatedMatcher: "toBeGreaterThanOrEqual"},
-	ast.KindGreaterThanEqualsToken: {matcher: "toBeGreaterThanOrEqual", negatedMatcher: "toBeLessThan"},
-	ast.KindLessThanEqualsToken:    {matcher: "toBeLessThanOrEqual", negatedMatcher: "toBeGreaterThan"},
-}
-
-func buildUseComparisonMatcherMessage(preferredMatcher string) rule.RuleMessage {
-	return rule.RuleMessage{
-		Id:          "useToBeComparison",
-		Description: "Prefer using `" + preferredMatcher + "` instead",
-		Data: map[string]string{
-			"preferredMatcher": preferredMatcher,
-		},
-	}
-}
-
-func isStringComparisonOperand(node *ast.Node) bool {
-	return internalUtils.IsStringLiteralOrTemplate(utils.UnwrapBasicTypeAssertions(node))
-}
-
-func parseComparison(node *ast.Node) (left, right *ast.Node, matchers comparisonMatcher, ok bool) {
-	node = ast.SkipParentheses(node)
-	if node == nil || node.Kind != ast.KindBinaryExpression {
-		return nil, nil, comparisonMatcher{}, false
-	}
-
-	bin := node.AsBinaryExpression()
-	matchers, ok = comparisonMatchers[bin.OperatorToken.Kind]
-	if !ok || isStringComparisonOperand(bin.Left) || isStringComparisonOperand(bin.Right) {
-		return nil, nil, comparisonMatcher{}, false
-	}
-
-	return bin.Left, bin.Right, matchers, true
-}
-
-func buildModifierText(jestFnCall *utils.ParsedJestFnCall) string {
-	if len(jestFnCall.ModifierEntries) > 0 && jestFnCall.ModifierEntries[0].Name != "not" {
-		return "." + jestFnCall.ModifierEntries[0].Name
-	}
-	return ""
-}
-
-var PreferComparisonMatcherRule = rule.Rule{
-	Name:   "jest/prefer-comparison-matcher",
-	Schema: rule.EmptyArraySchema,
-	Run: func(ctx rule.RuleContext, _options []any) rule.RuleListeners {
-		return rule.RuleListeners{
-			ast.KindCallExpression: func(node *ast.Node) {
-				jestFnCall := utils.ParseJestFnCall(node, ctx)
-				if jestFnCall == nil ||
-					jestFnCall.Kind != utils.JestFnTypeExpect ||
-					jestFnCall.MatcherEntry == nil ||
-					!utils.EQUALITY_METHOD_NAMES[jestFnCall.Matcher] {
-					return
-				}
-
-				expectCall := jestFnCall.Head.Local.Node.Parent
-				if expectCall == nil || expectCall.Kind != ast.KindCallExpression {
-					return
-				}
-
-				expectArgs := expectCall.Arguments()
-				if len(expectArgs) == 0 {
-					return
-				}
-
-				left, right, matchers, ok := parseComparison(expectArgs[0])
-				if !ok {
-					return
-				}
-
-				matcherEntry := jestFnCall.MatcherEntry
-				if matcherEntry.Call == nil || node != matcherEntry.Call {
-					return
-				}
-
-				// The accessor, not the entry's direct parent, ends the modifier
-				// range: a parenthesized key such as `[("toBe")]` parents the
-				// literal to the parentheses rather than the element access.
-				_, matcherAccessor := utils.GetAccessorReceiverAndParent(matcherEntry)
-				if matcherAccessor == nil {
-					return
-				}
-
-				matcherArgs := matcherEntry.Call.AsCallExpression().Arguments.Nodes
-				if len(matcherArgs) == 0 {
-					return
-				}
-
-				matcherArg := matcherArgs[0]
-				matcherValue, ok := utils.IsBooleanLiteral(matcherArg)
-				if !ok {
-					return
-				}
-
-				preferredMatcher := matchers.matcher
-				if matcherValue == slices.Contains(jestFnCall.Modifiers, "not") {
-					preferredMatcher = matchers.negatedMatcher
-				}
-
-				comparison := ast.SkipParentheses(expectArgs[0])
-				leftText := scanner.GetSourceTextOfNodeFromSourceFile(ctx.SourceFile, left, false)
-				rightText := scanner.GetSourceTextOfNodeFromSourceFile(ctx.SourceFile, right, false)
-				modifierRange := core.NewTextRange(expectCall.End(), matcherAccessor.End())
-
-				ctx.ReportNodeWithFixes(
-					matcherEntry.Node,
-					buildUseComparisonMatcherMessage(preferredMatcher),
-					rule.RuleFixReplace(ctx.SourceFile, comparison, leftText),
-					rule.RuleFixReplaceRange(modifierRange, buildModifierText(jestFnCall)+"."+preferredMatcher),
-					rule.RuleFixReplace(ctx.SourceFile, matcherArg, rightText),
-				)
-			},
+var PreferComparisonMatcherRule = shared.NewRule(shared.Config{
+	Name: "jest/prefer-comparison-matcher",
+	Prepare: func(ctx rule.RuleContext) func(*ast.Node) *shared.ExpectCall {
+		return func(node *ast.Node) *shared.ExpectCall {
+			parsed := jestUtils.ParseJestFnCall(node, ctx)
+			if parsed == nil || parsed.Kind != jestUtils.JestFnTypeExpect || parsed.MatcherEntry == nil || parsed.MatcherEntry.Call != node {
+				return nil
+			}
+			head := ast.WalkUpParenthesizedExpressions(parsed.Head.Local.Node.Parent)
+			if head == nil || head.Kind != ast.KindCallExpression {
+				return nil
+			}
+			return &shared.ExpectCall{
+				HeadCall: head, MatcherCall: node, MatcherEntry: *parsed.MatcherEntry,
+				Matcher: parsed.Matcher, Modifiers: parsed.ModifierEntries,
+			}
 		}
 	},
-}
+	BuildFixes: func(ctx rule.RuleContext, match shared.Match) []rule.RuleFix {
+		_, accessor := testFramework.AccessorReceiverAndParent(&match.Expect.MatcherEntry)
+		if accessor == nil {
+			return nil
+		}
+		// Replacing across receiver parentheses would leave unmatched opening parentheses.
+		for receiver := accessor.Expression(); receiver != match.Expect.HeadCall; receiver = receiver.Expression() {
+			if receiver == nil || receiver.Kind == ast.KindParenthesizedExpression {
+				return nil
+			}
+		}
+		modifier := ""
+		if entries := match.Expect.Modifiers; len(entries) > 0 && entries[0].Name != "not" {
+			modifier = "." + entries[0].Name
+		}
+		return append(shared.OperandFixes(ctx, match), rule.RuleFixReplaceRange(
+			core.NewTextRange(match.Expect.HeadCall.End(), accessor.End()), modifier+"."+match.Matcher,
+		))
+	},
+})

--- a/internal/plugins/jest/rules/prefer_comparison_matcher/prefer_comparison_matcher.md
+++ b/internal/plugins/jest/rules/prefer_comparison_matcher/prefer_comparison_matcher.md
@@ -48,7 +48,17 @@ fix rewrites the assertion to a numeric matcher and fails at runtime:
 expect(myName > theirName).toBe(true);
 ```
 
+Negative expectations use the opposite comparison operator, matching eslint-plugin-jest. This assumes neither operand is `NaN`: for example, `expect(NaN > 1).toBe(false)` passes, but its fix `expect(NaN).toBeLessThanOrEqual(1)` fails. Disable the rule for comparisons that may involve `NaN` and need to retain that behavior.
+
+## Differences from ESLint
+
+- Parentheses around comma-expression operands are preserved, so moving `(read(), value)` does not turn it into multiple arguments.
+- Type assertions on boolean expectations are removed with the boolean, rather than being applied to the replacement operand. For example, `toBe(true as const)` does not become `toBeGreaterThan(limit as const)`.
+- String literals inside TypeScript type assertions are excluded just like unwrapped string literals.
+- Only one diagnostic is emitted for the equality matcher when further calls follow it, such as `expect(a > b).toBe(true).toString()`.
+- Assertions with parentheses around the receiver, such as `(expect(a > b)).toBe(true)`, are reported without an autofix to avoid removing only the closing parentheses.
+
 ## Original Documentation
 
-- [eslint-plugin-jest: prefer-comparison-matcher](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/docs/rules/prefer-comparison-matcher.md)
-- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.0/src/rules/prefer-comparison-matcher.ts)
+- [eslint-plugin-jest: prefer-comparison-matcher](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.1/docs/rules/prefer-comparison-matcher.md)
+- [Source code](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.1/src/rules/prefer-comparison-matcher.ts)

--- a/internal/plugins/jest/rules/prefer_comparison_matcher/prefer_comparison_matcher_extras_test.go
+++ b/internal/plugins/jest/rules/prefer_comparison_matcher/prefer_comparison_matcher_extras_test.go
@@ -1,0 +1,60 @@
+// Regression and branch coverage beyond prefer_comparison_matcher_upstream_test.go.
+package prefer_comparison_matcher_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/jest/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/jest/rules/prefer_comparison_matcher"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestPreferComparisonMatcherExtras(t *testing.T) {
+	valid := []rule_tester.ValidTestCase{
+		{Code: `expect(value > 1)[matcher].toBe(true);`}, {Code: `expect(value > 1)[foo()].toBe(true);`},
+		{Code: `expect(a > b).toBe();`}, {Code: `expect(a > b).toBe(flag);`}, {Code: `expect(a > b).toBe(...flags);`},
+		{Code: `expect(a + b).toBe(true);`}, {Code: `expect(a > b).toContain(true);`},
+		{Code: `expect.soft(a > b).toBe(true);`}, {Code: `expect(a > b).toBe(true satisfies boolean);`},
+		{Code: `expect(a > ('b' as string)).toBe(true);`},
+		{Code: `function test(expect: any) { expect(a > b).toBe(true); }`},
+		{Code: `import { expect } from '@rstest/core'; expect(a > b).toBe(true);`},
+		{Code: `(expect(a > b) as any).toBe(true);`}, {Code: `expect(a > b)!.toBe(true);`},
+	}
+	var invalid []rule_tester.InvalidTestCase
+	for _, test := range []struct {
+		code, output, matcher string
+		column                int
+	}{
+		// ---- Dimension 4: accessor, receiver and literal wrappers ----
+		{`expect(value > 1)[("toBe")](true);`, `expect(value).toBeGreaterThan(1);`, "toBeGreaterThan", 20},
+		{`expect(value > 1).toBe(true as const);`, `expect(value).toBeGreaterThan(1);`, "toBeGreaterThan", 19},
+		{`expect(value > 1).toBe((true));`, `expect(value).toBeGreaterThan((1));`, "toBeGreaterThan", 19},
+		{`expect((a, b) > c).toBe(true);`, `expect((a, b)).toBeGreaterThan(c);`, "toBeGreaterThan", 20},
+		{`expect(a > (b, c)).toBe(true);`, `expect(a).toBeGreaterThan((b, c));`, "toBeGreaterThan", 20},
+		{`expect(((a) > (b))).toBe(true);`, `expect((a)).toBeGreaterThan(b);`, "toBeGreaterThan", 21},
+		{`expect(value > 1).toBe(true).toString();`, `expect(value).toBeGreaterThan(1).toString();`, "toBeGreaterThan", 19},
+		{`expect(value > 1).toBe(true).foo(false);`, `expect(value).toBeGreaterThan(1).foo(false);`, "toBeGreaterThan", 19},
+		{`expect(a > b)?.toBe(true);`, `expect(a).toBeGreaterThan(b);`, "toBeGreaterThan", 16},
+		{`expect(a > b).toBe?.(true);`, `expect(a).toBeGreaterThan?.(b);`, "toBeGreaterThan", 15},
+		// Locks in upstream's inverted-operator policy, including its NaN limitation.
+		{`expect(NaN > 1).toBe(false);`, `expect(NaN).toBeLessThanOrEqual(1);`, "toBeLessThanOrEqual", 17},
+		{`expect(a <= b).rejects.not.toBe(true);`, `expect(a).rejects.toBeGreaterThan(b);`, "toBeGreaterThan", 28},
+		// ---- Real-user: jest-community/eslint-plugin-jest#2000 empty subject ----
+		{`expect().toBe(true); expect(a > b).toBe(true);`, `expect().toBe(true); expect(a).toBeGreaterThan(b);`, "toBeGreaterThan", 36},
+		// ---- Real-user: trailing comma formatting in generated assertions ----
+		{`expect(a > b,).toBe(true,);`, `expect(a,).toBeGreaterThan(b,);`, "toBeGreaterThan", 16},
+		// ---- Dimension 4: comments and UTF-16 ----
+		{`expect(a /* note */ > b).toBe(true);`, `expect(a).toBeGreaterThan(b);`, "toBeGreaterThan", 26},
+		{`expect(a > b, "😀").toBe(true);`, `expect(a, "😀").toBeGreaterThan(b);`, "toBeGreaterThan", 21},
+		// N/A: declaration names and private fields do not participate in matcher selection.
+	} {
+		expectedError := rule_tester.InvalidTestCaseError{MessageId: "useToBeComparison", Message: "Prefer using `" + test.matcher + "` instead", Line: 1, Column: test.column}
+		invalid = append(invalid, rule_tester.InvalidTestCase{Code: test.code, Output: []string{test.output}, Errors: []rule_tester.InvalidTestCaseError{expectedError}})
+	}
+	invalid = append(invalid,
+		rule_tester.InvalidTestCase{Code: `(expect)(a > b).toBe(true);`, Output: []string{`(expect)(a).toBeGreaterThan(b);`}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBeComparison"}}},
+		rule_tester.InvalidTestCase{Code: `(expect(a > b)).toBe(true);`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBeComparison"}}},
+		rule_tester.InvalidTestCase{Code: `((expect(a > b).not)).toBe(false);`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToBeComparison"}}},
+	)
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &prefer_comparison_matcher.PreferComparisonMatcherRule, valid, invalid)
+}

--- a/internal/plugins/jest/rules/prefer_comparison_matcher/prefer_comparison_matcher_upstream_test.go
+++ b/internal/plugins/jest/rules/prefer_comparison_matcher/prefer_comparison_matcher_upstream_test.go
@@ -1,3 +1,4 @@
+// Mirrors eslint-plugin-jest v29.16.1; additional shapes live in prefer_comparison_matcher_extras_test.go.
 package prefer_comparison_matcher_test
 
 import (
@@ -197,53 +198,7 @@ func TestPreferComparisonMatcherRule(t *testing.T) {
 		rule_tester.ValidTestCase{Code: `expect(5 != a).toBe(true)`},
 		rule_tester.ValidTestCase{Code: `expect(a == "string").toBe(true)`},
 		rule_tester.ValidTestCase{Code: `expect(a == "string").not.toBe(true)`},
-		rule_tester.ValidTestCase{Code: `expect(value > 1)[matcher].toBe(true);`},
-		rule_tester.ValidTestCase{Code: `expect(value > 1)[foo()].toBe(true);`},
-	)
-
-	invalidCases = append(invalidCases,
-		rule_tester.InvalidTestCase{
-			Code:   `expect(value > 1)[("toBe")](true);`,
-			Output: []string{`expect(value).toBeGreaterThan(1);`},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "useToBeComparison", Line: 1, Column: 20},
-			},
-		},
-		rule_tester.InvalidTestCase{
-			Code:   `expect(value > 1).toBe(true as const);`,
-			Output: []string{`expect(value).toBeGreaterThan(1);`},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "useToBeComparison", Line: 1, Column: 19},
-			},
-		},
-		rule_tester.InvalidTestCase{
-			Code:   `expect((a, b) > c).toBe(true);`,
-			Output: []string{`expect((a, b)).toBeGreaterThan(c);`},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "useToBeComparison", Line: 1, Column: 20},
-			},
-		},
-		rule_tester.InvalidTestCase{
-			Code:   `expect(a > (b, c)).toBe(true);`,
-			Output: []string{`expect(a).toBeGreaterThan((b, c));`},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "useToBeComparison", Line: 1, Column: 20},
-			},
-		},
-		rule_tester.InvalidTestCase{
-			Code:   `expect(value > 1).toBe(true).toString();`,
-			Output: []string{`expect(value).toBeGreaterThan(1).toString();`},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "useToBeComparison", Line: 1, Column: 19},
-			},
-		},
-		rule_tester.InvalidTestCase{
-			Code:   `expect(value > 1).toBe(true).foo(false);`,
-			Output: []string{`expect(value).toBeGreaterThan(1).foo(false);`},
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "useToBeComparison", Line: 1, Column: 19},
-			},
-		},
+		rule_tester.ValidTestCase{Code: `expect().toStrictEqual({})`},
 	)
 
 	rule_tester.RunRuleTester(

--- a/internal/plugins/jest/utils/parse_jest_fn.go
+++ b/internal/plugins/jest/utils/parse_jest_fn.go
@@ -230,11 +230,17 @@ func ResolveFunctionReferenceForModule(
 	ctx rule.RuleContext,
 	importModule string,
 ) (string, *ast.Node, JestImportMode) {
-	return testFramework.ResolveFunctionReferenceForModule(
-		node,
+	if node == nil || node.Kind != ast.KindCallExpression {
+		return localName, localNode, JEST_GLOBAL_MODE
+	}
+	identifier := ResolveFirstIdentifier(node.AsCallExpression().Expression)
+	if identifier == nil {
+		return localName, localNode, JEST_GLOBAL_MODE
+	}
+	return testFramework.ResolveFunctionIdentifierReferenceFromSymbol(
 		localName,
-		localNode,
-		ctx.TypeChecker,
+		identifier,
+		ctx.Refs.Resolve(identifier),
 		ctx.SourceFile,
 		importModule,
 	)

--- a/internal/plugins/rstest/all.go
+++ b/internal/plugins/rstest/all.go
@@ -37,6 +37,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/prefer_called_once"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/prefer_called_times"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/prefer_called_with"
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/prefer_comparison_matcher"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/prefer_each"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/prefer_equality_matcher"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/prefer_expect_type_of"
@@ -99,6 +100,7 @@ func GetAllRules() []rule.Rule {
 		prefer_called_once.PreferCalledOnceRule,
 		prefer_called_times.PreferCalledTimesRule,
 		prefer_called_with.PreferCalledWithRule,
+		prefer_comparison_matcher.PreferComparisonMatcherRule,
 		prefer_each.PreferEachRule,
 		prefer_equality_matcher.PreferEqualityMatcherRule,
 		prefer_expect_type_of.PreferExpectTypeOfRule,

--- a/internal/plugins/rstest/rules/prefer_comparison_matcher/prefer_comparison_matcher.go
+++ b/internal/plugins/rstest/rules/prefer_comparison_matcher/prefer_comparison_matcher.go
@@ -1,0 +1,140 @@
+package prefer_comparison_matcher
+
+import (
+	"github.com/microsoft/TypeScript/tsc/shim/ast"
+	rstestUtils "github.com/web-infra-dev/rslint/internal/plugins/rstest/utils"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+	testFramework "github.com/web-infra-dev/rslint/internal/utils/test_framework"
+	shared "github.com/web-infra-dev/rslint/internal/utils/test_framework/rules/prefer_comparison_matcher"
+)
+
+var PreferComparisonMatcherRule = shared.NewRule(shared.Config{
+	Name: "rstest/prefer-comparison-matcher",
+	// !(a > b) is not a <= b when either operand is NaN.
+	PreserveNegation: true,
+	// Numeric matchers reject coercion, which cannot be ruled out without type information.
+	Suggestions:   true,
+	IgnoreOperand: isNonNumericOperand,
+	Prepare: func(ctx rule.RuleContext) func(*ast.Node) *shared.ExpectCall {
+		analysis := rstestUtils.GetRstestCallAnalysis(ctx)
+		return func(node *ast.Node) *shared.ExpectCall {
+			parsed := analysis.ParseExpectCall(node)
+			if parsed == nil || parsed.Reason != rstestUtils.RstestExpectParseReasonNone || parsed.MatcherEntry == nil || parsed.Head == nil {
+				return nil
+			}
+			// Poll consumes a callback and element consumes a locator, not a boolean subject.
+			if parsed.Entry != rstestUtils.RstestExpectEntryCall && parsed.Entry != rstestUtils.RstestExpectEntrySoft {
+				return nil
+			}
+			if len(parsed.Matchers) == 0 || parsed.Matchers[0].Kind != rstestUtils.RstestExpectMatcherCall || testFramework.IsComputedIdentifierAccessor(parsed.MatcherEntry.Node) {
+				return nil
+			}
+			for _, modifier := range parsed.Modifiers {
+				// A relational expression produces a boolean, never a promise to resolve or reject.
+				if modifier == "resolves" || modifier == "rejects" {
+					return nil
+				}
+			}
+			matcherCall := rstestUtils.MatcherCall(parsed.MatcherEntry)
+			if matcherCall == nil {
+				return nil
+			}
+			return &shared.ExpectCall{
+				HeadCall: parsed.Head, MatcherCall: matcherCall, MatcherEntry: *parsed.MatcherEntry,
+				Matcher: parsed.Matcher, Modifiers: parsed.ModifierEntries,
+				Editable: parsed.Expression == matcherCall,
+			}
+		}
+	},
+	BuildFixes: buildSuggestion,
+})
+
+func isNonNumericOperand(node *ast.Node) bool {
+	node = utils.SkipAssertionsAndParens(node)
+	if utils.IsStringLiteralOrTemplate(node) {
+		return true
+	}
+	switch node.Kind {
+	case ast.KindTrueKeyword, ast.KindFalseKeyword, ast.KindNullKeyword, ast.KindRegularExpressionLiteral,
+		ast.KindArrayLiteralExpression, ast.KindObjectLiteralExpression, ast.KindArrowFunction,
+		ast.KindFunctionExpression, ast.KindClassExpression, ast.KindVoidExpression:
+		return true
+	default:
+		return false
+	}
+}
+
+func buildSuggestion(ctx rule.RuleContext, match shared.Match) []rule.RuleFix {
+	if !match.Expect.Editable {
+		return nil
+	}
+	headCall := match.Expect.HeadCall.AsCallExpression()
+	matcherCall := match.Expect.MatcherCall.AsCallExpression()
+	if headCall == nil || matcherCall == nil || hasTypeArguments(headCall) || hasTypeArguments(matcherCall) ||
+		!isStaticNumericOperand(match.Left) || !isStaticNumericOperand(match.Right) {
+		return nil
+	}
+	for _, node := range []*ast.Node{match.Comparison, match.MatcherArgument} {
+		span := utils.TrimNodeTextRange(ctx.SourceFile, node)
+		if utils.HasCommentInSpan(ctx.Comments.All(), span.Pos(), span.End()) {
+			return nil
+		}
+	}
+	matcherRange, matcherText, ok := testFramework.AccessorReplacement(ctx.SourceFile, match.Expect.MatcherEntry.Node, match.Matcher)
+	if !ok {
+		return nil
+	}
+	fixes := append(shared.OperandFixes(ctx, match), rule.RuleFixReplaceRange(matcherRange, matcherText))
+	var not *testFramework.MemberEntry
+	for i := range match.Expect.Modifiers {
+		if match.Expect.Modifiers[i].Name == "not" {
+			not = &match.Expect.Modifiers[i]
+			break
+		}
+	}
+	switch {
+	case match.Negated && not == nil:
+		span, text, ok := testFramework.InsertMemberBeforeAccessor(&match.Expect.MatcherEntry, "not")
+		if !ok {
+			return nil
+		}
+		fixes = append(fixes, rule.RuleFixReplaceRange(span, text))
+	case !match.Negated && not != nil:
+		ranges, ok := testFramework.RemoveAccessorEntryRanges(ctx.SourceFile, ctx.Comments.All(), not)
+		if !ok {
+			return nil
+		}
+		for _, span := range ranges {
+			fixes = append(fixes, rule.RuleFixRemoveRange(span))
+		}
+	}
+	return fixes
+}
+
+func hasTypeArguments(call *ast.CallExpression) bool {
+	return call.TypeArguments != nil && len(call.TypeArguments.Nodes) > 0
+}
+
+func isStaticNumericOperand(node *ast.Node) bool {
+	node = utils.SkipAssertionsAndParens(node)
+	if node == nil {
+		return false
+	}
+	switch node.Kind {
+	case ast.KindNumericLiteral, ast.KindBigIntLiteral:
+		return true
+	case ast.KindPrefixUnaryExpression:
+		unary := node.AsPrefixUnaryExpression()
+		operand := utils.SkipAssertionsAndParens(unary.Operand)
+		if operand == nil {
+			return false
+		}
+		if unary.Operator == ast.KindMinusToken {
+			return operand.Kind == ast.KindNumericLiteral || operand.Kind == ast.KindBigIntLiteral
+		}
+		return unary.Operator == ast.KindPlusToken && operand.Kind == ast.KindNumericLiteral
+	default:
+		return false
+	}
+}

--- a/internal/plugins/rstest/rules/prefer_comparison_matcher/prefer_comparison_matcher.md
+++ b/internal/plugins/rstest/rules/prefer_comparison_matcher/prefer_comparison_matcher.md
@@ -1,0 +1,33 @@
+# prefer-comparison-matcher
+
+## Rule Details
+
+Prefer numeric comparison matchers over checking a comparison's boolean result with `toBe`, `toEqual`, or `toStrictEqual`. For example, `expect(duration).toBeLessThan(timeout)` provides more useful failure messages than `expect(duration < timeout).toBe(true)`. The rule handles `>`, `>=`, `<`, and `<=`, literal boolean expectations, and `.not`. Negative expectations use `.not` with the original comparison matcher, rather than the opposite operator, because comparisons involving `NaN` are always false.
+
+The rule recognizes Rstest globals, imports and import aliases from `@rstest/core` and `@rstest/playwright`, namespace and CommonJS access, `import.meta.rstest`, and the local `expect` from a test's [TestContext](https://rstest.rs/api/runtime-api/test-api/test#testcontext). Both `expect(value, message)` and `expect.soft(value, message)` are checked. Dot access and static string or template matcher names are recognized, including Chai language chains before these three equality matchers; Chai's own equality methods and property assertions are not checked.
+
+The rule does not require type information. Comparisons with string or template literals, boolean or null literals, arrays, objects, functions, classes, regular expressions, or `void` operands are excluded, including through TypeScript assertions. Other operands are assumed to be numeric: use this rule for number and bigint comparisons, not comparisons relying on implicit conversion. Dynamic matcher names, shadowed or foreign `expect` functions, `expect.poll`, `expect.element`, and chains with `resolves` or `rejects` are excluded. A relational expression returns a boolean, not the promise those modifiers require. Only the first matcher in a chain is checked.
+
+## Incorrect
+
+```ts
+test('keeps processing within the limit', () => {
+  expect(processingTime < timeout).toBe(true);
+  expect(retryCount > maximumRetries).toEqual(false);
+});
+```
+
+## Correct
+
+```ts
+test('keeps processing within the limit', () => {
+  expect(processingTime).toBeLessThan(timeout);
+  expect(retryCount).not.toBeGreaterThan(maximumRetries);
+});
+```
+
+## Suggestions
+
+When both operands are numeric or bigint constants, the suggestion moves the left operand into `expect`, moves the right operand into the comparison matcher, and adjusts `.not` according to the boolean expectation. It preserves accessor quoting, optional chaining, and trailing commas. The change is a suggestion rather than an autofix because numeric matchers reject values that JavaScript comparison operators implicitly convert.
+
+Other operands are still reported without a suggestion. Calling `expect` before evaluating the right operand changes evaluation order, while passing an object to `expect` postpones numeric coercion until the matcher runs. Explicit type arguments on `expect` or the equality matcher suppress the suggestion because they describe the original boolean assertion. Comments inside a replaced comparison or boolean argument and members following the equality matcher suppress suggestions as well.

--- a/internal/plugins/rstest/rules/prefer_comparison_matcher/prefer_comparison_matcher_extras_test.go
+++ b/internal/plugins/rstest/rules/prefer_comparison_matcher/prefer_comparison_matcher_extras_test.go
@@ -1,0 +1,111 @@
+// Rstest semantics and edge shapes beyond prefer_comparison_matcher_upstream_test.go.
+package prefer_comparison_matcher
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestPreferComparisonMatcherExtras(t *testing.T) {
+	valid := []rule_tester.ValidTestCase{
+		// Locks in subject, operator, matcher and boolean-argument gates.
+		{Code: `expect(a > b).toBe();`}, {Code: `expect(a > b).toBe(flag);`}, {Code: `expect(a > b).toBe(...flags);`},
+		{Code: `expect(a + b).toBe(true);`}, {Code: `expect(a > b).toContain(true);`},
+		{Code: `expect(a > b).toBe(true satisfies boolean);`}, {Code: `expect(a > b).toBe(true!);`},
+		// ---- Dimension 4: receiver and computed-name boundaries ----
+		{Code: `expect(a > b).toBe;`}, {Code: `expect(a > b)[toBe](true);`}, {Code: `expect(a > b)[0](true);`},
+		{Code: `expect(a > b).to.be.true;`}, {Code: `expect(a > b).equal(true);`},
+		{Code: `expect(a > b)!.toBe(true);`}, {Code: `(expect(a > b) as any).toBe(true);`},
+		{Code: `(expect(a > b) satisfies Assertion).toBe(true);`},
+		{Code: `expect(a > b).not.not.toBe(true);`},
+		// Relational operators always produce booleans, not promises or locators.
+		{Code: `expect(a > b).resolves.toBe(true);`}, {Code: `expect(a > b).rejects.toBe(false);`},
+		{Code: `expect.poll(() => a > b).toBe(true);`}, {Code: `expect.poll(a > b).toBe(true);`},
+		{Code: `expect.element(a > b).toBe(true);`}, {Code: `expect.element(locator).toBe(true);`},
+		// Proven non-numeric operands cannot use number/bigint matchers.
+		{Code: `expect(null < 1).toBe(true);`}, {Code: `expect(true > 0).toBe(true);`},
+		{Code: `expect([] < 1).toBe(true);`}, {Code: `expect({ valueOf: () => 2 } > 1).toBe(true);`},
+		{Code: `expect(a > /x/).toBe(false);`}, {Code: `expect(a > void 0).toBe(false);`},
+		{Code: `expect(("a" as string) > b).toBe(true);`}, {Code: "expect(a > (`${b}` satisfies string)).toBe(true);"},
+		// Foreign imports and shadowed expect are not Rstest assertions.
+		{Code: `import { expect } from 'vitest'; expect(a > b).toBe(true);`},
+		{Code: `import { expect } from '@jest/globals'; expect(a > b).toBe(true);`},
+		{Code: `import { expect } from 'chai'; expect(a > b).toBe(true);`},
+		{Code: `const expect = makeExpect(); expect(a > b).toBe(true);`},
+		{Code: `function check(expect: any) { expect(a > b).toBe(true); }`},
+	}
+	var invalid []rule_tester.InvalidTestCase
+	for _, test := range []struct{ code, output, matcher string }{
+		// ---- Dimension 4: parentheses, TS, optional chains, static accessor spellings ----
+		{`expect(((a) > (b))).toBe(true);`, "", "toBeGreaterThan"},
+		{`expect((f(), a) > b).toBe(true);`, "", "toBeGreaterThan"},
+		{`expect(a > (f(), b)).toBe(true);`, "", "toBeGreaterThan"},
+		{`expect((2 as number) > (1 as number)).toBe((true as const));`, `expect(2 as number).toBeGreaterThan((1 as number));`, "toBeGreaterThan"},
+		{`expect(2 > 1).toBe(<const>true);`, `expect(2).toBeGreaterThan(1);`, "toBeGreaterThan"},
+		{`expect(2 > 1)?.toBe(false);`, `expect(2)?.not.toBeGreaterThan(1);`, "not.toBeGreaterThan"},
+		{`expect(2 > 1)?.not.toBe(false);`, `expect(2)?.toBeGreaterThan(1);`, "toBeGreaterThan"},
+		{`expect(2 > 1).toBe?.(true);`, `expect(2).toBeGreaterThan?.(1);`, "toBeGreaterThan"},
+		{`expect(2 > 1)[("toBe")](true);`, `expect(2)[("toBeGreaterThan")](1);`, "toBeGreaterThan"},
+		{"expect(2 > 1)[`toBe`](false);", "expect(2).not[`toBeGreaterThan`](1);", "not.toBeGreaterThan"},
+		{`expect(2 > 1).to.be.toEqual(false);`, `expect(2).to.be.not.toBeGreaterThan(1);`, "not.toBeGreaterThan"},
+		// The original boolean remains the subject of later Chai assertions, so do not rewrite a multi-matcher chain.
+		{`expect(a > b).toBe(true).and.toEqual(true);`, "", "toBeGreaterThan"},
+		{`expect(a > b).toBe(true).toString();`, "", "toBeGreaterThan"},
+		// ---- NaN, bigints and negative comparisons ----
+		{`expect(NaN > 1).toBe(false);`, "", "not.toBeGreaterThan"},
+		{`expect(2n <= 1n).not.toStrictEqual(false);`, `expect(2n).toBeLessThanOrEqual(1n);`, "toBeLessThanOrEqual"},
+		{`expect(-2 >= +1).toEqual(true);`, `expect(-2).toBeGreaterThanOrEqual(+1);`, "toBeGreaterThanOrEqual"},
+		// ---- Rstest factories, sources and TestContext ----
+		{`expect.soft(2 > 1, 'limit').toBe(false);`, `expect.soft(2, 'limit').not.toBeGreaterThan(1);`, "not.toBeGreaterThan"},
+		{`import { expect as check } from '@rstest/core'; check(2 > 1).toBe(true);`, `import { expect as check } from '@rstest/core'; check(2).toBeGreaterThan(1);`, "toBeGreaterThan"},
+		{`import * as core from '@rstest/core'; core.expect(2 > 1).toBe(true);`, `import * as core from '@rstest/core'; core.expect(2).toBeGreaterThan(1);`, "toBeGreaterThan"},
+		{`const { expect } = require('@rstest/core'); expect(2 > 1).toBe(true);`, `const { expect } = require('@rstest/core'); expect(2).toBeGreaterThan(1);`, "toBeGreaterThan"},
+		{`import { expect } from '@rstest/playwright'; expect(2 > 1).toBe(true);`, `import { expect } from '@rstest/playwright'; expect(2).toBeGreaterThan(1);`, "toBeGreaterThan"},
+		{`import.meta.rstest.expect(2 > 1).toBe(true);`, `import.meta.rstest.expect(2).toBeGreaterThan(1);`, "toBeGreaterThan"},
+		{`const api = import.meta.rstest; api.expect(2 > 1).toBe(true);`, `const api = import.meta.rstest; api.expect(2).toBeGreaterThan(1);`, "toBeGreaterThan"},
+		{`test('limit', ({ expect: check }) => check(2 > 1).toBe(true));`, `test('limit', ({ expect: check }) => check(2).toBeGreaterThan(1));`, "toBeGreaterThan"},
+		{`test('limit', ctx => ctx.expect(2 > 1).toBe(true));`, `test('limit', ctx => ctx.expect(2).toBeGreaterThan(1));`, "toBeGreaterThan"},
+		// ---- Real-user: empty expect regression (jest-community/eslint-plugin-jest#2000) ----
+		{`expect().toBe(true); expect(a > b).toBe(true);`, "", "toBeGreaterThan"},
+		// ---- Real-user: comments and trailing commas in formatted assertions ----
+		{`expect(2 > 1, 'message').not /* keep */ .toBe(false,);`, `expect(2, 'message') /* keep */ .toBeGreaterThan(1,);`, "toBeGreaterThan"},
+		{`expect(2 /* keep */ > 1).toBe(true);`, "", "toBeGreaterThan"},
+		{`expect(a > b).toBe(true /* keep */ as const);`, "", "toBeGreaterThan"},
+		{`expect(2 > 1).toBe(/* keep */ true,);`, `expect(2).toBeGreaterThan(/* keep */ 1,);`, "toBeGreaterThan"},
+		// Moving operands past expect() changes evaluation order or delays object coercion.
+		{`expect(1 > expect.getState().assertionCalls).toBe(true);`, "", "toBeGreaterThan"},
+		{`expect(a > limits.maximum).toBe(true);`, "", "toBeGreaterThan"},
+		{`expect(a > nextLimit()).toBe(true);`, "", "toBeGreaterThan"},
+		{`expect(a > counter++).toBe(true);`, "", "toBeGreaterThan"},
+		{`expect(a > (ready ? upper : lower)).toBe(true);`, "", "toBeGreaterThan"},
+		{`expect(objectWithValueOf > 1).toBe(true);`, "", "toBeGreaterThan"},
+		// Type arguments describe the original boolean subject or matcher argument.
+		{`expect<boolean>(1 > 0).toBe(true);`, "", "toBeGreaterThan"},
+		{`expect(1 > 0).toBe<boolean>(true);`, "", "toBeGreaterThan"},
+		// N/A: declaration names and private identifiers do not participate in matcher selection.
+	} {
+		expectedError := comparisonError(test.matcher, test.output)
+		invalid = append(invalid, rule_tester.InvalidTestCase{Code: test.code, Errors: []rule_tester.InvalidTestCaseError{expectedError}})
+	}
+	for _, test := range []struct {
+		code, output            string
+		line, column, endColumn int
+	}{
+		{"expect(a > b)\n  .toBe(true);", "", 2, 4, 8},
+		{`expect(a > b, "😀").toBe(true);`, "", 1, 21, 25},
+	} {
+		expectedError := comparisonError("toBeGreaterThan", test.output)
+		expectedError.Line, expectedError.Column, expectedError.EndLine, expectedError.EndColumn = test.line, test.column, test.line, test.endColumn
+		invalid = append(invalid, rule_tester.InvalidTestCase{Code: test.code, Errors: []rule_tester.InvalidTestCaseError{expectedError}})
+	}
+	// Adjacent constant suggestions must only rewrite their own assertion.
+	code := `expect(2 > 1).toBe(true); expect(1 < 2).toBe(false);`
+	invalid = append(invalid, rule_tester.InvalidTestCase{Code: code, Errors: []rule_tester.InvalidTestCaseError{
+		comparisonError("toBeGreaterThan", strings.Replace(code, "expect(2 > 1).toBe(true)", "expect(2).toBeGreaterThan(1)", 1)),
+		comparisonError("not.toBeLessThan", strings.Replace(code, "expect(1 < 2).toBe(false)", "expect(1).not.toBeLessThan(2)", 1)),
+	}})
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &PreferComparisonMatcherRule, valid, invalid)
+}

--- a/internal/plugins/rstest/rules/prefer_comparison_matcher/prefer_comparison_matcher_upstream_test.go
+++ b/internal/plugins/rstest/rules/prefer_comparison_matcher/prefer_comparison_matcher_upstream_test.go
@@ -1,0 +1,98 @@
+// Mirrors Jest v29.16.1 and Vitest v1.6.27; Rstest-only cases live in prefer_comparison_matcher_extras_test.go.
+package prefer_comparison_matcher
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func comparisonError(matcher, output string) rule_tester.InvalidTestCaseError {
+	expectedError := rule_tester.InvalidTestCaseError{
+		MessageId: "useToBeComparison",
+		Message:   "Prefer using `" + matcher + "` instead",
+	}
+	if output != "" {
+		expectedError.Suggestions = []rule_tester.InvalidTestCaseSuggestion{{
+			MessageId: "suggestComparisonMatcher", Output: output,
+		}}
+	}
+	return expectedError
+}
+
+func TestPreferComparisonMatcherUpstream(t *testing.T) {
+	valid := []rule_tester.ValidTestCase{
+		{Code: `expect.hasAssertions`}, {Code: `expect.hasAssertions()`}, {Code: `expect.assertions(1)`},
+		{Code: `expect(true).toBe(...true)`}, {Code: `expect()`}, {Code: `expect().toStrictEqual({})`},
+		{Code: `expect({}).toStrictEqual({})`}, {Code: `expect(a === b).toBe(true)`},
+		{Code: `expect(a !== 2).toStrictEqual(true)`}, {Code: `expect(a === b).not.toEqual(true)`},
+		{Code: `expect(a !== "string").toStrictEqual(true)`}, {Code: `expect(5 != a).toBe(true)`},
+		{Code: `expect(a == "string").toBe(true)`}, {Code: `expect(a == "string").not.toBe(true)`},
+		{Code: `expect(a).to.be.a("string");`}, {Code: `expect().fail('Should not succeed a HTTPS proxy request.');`},
+	}
+	var invalid []rule_tester.InvalidTestCase
+	for _, op := range []struct{ operator, matcher, inverse string }{
+		{">", "toBeGreaterThan", "toBeLessThanOrEqual"}, {"<", "toBeLessThan", "toBeGreaterThanOrEqual"},
+		{">=", "toBeGreaterThanOrEqual", "toBeLessThan"}, {"<=", "toBeLessThanOrEqual", "toBeGreaterThan"},
+	} {
+		for _, matcher := range []string{op.matcher, op.inverse} {
+			valid = append(valid, rule_tester.ValidTestCase{Code: "expect(value)." + matcher + "(1);"}, rule_tester.ValidTestCase{Code: "expect(value).not." + matcher + "(1);"})
+		}
+		for _, equality := range []string{"toBe", "toEqual", "toStrictEqual"} {
+			for _, literal := range []string{"'y'", "`y`", "`y${z}`"} {
+				for _, pair := range [][2]string{{"x", literal}, {literal, "x"}} {
+					for _, modifier := range []string{"", "not.", "resolves.", "resolves.not."} {
+						for _, boolean := range []string{"true", "false"} {
+							valid = append(valid, rule_tester.ValidTestCase{Code: fmt.Sprintf("expect(%s %s %s).%s%s(%s)", pair[0], op.operator, pair[1], modifier, equality, boolean)})
+						}
+					}
+				}
+			}
+			for _, shape := range []struct {
+				subjectSuffix, accessor, argument string
+				negated                           bool
+				column                            int
+			}{
+				{"", ".%s", "true", false, 18}, {",", ".%s", "true,", false, 19}, {"", "['%s']", "true", false, 18},
+				{"", ".resolves.%s", "true", false, 27},
+				{"", ".%s", "false", true, 18}, {"", "['%s']", "false", true, 18}, {"", ".resolves.%s", "false", true, 27},
+				{"", ".not.%s", "true", true, 22}, {"", "['not'].%s", "true", true, 25}, {"", ".resolves.not.%s", "true", true, 31},
+				{"", ".not.%s", "false", false, 22}, {"", ".resolves.not.%s", "false", false, 31},
+				{"", `["resolves"].not.%s`, "false", false, 34}, {"", `["resolves"]["not"].%s`, "false", false, 37},
+				{"", `["resolves"]["not"]['%s']`, "false", false, 37},
+			} {
+				code := fmt.Sprintf("expect(value %s 1%s)%s(%s);", op.operator, shape.subjectSuffix, fmt.Sprintf(shape.accessor, equality), shape.argument)
+				// Relational subjects are booleans, so upstream promise-modifier cases are invalid Rstest assertions.
+				if strings.Contains(shape.accessor, "resolves") {
+					valid = append(valid, rule_tester.ValidTestCase{Code: code})
+					continue
+				}
+				preferred := op.matcher
+				if shape.negated {
+					preferred = "not." + preferred
+				}
+				// Rstest keeps upstream's diagnostic but withholds the edit because
+				// moving a non-constant operand after expect() can change evaluation.
+				expectedError := comparisonError(preferred, "")
+				expectedError.Line, expectedError.Column = 1, shape.column+len(op.operator)
+				invalid = append(invalid, rule_tester.InvalidTestCase{Code: code, Errors: []rule_tester.InvalidTestCaseError{expectedError}})
+			}
+		}
+		// All seven Vitest invalid cases: four positive comparisons and three negated comparisons.
+		for _, negated := range []bool{false, true} {
+			if negated && op.operator == "<=" {
+				continue
+			}
+			modifier := ""
+			if negated {
+				modifier = "not."
+			}
+			code := fmt.Sprintf("expect(a %s b).%stoBe(true)", op.operator, modifier)
+			invalid = append(invalid, rule_tester.InvalidTestCase{Code: code, Errors: []rule_tester.InvalidTestCaseError{comparisonError(modifier+op.matcher, "")}})
+		}
+	}
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &PreferComparisonMatcherRule, valid, invalid)
+}

--- a/internal/utils/test_framework/rules/prefer_comparison_matcher/prefer_comparison_matcher.go
+++ b/internal/utils/test_framework/rules/prefer_comparison_matcher/prefer_comparison_matcher.go
@@ -1,0 +1,142 @@
+package prefer_comparison_matcher
+
+import (
+	"slices"
+
+	"github.com/microsoft/TypeScript/tsc/shim/ast"
+	"github.com/microsoft/TypeScript/tsc/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+	testFramework "github.com/web-infra-dev/rslint/internal/utils/test_framework"
+)
+
+type ExpectCall struct {
+	HeadCall     *ast.Node
+	MatcherCall  *ast.Node
+	MatcherEntry testFramework.MemberEntry
+	Matcher      string
+	Modifiers    []testFramework.MemberEntry
+	Editable     bool
+}
+
+type Match struct {
+	Expect          *ExpectCall
+	Comparison      *ast.Node
+	Left            *ast.Node
+	Right           *ast.Node
+	MatcherArgument *ast.Node
+	Matcher         string
+	Negated         bool
+}
+
+type Config struct {
+	Name             string
+	Prepare          func(rule.RuleContext) func(*ast.Node) *ExpectCall
+	PreserveNegation bool
+	Suggestions      bool
+	IgnoreOperand    func(*ast.Node) bool
+	BuildFixes       func(rule.RuleContext, Match) []rule.RuleFix
+}
+
+func comparisonMatchers(operator ast.Kind) (string, string) {
+	switch operator {
+	case ast.KindGreaterThanToken:
+		return "toBeGreaterThan", "toBeLessThanOrEqual"
+	case ast.KindLessThanToken:
+		return "toBeLessThan", "toBeGreaterThanOrEqual"
+	case ast.KindGreaterThanEqualsToken:
+		return "toBeGreaterThanOrEqual", "toBeLessThan"
+	case ast.KindLessThanEqualsToken:
+		return "toBeLessThanOrEqual", "toBeGreaterThan"
+	default:
+		return "", ""
+	}
+}
+
+func NewRule(config Config) rule.Rule {
+	return rule.Rule{
+		Name:   config.Name,
+		Schema: rule.EmptyArraySchema,
+		Run: func(ctx rule.RuleContext, _ []any) rule.RuleListeners {
+			parse := config.Prepare(ctx)
+			return rule.RuleListeners{
+				ast.KindCallExpression: func(node *ast.Node) {
+					expect := parse(node)
+					if expect == nil || !slices.Contains([]string{"toBe", "toEqual", "toStrictEqual"}, expect.Matcher) {
+						return
+					}
+					expectArgs, matcherArgs := expect.HeadCall.Arguments(), expect.MatcherCall.Arguments()
+					if len(expectArgs) == 0 || len(matcherArgs) == 0 {
+						return
+					}
+					comparison := ast.SkipParentheses(expectArgs[0])
+					if comparison.Kind != ast.KindBinaryExpression {
+						return
+					}
+					binary := comparison.AsBinaryExpression()
+					matcher, inverse := comparisonMatchers(binary.OperatorToken.Kind)
+					if matcher == "" {
+						return
+					}
+					for _, operand := range []*ast.Node{binary.Left, binary.Right} {
+						inner := ast.SkipOuterExpressions(operand, ast.OEKParentheses|ast.OEKTypeAssertions)
+						if utils.IsStringLiteralOrTemplate(inner) || (config.IgnoreOperand != nil && config.IgnoreOperand(operand)) {
+							return
+						}
+					}
+					boolean := ast.SkipOuterExpressions(matcherArgs[0], ast.OEKParentheses|ast.OEKTypeAssertions)
+					if boolean.Kind != ast.KindTrueKeyword && boolean.Kind != ast.KindFalseKeyword {
+						return
+					}
+					hasNot := slices.ContainsFunc(expect.Modifiers, func(entry testFramework.MemberEntry) bool { return entry.Name == "not" })
+					negated := (boolean.Kind == ast.KindTrueKeyword) == hasNot
+					if negated && !config.PreserveNegation {
+						matcher, negated = inverse, false
+					}
+					preferred := matcher
+					if negated {
+						preferred = "not." + matcher
+					}
+					match := Match{expect, comparison, binary.Left, binary.Right, ast.SkipParentheses(matcherArgs[0]), matcher, negated}
+					message := rule.RuleMessage{
+						Id:          "useToBeComparison",
+						Description: "Prefer using `" + preferred + "` instead",
+						Data:        map[string]string{"preferredMatcher": preferred},
+					}
+					if config.Suggestions {
+						ctx.ReportNodeWithDeferredSuggestions(expect.MatcherEntry.Node, message, func() []rule.RuleSuggestion {
+							fixes := config.BuildFixes(ctx, match)
+							if len(fixes) == 0 {
+								return nil
+							}
+							return []rule.RuleSuggestion{{
+								Message:  rule.RuleMessage{Id: "suggestComparisonMatcher", Description: "Use `" + preferred + "`"},
+								FixesArr: fixes,
+							}}
+						})
+					} else {
+						ctx.ReportNodeWithDeferredFixes(expect.MatcherEntry.Node, message, func() []rule.RuleFix {
+							return config.BuildFixes(ctx, match)
+						})
+					}
+				},
+			}
+		},
+	}
+}
+
+func OperandFixes(ctx rule.RuleContext, match Match) []rule.RuleFix {
+	return []rule.RuleFix{
+		rule.RuleFixReplace(ctx.SourceFile, match.Comparison, operandText(ctx.SourceFile, match.Left)),
+		rule.RuleFixReplace(ctx.SourceFile, match.MatcherArgument, operandText(ctx.SourceFile, match.Right)),
+	}
+}
+
+func operandText(source *ast.SourceFile, node *ast.Node) string {
+	inner := ast.SkipParentheses(node)
+	// Comma-expression parentheses prevent an operand from becoming several call arguments.
+	if inner.Kind == ast.KindBinaryExpression && inner.AsBinaryExpression().OperatorToken.Kind == ast.KindCommaToken {
+		return scanner.GetSourceTextOfNodeFromSourceFile(source, node, false)
+	}
+	return scanner.GetSourceTextOfNodeFromSourceFile(source, inner, false)
+}

--- a/internal/utils/test_framework/rules/prefer_comparison_matcher/prefer_comparison_matcher_test.go
+++ b/internal/utils/test_framework/rules/prefer_comparison_matcher/prefer_comparison_matcher_test.go
@@ -1,0 +1,106 @@
+package prefer_comparison_matcher_test
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/microsoft/TypeScript/tsc/shim/ast"
+	"github.com/microsoft/TypeScript/tsc/shim/core"
+	"github.com/microsoft/TypeScript/tsc/shim/tspath"
+	"github.com/web-infra-dev/rslint/internal/linter"
+	jestRule "github.com/web-infra-dev/rslint/internal/plugins/jest/rules/prefer_comparison_matcher"
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/fixtures"
+	rstestRule "github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/prefer_comparison_matcher"
+	lintprogram "github.com/web-infra-dev/rslint/internal/program"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+func TestPreferComparisonMatcherSourceOnlyReferences(t *testing.T) {
+	for _, target := range []*rule.Rule{&jestRule.PreferComparisonMatcherRule, &rstestRule.PreferComparisonMatcherRule} {
+		module := "@jest/globals"
+		if strings.HasPrefix(target.Name, "rstest/") {
+			module = "@rstest/core"
+		}
+		for _, test := range []struct {
+			code  string
+			count int
+		}{
+			{`import { expect as check } from '` + module + `'; check(a > b).toBe(true);`, 1},
+			{`const { expect: check } = require('` + module + `'); check(a > b).toBe(true);`, 1},
+			{`function f(expect: any) { expect(a > b).toBe(true); }`, 0},
+			{`const expect = custom(); expect(a > b).toBe(true);`, 0},
+			{`import { expect } from 'other'; expect(a > b).toBe(true);`, 0},
+		} {
+			root := fixtures.GetRootDir()
+			fileName := tspath.ResolvePath(root.Dir, "references.ts")
+			fs := utils.NewOverlayVFS(root.FS, map[string]string{fileName: test.code})
+			program, err := lintprogram.NewFromRoots(lintprogram.RootOptions{
+				RootFileNames: []string{fileName}, Host: utils.CreateCompilerHost(root.Dir, fs),
+				CompilerOptions: &core.CompilerOptions{Module: core.ModuleKindESNext}, SingleThreaded: true,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			count := 0
+			linter.LintSingleFile(linter.LintSingleFileOptions{
+				Program: program, File: fileName,
+				GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+					return []rule.ConfiguredRule{{Name: target.Name, Severity: rule.SeverityError, Run: func(ctx rule.RuleContext) rule.RuleListeners {
+						if ctx.TypeChecker != nil {
+							t.Fatal("expected no type checker")
+						}
+						return target.Run(ctx, nil)
+					}}}
+				},
+				Consumer: rule.DiagnosticConsumer{Report: func(rule.RuleDiagnostic) { count++ }},
+			})
+			if count != test.count {
+				t.Errorf("%s: %s: got %d diagnostics, want %d", target.Name, test.code, count, test.count)
+			}
+		}
+	}
+}
+
+func TestPreferComparisonMatcherEditDemand(t *testing.T) {
+	helper := rule_tester.NewProgramHelper(fixtures.GetRootDir())
+	program, source, err := helper.CreateTestProgram(`expect(2 > 1).toBe(false);`, "demand.ts", "tsconfig.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, target := range []*rule.Rule{&jestRule.PreferComparisonMatcherRule, &rstestRule.PreferComparisonMatcherRule} {
+		t.Run(target.Name, func(t *testing.T) {
+			var baseline rule.RuleDiagnostic
+			for _, demand := range []rule.EditDemand{rule.EditDemandNone, rule.EditDemandAutofix, rule.EditDemandSuggestion, rule.EditDemandAll} {
+				var diagnostics []rule.RuleDiagnostic
+				linter.LintSingleFile(linter.LintSingleFileOptions{
+					Program: lintprogram.NewFromCompiler(program), File: source.FileName(),
+					GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+						return []rule.ConfiguredRule{{Name: target.Name, Severity: rule.SeverityError, Run: func(ctx rule.RuleContext) rule.RuleListeners { return target.Run(ctx, nil) }}}
+					},
+					Consumer: rule.DiagnosticConsumer{Demand: demand, Report: func(d rule.RuleDiagnostic) { diagnostics = append(diagnostics, d) }},
+				})
+				if len(diagnostics) != 1 {
+					t.Fatalf("demand %d: %d diagnostics", demand, len(diagnostics))
+				}
+				diagnostic := diagnostics[0]
+				wantsFix := target == &jestRule.PreferComparisonMatcherRule && (demand == rule.EditDemandAutofix || demand == rule.EditDemandAll)
+				wantsSuggestion := target == &rstestRule.PreferComparisonMatcherRule && (demand == rule.EditDemandSuggestion || demand == rule.EditDemandAll)
+				if (diagnostic.FixesPtr != nil) != wantsFix || (diagnostic.Suggestions != nil) != wantsSuggestion {
+					t.Fatalf("demand %d: unexpected edit materialization: %#v", demand, diagnostic)
+				}
+				if wantsSuggestion && len(*diagnostic.Suggestions) != 1 {
+					t.Fatal("expected one suggestion")
+				}
+				diagnostic.FixesPtr, diagnostic.Suggestions = nil, nil
+				if demand == rule.EditDemandNone {
+					baseline = diagnostic
+				} else if !reflect.DeepEqual(baseline, diagnostic) {
+					t.Fatalf("demand %d changed diagnostic", demand)
+				}
+			}
+		})
+	}
+}

--- a/packages/rslint-test-tools/rstack.config.mts
+++ b/packages/rslint-test-tools/rstack.config.mts
@@ -673,6 +673,7 @@ define.test({
     './tests/rstest/rules/prefer-called-times.test.ts',
     './tests/rstest/rules/prefer-called-with.test.ts',
     './tests/rstest/rules/prefer-each.test.ts',
+    './tests/rstest/rules/prefer-comparison-matcher.test.ts',
     './tests/rstest/rules/prefer-equality-matcher.test.ts',
     './tests/rstest/rules/prefer-expect-type-of.test.ts',
     './tests/rstest/rules/prefer-hooks-in-order.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-jest/rules/prefer-comparison-matcher.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-jest/rules/prefer-comparison-matcher.test.ts
@@ -266,33 +266,7 @@ ruleTester.run(`prefer-comparison-matcher`, {} as never, {
     { code: 'expect(5 != a).toBe(true)' },
     { code: 'expect(a == "string").toBe(true)' },
     { code: 'expect(a == "string").not.toBe(true)' },
-    { code: 'expect(value > 1)[matcher].toBe(true);' },
-    { code: 'expect(value > 1)[foo()].toBe(true);' },
+    { code: 'expect().toStrictEqual({})' },
   ],
-  invalid: [
-    {
-      code: 'expect(value > 1).toBe(true).toString();',
-      output: 'expect(value).toBeGreaterThan(1).toString();',
-      errors: [
-        {
-          messageId: 'useToBeComparison',
-          data: { preferredMatcher: 'toBeGreaterThan' },
-          column: 19,
-          line: 1,
-        },
-      ],
-    },
-    {
-      code: 'expect(value > 1).toBe(true).foo(false);',
-      output: 'expect(value).toBeGreaterThan(1).foo(false);',
-      errors: [
-        {
-          messageId: 'useToBeComparison',
-          data: { preferredMatcher: 'toBeGreaterThan' },
-          column: 19,
-          line: 1,
-        },
-      ],
-    },
-  ],
+  invalid: [],
 });

--- a/packages/rslint-test-tools/tests/rstest/rules/prefer-comparison-matcher.test.ts
+++ b/packages/rslint-test-tools/tests/rstest/rules/prefer-comparison-matcher.test.ts
@@ -1,0 +1,60 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('prefer-comparison-matcher', {} as never, {
+  valid: [
+    'expect.hasAssertions',
+    'expect.hasAssertions()',
+    'expect.assertions(1)',
+    'expect(true).toBe(...true)',
+    'expect()',
+    'expect({}).toStrictEqual({})',
+    'expect(a).to.be.a("string");',
+    'expect(a === b).toBe(true)',
+    'expect(a !== 2).toStrictEqual(true)',
+    'expect(a === b).not.toEqual(true)',
+    'expect(a !== "string").toStrictEqual(true)',
+    'expect(5 != a).toBe(true)',
+    'expect(a == "string").toBe(true)',
+    'expect(a == "string").not.toBe(true)',
+    "expect().fail('Should not succeed a HTTPS proxy request.');",
+  ].map((code) => ({ code })),
+  invalid: [
+    ...[
+      ['>', 'toBeGreaterThan'],
+      ['<', 'toBeLessThan'],
+      ['>=', 'toBeGreaterThanOrEqual'],
+      ['<=', 'toBeLessThanOrEqual'],
+    ].flatMap(([operator, matcher]) =>
+      [false, true]
+        .filter((negated) => !negated || operator !== '<=')
+        .map((negated) => {
+          const modifier = negated ? 'not.' : '';
+          return {
+            code: `expect(a ${operator} b).${modifier}toBe(true)`,
+            errors: [
+              {
+                messageId: 'useToBeComparison',
+                message: `Prefer using \`${modifier}${matcher}\` instead`,
+              },
+            ],
+          };
+        }),
+    ),
+    {
+      code: 'expect(2 > 1).toBe(true)',
+      errors: [
+        {
+          messageId: 'useToBeComparison',
+          suggestions: [
+            {
+              messageId: 'suggestComparisonMatcher',
+              output: 'expect(2).toBeGreaterThan(1)',
+            },
+          ],
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
## Motivation

Boolean assertions around relational expressions are harder to read and produce less useful failures than Rstest's numeric comparison matchers.

Rstest also differs from the reference implementations in several important areas, including negated comparisons involving `NaN`, numeric matcher coercion, assertion factories, TestContext and import provenance, and the safety of moving operands across the `expect()` call.

## Changes

Add `rstest/prefer-comparison-matcher` with Rstest-specific handling for globals, imports, aliases, namespaces, CommonJS, `rstack/test`, `import.meta.rstest`, Playwright, TestContext, and `expect.soft`.

Share the framework-independent comparison analysis with the existing Jest rule while preserving its behavior.

Keep negated Rstest comparisons expressed with `.not` so `NaN` semantics are preserved. Report potentially coercive comparisons, but only offer a suggestion when both operands are static number or bigint constants, no explicit type arguments are present, and the edit can preserve comments and chain semantics.

Add complete upstream coverage, Rstest-specific edge cases, source-only resolution tests, JS integration coverage, runtime equivalence checks, and user documentation.

## Differences from upstream

- Negated comparisons retain the original comparison matcher and use `.not`, preserving behavior when an operand is `NaN`.
- `expect.poll`, `expect.element`, and assertions with `resolves` or `rejects` are not reported because a relational expression produces a boolean rather than the callback, locator, or promise those APIs require.
- Comparisons with operands that are statically known to be incompatible with numeric matchers are not reported.
- Reports use suggestions instead of autofixes because JavaScript relational operators permit coercion while Rstest's comparison matchers accept only numbers and bigints.
- Suggestions are only provided when both operands are static number or bigint constants. Other operands are reported without a suggestion because moving them across the `expect()` call can change evaluation or coercion order.
- Assertions with explicit type arguments are reported without a suggestion because those arguments describe the original boolean subject or matcher argument.
- Rstest-specific assertion sources such as `rstack/test`, `import.meta.rstest`, Playwright, and TestContext are recognized.

## Related Links

- Related to #935
- [eslint-plugin-jest rule](https://github.com/jest-community/eslint-plugin-jest/blob/v29.16.1/docs/rules/prefer-comparison-matcher.md)
- [@vitest/eslint-plugin rule](https://github.com/vitest-dev/eslint-plugin-vitest/blob/v1.6.27/docs/rules/prefer-comparison-matcher.md)
