### PR TITLE
perf(rstest): defer edits in five `rstest/` rules

### DIFF
--- a/internal/plugins/rstest/deferred_edits_test.go
+++ b/internal/plugins/rstest/deferred_edits_test.go
@@ -1,0 +1,292 @@
+package rstest_test
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/microsoft/TypeScript/tsc/shim/ast"
+	"github.com/microsoft/TypeScript/tsc/shim/core"
+	"github.com/microsoft/TypeScript/tsc/shim/parser"
+	"github.com/microsoft/TypeScript/tsc/shim/tspath"
+	"github.com/web-infra-dev/rslint/internal/linter"
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/no_focused_tests"
+	noImportNode "github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/no_import_node_test"
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/prefer_called_exactly_once_with"
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/prefer_equality_matcher"
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/prefer_importing_rstest_globals"
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/valid_expect"
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/valid_title"
+	lintprogram "github.com/web-infra-dev/rslint/internal/program"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+type deferredEditCase struct {
+	name        string
+	rule        rule.Rule
+	code        string
+	options     []any
+	messages    []string
+	output      string
+	suggestions map[int][]string
+}
+
+func deferredEditCases() []deferredEditCase {
+	return []deferredEditCase{
+		{
+			name:        "focused alias deduplication after suppression",
+			rule:        no_focused_tests.NoFocusedTestsRule,
+			code:        "const focused = test.only;\n// rslint-disable-next-line rstest/no-focused-tests\nfocused('hidden', fn);\nfocused('first', fn);\nfocused('second', fn);",
+			messages:    []string{"focusedTest", "focusedTest"},
+			suggestions: map[int][]string{0: {"const focused = test;\n// rslint-disable-next-line rstest/no-focused-tests\nfocused('hidden', fn);\nfocused('first', fn);\nfocused('second', fn);"}},
+		},
+		{
+			name:        "focused optional computed accessor with comments",
+			rule:        no_focused_tests.NoFocusedTestsRule,
+			code:        `test?.[/* keep */ "only"]('case', fn);`,
+			messages:    []string{"focusedTest"},
+			suggestions: map[int][]string{0: {`test?./* keep */ ('case', fn);`}},
+		},
+		{
+			name:     "async insertion after suppressed descriptor",
+			rule:     valid_expect.ValidExpectRule,
+			code:     "test('case', () => {\n// rslint-disable-next-line rstest/valid-expect\nexpect(p).resolves.toBe(0);\nexpect(p).resolves.toBe(1);\nexpect(q).rejects.toThrow();\n});",
+			messages: []string{"asyncMustBeAwaited", "asyncMustBeAwaited"},
+			output:   "test('case', async () => {\n// rslint-disable-next-line rstest/valid-expect\nexpect(p).resolves.toBe(0);\nawait expect(p).resolves.toBe(1);\nawait expect(q).rejects.toThrow();\n});",
+		},
+		{
+			name:     "async return and nested functions",
+			rule:     valid_expect.ValidExpectRule,
+			code:     `test('case', () => { function inner() { return (expect(p).resolves.toBe(1)); } return expect(q).rejects.toThrow(); });`,
+			options:  []any{map[string]any{"alwaysAwait": true}},
+			messages: []string{"asyncMustBeAwaited", "asyncMustBeAwaited"},
+			output:   `test('case', async () => { async function inner() { await (expect(p).resolves.toBe(1)); } await expect(q).rejects.toThrow(); });`,
+		},
+		{
+			name:     "top level async assertion remains report only",
+			rule:     valid_expect.ValidExpectRule,
+			code:     `expect(p).resolves.toBe(1);`,
+			messages: []string{"asyncMustBeAwaited"},
+		},
+		{
+			name:     "late rstack import selects replacement for every import",
+			rule:     noImportNode.NoImportNodeTestRule,
+			code:     "import { test as a } from 'node:test';\nimport { it as b } from \"node:test\";\nimport { expect } from 'rstack/test';",
+			messages: []string{"noImportNodeTest", "noImportNodeTest"},
+			output:   "import { test as a } from 'rstack/test';\nimport { it as b } from \"rstack/test\";\nimport { expect } from 'rstack/test';",
+		},
+		{
+			name:     "core reference wins and unsafe imports remain report only",
+			rule:     noImportNode.NoImportNodeTestRule,
+			code:     "import { test } from 'node:test';\nimport { mock } from 'node:test';\nimport reporters from 'node:test/reporters';\nimport { expect } from 'rstack/test';\nconst api = require('@rstest/core');",
+			messages: []string{"noImportNodeTest", "noImportNodeTest", "noImportNodeTest"},
+			output:   "import { test } from '@rstest/core';\nimport { mock } from 'node:test';\nimport reporters from 'node:test/reporters';\nimport { expect } from 'rstack/test';\nconst api = require('@rstest/core');",
+		},
+		{
+			name:     "title overlapping fixes converge",
+			rule:     valid_title.ValidTitleRule,
+			code:     `test('test title ', fn);`,
+			messages: []string{"accidentalSpace", "duplicatePrefix"},
+			output:   `test('title', fn);`,
+		},
+		{
+			name:     "escaped title space remains report only",
+			rule:     valid_title.ValidTitleRule,
+			code:     `test('\u0020title', fn);`,
+			messages: []string{"accidentalSpace"},
+		},
+		{
+			name:     "matcher merge preserves computed access type arguments and comments",
+			rule:     prefer_called_exactly_once_with.PreferCalledExactlyOnceWithRule,
+			code:     "expect(spy).toHaveBeenCalledOnce();\nexpect(spy)[/* keep */ 'toHaveBeenCalledWith']<string>('value');",
+			messages: []string{"preferCalledExactlyOnceWith"},
+			output:   `expect(spy)[/* keep */ 'toHaveBeenCalledExactlyOnceWith']<string>('value');`,
+		},
+		{
+			name:     "unstable second expect argument forbids merge fix",
+			rule:     prefer_called_exactly_once_with.PreferCalledExactlyOnceWithRule,
+			code:     "expect(spy, message()).toHaveBeenCalledOnce();\nexpect(spy, message()).toHaveBeenCalledWith('value');",
+			messages: []string{"preferCalledExactlyOnceWith"},
+		},
+		{
+			name:     "equality suggestion truth table and comma operands",
+			rule:     prefer_equality_matcher.PreferEqualityMatcherRule,
+			code:     `expect((a(), b) !== c).not.toBe(false);`,
+			messages: []string{"useEqualityMatcher"},
+			suggestions: map[int][]string{0: {
+				`expect((a(), b)).not.toBe(c);`,
+				`expect((a(), b)).not.toEqual(c);`,
+				`expect((a(), b)).not.toStrictEqual(c);`,
+			}},
+		},
+		{
+			name:     "global import diagnostic order differs from sorted fix",
+			rule:     prefer_importing_rstest_globals.PreferImportingRstestGlobalsRule,
+			code:     `test('case', () => { expect(rs.fn()).toBeDefined(); });`,
+			messages: []string{"preferImportingRstestGlobals"},
+			output:   "import { expect, rs, test } from '@rstest/core';\ntest('case', () => { expect(rs.fn()).toBeDefined(); });",
+		},
+		{
+			name:     "global write forbids import fix",
+			rule:     prefer_importing_rstest_globals.PreferImportingRstestGlobalsRule,
+			code:     `expect(1).toBe(1); expect = other;`,
+			messages: []string{"preferImportingRstestGlobals"},
+		},
+	}
+}
+
+func deferredEditProgram(t *testing.T, code string, typed bool) (*lintprogram.Program, *ast.SourceFile) {
+	t.Helper()
+	root := fixtures.GetRootDir()
+	if typed {
+		program, sourceFile, err := rule_tester.NewProgramHelper(root).CreateTestProgram(code, "deferred-edits.ts", "tsconfig.json")
+		if err != nil {
+			t.Fatal(err)
+		}
+		return lintprogram.NewFromCompiler(program), sourceFile
+	}
+	fileName := tspath.ResolvePath(root.Dir, "deferred-edits.ts")
+	fs := utils.NewOverlayVFS(root.FS, map[string]string{fileName: code})
+	program, err := lintprogram.NewFromRoots(lintprogram.RootOptions{
+		RootFileNames: []string{fileName}, Host: utils.CreateCompilerHost(root.Dir, fs),
+		CompilerOptions: &core.CompilerOptions{Module: core.ModuleKindESNext}, SingleThreaded: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sourceFile := program.GetSourceFile(fileName)
+	if sourceFile == nil || program.CanProvideTypeChecker(sourceFile) {
+		t.Fatal("expected source-only program")
+	}
+	return program, sourceFile
+}
+
+func lintDeferredEdits(t *testing.T, test deferredEditCase, program *lintprogram.Program, sourceFile *ast.SourceFile, typed bool, demand rule.EditDemand) []rule.RuleDiagnostic {
+	t.Helper()
+	var diagnostics []rule.RuleDiagnostic
+	options := rule_tester.ResolveTestCaseOptions(t, &test.rule, test.options)
+	linter.LintSingleFile(linter.LintSingleFileOptions{
+		Program: program, File: sourceFile.FileName(), HasTypeInfo: typed,
+		GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+			return []rule.ConfiguredRule{{Name: test.rule.Name, Severity: rule.SeverityWarning,
+				Run: func(ctx rule.RuleContext) rule.RuleListeners { return test.rule.Run(ctx, options) },
+			}}
+		},
+		Consumer: rule.DiagnosticConsumer{Demand: demand, Report: func(d rule.RuleDiagnostic) { diagnostics = append(diagnostics, d) }},
+	})
+	return diagnostics
+}
+
+func TestRstestDeferredEditDemand(t *testing.T) {
+	for _, test := range deferredEditCases() {
+		for _, typed := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/typed=%t", test.name, typed), func(t *testing.T) {
+				program, sourceFile := deferredEditProgram(t, test.code, typed)
+				all := lintDeferredEdits(t, test, program, sourceFile, typed, rule.EditDemandAll)
+				if len(all) != len(test.messages) {
+					t.Fatalf("diagnostics = %d, want %d: %#v", len(all), len(test.messages), all)
+				}
+				for index, diagnostic := range all {
+					if diagnostic.Message.Id != test.messages[index] {
+						t.Fatalf("diagnostic %d = %s, want %s", index, diagnostic.Message.Id, test.messages[index])
+					}
+					want := test.suggestions[index]
+					var suggestions []rule.RuleSuggestion
+					if diagnostic.Suggestions != nil {
+						suggestions = *diagnostic.Suggestions
+					}
+					if len(suggestions) != len(want) {
+						t.Fatalf("diagnostic %d suggestions = %d, want %d", index, len(suggestions), len(want))
+					}
+					for i, suggestion := range suggestions {
+						output, _, applied := linter.ApplyRuleFixes(test.code, []rule.RuleSuggestion{suggestion})
+						if !applied || output != want[i] {
+							t.Fatalf("suggestion %d output:\n%s\nwant:\n%s", i, output, want[i])
+						}
+						assertDeferredOutputParses(t, output)
+					}
+				}
+				for _, demand := range []rule.EditDemand{rule.EditDemandNone, rule.EditDemandAutofix, rule.EditDemandSuggestion} {
+					got := lintDeferredEdits(t, test, program, sourceFile, typed, demand)
+					if len(got) != len(all) {
+						t.Fatalf("demand %d changed diagnostic count", demand)
+					}
+					for index, expected := range all {
+						if demand&rule.EditDemandAutofix == 0 {
+							expected.FixesPtr = nil
+						}
+						if demand&rule.EditDemandSuggestion == 0 {
+							expected.Suggestions = nil
+						}
+						if !reflect.DeepEqual(got[index], expected) {
+							t.Fatalf("demand %d changed diagnostic %d:\ngot %#v\nwant %#v", demand, index, got[index], expected)
+						}
+					}
+				}
+				code := test.code
+				for pass := range 5 {
+					diagnostics := all
+					if pass > 0 {
+						program, sourceFile = deferredEditProgram(t, code, typed)
+						diagnostics = lintDeferredEdits(t, test, program, sourceFile, typed, rule.EditDemandAutofix)
+					}
+					output, _, applied := linter.ApplyRuleFixes(code, diagnostics)
+					if !applied {
+						break
+					}
+					if pass == 4 {
+						t.Fatal("autofix did not converge")
+					}
+					assertDeferredOutputParses(t, output)
+					code = output
+				}
+				want := test.output
+				if want == "" {
+					want = test.code
+				}
+				if code != want {
+					t.Fatalf("autofix output:\n%s\nwant:\n%s", code, want)
+				}
+				program, sourceFile = deferredEditProgram(t, "/* rslint-disable "+test.rule.Name+" */\n"+test.code, typed)
+				if got := lintDeferredEdits(t, test, program, sourceFile, typed, rule.EditDemandAll); len(got) != 0 {
+					t.Fatalf("suppressed diagnostics = %d", len(got))
+				}
+			})
+		}
+	}
+}
+
+func assertDeferredOutputParses(t *testing.T, code string) {
+	t.Helper()
+	sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{FileName: "/fixed.ts", Path: "/fixed.ts"}, code, core.ScriptKindTS)
+	if len(sourceFile.Diagnostics()) != 0 {
+		t.Fatalf("fix produced parse diagnostics: %s", code)
+	}
+}
+
+func BenchmarkRstestDeferredNodeImports(b *testing.B) {
+	for _, count := range []int{500, 1000, 2000} {
+		var source strings.Builder
+		for i := range count {
+			fmt.Fprintf(&source, "import { test as test%d } from 'node:test';\n", i)
+		}
+		source.WriteString("import { expect } from 'rstack/test';\n")
+		sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{FileName: "/bench.ts", Path: "/bench.ts"}, source.String(), core.ScriptKindTS)
+		for _, demand := range []rule.EditDemand{rule.EditDemandNone, rule.EditDemandAutofix} {
+			b.Run(fmt.Sprintf("imports=%d/demand=%d", count, demand), func(b *testing.B) {
+				b.ReportAllocs()
+				for b.Loop() {
+					ctx := rule.RuleContext{SourceFile: sourceFile}.WithDiagnosticConsumer(noImportNode.NoImportNodeTestRule.Name, rule.SeverityError, rule.DiagnosticConsumer{Demand: demand, Report: func(rule.RuleDiagnostic) {}})
+					listener := noImportNode.NoImportNodeTestRule.Run(ctx, nil)[ast.KindImportDeclaration]
+					for _, statement := range sourceFile.Statements.Nodes {
+						listener(statement)
+					}
+				}
+			})
+		}
+	}
+}

--- a/internal/plugins/rstest/rules/no_focused_tests/no_focused_tests.go
+++ b/internal/plugins/rstest/rules/no_focused_tests/no_focused_tests.go
@@ -45,37 +45,32 @@ var NoFocusedTestsRule = rule.Rule{
 				}
 
 				reportNode := focusedCallReportNode(node, parsed, focusEntries)
-				hasUnsuggestedEntry := false
-				for _, entry := range focusEntries {
-					if entry.Node != nil && !suggested[entry.Node] {
-						hasUnsuggestedEntry = true
-						break
+				ctx.ReportNodeWithDeferredSuggestions(reportNode, buildErrorFocusedTestMessage(), func() []rule.RuleSuggestion {
+					hasUnsuggestedEntry := false
+					for _, entry := range focusEntries {
+						if entry.Node != nil && !suggested[entry.Node] {
+							hasUnsuggestedEntry = true
+							break
+						}
 					}
-				}
-				if !hasUnsuggestedEntry {
-					ctx.ReportNode(reportNode, buildErrorFocusedTestMessage())
-					return
-				}
-
-				fixes, ok := removalFixes(focusEntries, ctx)
-				if !ok {
-					ctx.ReportNode(reportNode, buildErrorFocusedTestMessage())
-					return
-				}
-				for _, entry := range focusEntries {
-					if entry.Node != nil {
-						suggested[entry.Node] = true
+					if !hasUnsuggestedEntry {
+						return nil
 					}
-				}
 
-				ctx.ReportNodeWithSuggestions(
-					reportNode,
-					buildErrorFocusedTestMessage(),
-					rule.RuleSuggestion{
+					fixes, ok := removalFixes(focusEntries, ctx)
+					if !ok {
+						return nil
+					}
+					for _, entry := range focusEntries {
+						if entry.Node != nil {
+							suggested[entry.Node] = true
+						}
+					}
+					return []rule.RuleSuggestion{{
 						Message:  buildErrorSuggestRemoveFocusMessage(),
 						FixesArr: fixes,
-					},
-				)
+					}}
+				})
 			},
 		}
 	},

--- a/internal/plugins/rstest/rules/no_import_node_test/rule.go
+++ b/internal/plugins/rstest/rules/no_import_node_test/rule.go
@@ -208,6 +208,7 @@ var NoImportNodeTestRule = rule.Rule{
 	Name:   "rstest/no-import-node-test",
 	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, _ []any) rule.RuleListeners {
+		var replacementModule string
 		return rule.RuleListeners{
 			ast.KindImportDeclaration: func(node *ast.Node) {
 				declaration := node.AsImportDeclaration()
@@ -225,27 +226,26 @@ var NoImportNodeTestRule = rule.Rule{
 					return
 				}
 				message := noImportNodeTestMessage()
-				if specifier != nodeTestModule || !canSafelyReplaceModule(declaration) {
-					ctx.ReportNode(node, message)
-					return
-				}
-				replacement, ok := replacementForModuleSpecifier(
-					ctx.SourceFile,
-					declaration.ModuleSpecifier,
-					replacementModuleForFile(ctx.SourceFile),
-				)
-				if !ok {
-					ctx.ReportNode(node, message)
-					return
-				}
-				ctx.ReportNodeWithFixes(
-					node,
-					message,
-					rule.RuleFixReplaceRange(
+				ctx.ReportNodeWithDeferredFixes(node, message, func() []rule.RuleFix {
+					if specifier != nodeTestModule || !canSafelyReplaceModule(declaration) {
+						return nil
+					}
+					if replacementModule == "" {
+						replacementModule = replacementModuleForFile(ctx.SourceFile)
+					}
+					replacement, ok := replacementForModuleSpecifier(
+						ctx.SourceFile,
+						declaration.ModuleSpecifier,
+						replacementModule,
+					)
+					if !ok {
+						return nil
+					}
+					return []rule.RuleFix{rule.RuleFixReplaceRange(
 						internalUtils.TrimNodeTextRange(ctx.SourceFile, declaration.ModuleSpecifier),
 						replacement,
-					),
-				)
+					)}
+				})
 			},
 			// `import nodeTest = require('node:test')` is a static runner import
 			// too, but TypeScript parses it as its own declaration kind rather

--- a/internal/plugins/rstest/rules/prefer_called_exactly_once_with/prefer_called_exactly_once_with.go
+++ b/internal/plugins/rstest/rules/prefer_called_exactly_once_with/prefer_called_exactly_once_with.go
@@ -163,6 +163,7 @@ type chainAssertion struct {
 type mergeCandidate struct {
 	hits      []chainAssertion
 	statement *ast.Node
+	arguments []*ast.Node
 	// position is the trimmed start offset of statement, used to order the
 	// pair and to bound the mock-reset search between them.
 	position int
@@ -341,20 +342,7 @@ func mergeCandidateForStatement(
 	if len(arguments) == 0 {
 		return nil
 	}
-	// The fix keeps one `expect(...)` call and deletes the other, so every
-	// argument of the surviving call is evaluated once instead of twice. Equal
-	// source text does not make that safe: `expect(getMock())` may return a
-	// different mock each time, and dropping an evaluation drops whatever the
-	// expression did. Such a pair is still worth reporting, but the merge is
-	// the author's to make.
-	fixable := len(parsed.Matchers) == 1
-	for _, argument := range arguments {
-		if !isStableExpression(argument) {
-			fixable = false
-			break
-		}
-	}
-	candidate := &mergeCandidate{hits: hits, fixable: fixable}
+	candidate := &mergeCandidate{hits: hits, arguments: arguments, fixable: len(parsed.Matchers) == 1}
 
 	candidate.statement = statement
 	candidate.position = internalUtils.TrimNodeTextRange(sourceFile, statement).Pos()
@@ -909,30 +897,35 @@ func reportPair(
 	// The later assertion carries the report, as upstream does; the earlier one
 	// alone would point at code that reads fine until the second one shows up.
 	reportNode := second.hits[0].node
-	if !first.fixable || !second.fixable {
-		ctx.ReportNode(reportNode, message)
-		return
-	}
-	matcherRange, replacement, ok := test_framework.AccessorReplacement(
-		ctx.SourceFile,
-		with.node,
-		with.combined,
-	)
-	if !ok {
-		ctx.ReportNode(reportNode, message)
-		return
-	}
-	removeRange := statementRemovalRange(ctx.SourceFile, once.statement)
-	if removeRange.Overlaps(matcherRange) {
-		ctx.ReportNode(reportNode, message)
-		return
-	}
-	ctx.ReportNodeWithFixes(
-		reportNode,
-		message,
-		rule.RuleFixReplaceRange(matcherRange, replacement),
-		rule.RuleFixRemoveRange(removeRange),
-	)
+	ctx.ReportNodeWithDeferredFixes(reportNode, message, func() []rule.RuleFix {
+		if !first.fixable || !second.fixable {
+			return nil
+		}
+		// Merging removes an evaluation of every expect argument, not just the mock.
+		for _, candidate := range candidates {
+			for _, argument := range candidate.arguments {
+				if !isStableExpression(argument) {
+					return nil
+				}
+			}
+		}
+		matcherRange, replacement, ok := test_framework.AccessorReplacement(
+			ctx.SourceFile,
+			with.node,
+			with.combined,
+		)
+		if !ok {
+			return nil
+		}
+		removeRange := statementRemovalRange(ctx.SourceFile, once.statement)
+		if removeRange.Overlaps(matcherRange) {
+			return nil
+		}
+		return []rule.RuleFix{
+			rule.RuleFixReplaceRange(matcherRange, replacement),
+			rule.RuleFixRemoveRange(removeRange),
+		}
+	})
 }
 
 // pendingReport is one resolved merge, held until the whole block is analysed

--- a/internal/plugins/rstest/rules/prefer_importing_rstest_globals/prefer_importing_rstest_globals.go
+++ b/internal/plugins/rstest/rules/prefer_importing_rstest_globals/prefer_importing_rstest_globals.go
@@ -414,9 +414,8 @@ var PreferImportingRstestGlobalsRule = rule.Rule{
 				if reportingNode == nil || len(names.order) == 0 {
 					return
 				}
-				collected := slices.Clone(names.order)
 				ctx.ReportNodeWithDeferredFixes(reportingNode, preferMessage(names.joined()), func() []rule.RuleFix {
-					return buildAutofix(ctx, collected, written)
+					return buildAutofix(ctx, names.order, written)
 				})
 			},
 		}

--- a/internal/plugins/rstest/rules/valid_expect/valid_expect.go
+++ b/internal/plugins/rstest/rules/valid_expect/valid_expect.go
@@ -176,20 +176,17 @@ func reportAsyncDescriptor(
 ) {
 	msg := buildAsyncDescriptorMessage(descriptor, alwaysAwait)
 
-	var fixes []rule.RuleFix
-	if fn := ast.GetContainingFunction(descriptor.node); fn != nil {
-		if !ast.IsAsyncFunction(fn) && !asyncInserted[fn] {
-			fixes = append(fixes, sharedValidExpect.AsyncInsertFix(ctx.SourceFile, fn))
-			asyncInserted[fn] = true
+	ctx.ReportNodeWithDeferredFixes(descriptor.node, msg, func() []rule.RuleFix {
+		var fixes []rule.RuleFix
+		if fn := ast.GetContainingFunction(descriptor.node); fn != nil {
+			if !ast.IsAsyncFunction(fn) && !asyncInserted[fn] {
+				fixes = append(fixes, sharedValidExpect.AsyncInsertFix(ctx.SourceFile, fn))
+				asyncInserted[fn] = true
+			}
+			fixes = append(fixes, sharedValidExpect.AwaitFix(ctx.SourceFile, descriptor.node, alwaysAwait))
 		}
-		fixes = append(fixes, sharedValidExpect.AwaitFix(ctx.SourceFile, descriptor.node, alwaysAwait))
-	}
-
-	if len(fixes) > 0 {
-		ctx.ReportNodeWithFixes(descriptor.node, msg, fixes...)
-		return
-	}
-	ctx.ReportNode(descriptor.node, msg)
+		return fixes
+	})
 }
 
 // expectFactoryOpenParenRange locates the `(` of the assertion factory call so

--- a/internal/plugins/rstest/rules/valid_title/valid_title.go
+++ b/internal/plugins/rstest/rules/valid_title/valid_title.go
@@ -460,7 +460,7 @@ var ValidTitleRule = rule.Rule{
 						ignored = true
 					}
 					if !ignored && arg.Kind != ast.KindTemplateExpression {
-						ctx.ReportNodeWithFixes(arg, rule.RuleMessage{
+						ctx.ReportNode(arg, rule.RuleMessage{
 							Id:          "titleMustBeString",
 							Description: "Title must be a string",
 						})
@@ -511,19 +511,17 @@ var ValidTitleRule = rule.Rule{
 				if !co.ignoreSpaces {
 					trimmed := ecmascript.StringTrim(title)
 					if len(trimmed) != len(title) {
-						raw := scanner.GetSourceTextOfNodeFromSourceFile(ctx.SourceFile, arg, false)
-						fix := accidentalSpaceReplacement(raw)
-						if fix == raw {
-							ctx.ReportNode(arg, rule.RuleMessage{
-								Id:          "accidentalSpace",
-								Description: "should not have leading or trailing spaces",
-							})
-						} else {
-							ctx.ReportNodeWithFixes(arg, rule.RuleMessage{
-								Id:          "accidentalSpace",
-								Description: "should not have leading or trailing spaces",
-							}, rule.RuleFixReplace(ctx.SourceFile, arg, fix))
-						}
+						ctx.ReportNodeWithDeferredFixes(arg, rule.RuleMessage{
+							Id:          "accidentalSpace",
+							Description: "should not have leading or trailing spaces",
+						}, func() []rule.RuleFix {
+							raw := scanner.GetSourceTextOfNodeFromSourceFile(ctx.SourceFile, arg, false)
+							fix := accidentalSpaceReplacement(raw)
+							if fix == raw {
+								return nil
+							}
+							return []rule.RuleFix{rule.RuleFixReplace(ctx.SourceFile, arg, fix)}
+						})
 					}
 				}
 
@@ -541,16 +539,17 @@ var ValidTitleRule = rule.Rule{
 					firstTok = title[:i]
 				}
 				if ecmascript.EqualsWhenLowercased(firstTok, fnName) {
-					raw := scanner.GetSourceTextOfNodeFromSourceFile(ctx.SourceFile, arg, false)
 					msg := rule.RuleMessage{
 						Id:          "duplicatePrefix",
 						Description: "should not have duplicate prefix",
 					}
-					if fix, ok := duplicatePrefixReplacement(raw, fnName); ok {
-						ctx.ReportNodeWithFixes(arg, msg, rule.RuleFixReplace(ctx.SourceFile, arg, fix))
-					} else {
-						ctx.ReportNode(arg, msg)
-					}
+					ctx.ReportNodeWithDeferredFixes(arg, msg, func() []rule.RuleFix {
+						raw := scanner.GetSourceTextOfNodeFromSourceFile(ctx.SourceFile, arg, false)
+						if fix, ok := duplicatePrefixReplacement(raw, fnName); ok {
+							return []rule.RuleFix{rule.RuleFixReplace(ctx.SourceFile, arg, fix)}
+						}
+						return nil
+					})
 				}
 
 				if me := matcherFor(fnName, co.mustNotMatch); me.re.Test(title) {

--- a/internal/utils/test_framework/rules/prefer_equality_matcher/prefer_equality_matcher.go
+++ b/internal/utils/test_framework/rules/prefer_equality_matcher/prefer_equality_matcher.go
@@ -205,26 +205,25 @@ func NewRule(config Config) rule.Rule {
 						return
 					}
 
-					hasNot := slices.ContainsFunc(expectCall.Modifiers, func(entry testFramework.MemberEntry) bool {
-						return entry.Name == "not"
-					})
-					shouldHaveNot := shouldAddNot(comparisonNegated, matcherValue, hasNot)
-					match := Match{
-						Expect:          expectCall,
-						Comparison:      comparison,
-						Left:            left,
-						Right:           right,
-						MatcherArgument: matcherArgument,
-						ShouldHaveNot:   shouldHaveNot,
-						ModifierText:    modifierText(expectCall.Modifiers, shouldHaveNot),
-					}
-
 					ctx.ReportNodeWithDeferredSuggestions(
 						expectCall.MatcherEntry.Node,
 						buildUseEqualityMatcherMessage(),
 						func() []rule.RuleSuggestion {
-							match.LeftText = operandText(ctx.SourceFile, match.Left)
-							match.RightText = operandText(ctx.SourceFile, match.Right)
+							hasNot := slices.ContainsFunc(expectCall.Modifiers, func(entry testFramework.MemberEntry) bool {
+								return entry.Name == "not"
+							})
+							shouldHaveNot := shouldAddNot(comparisonNegated, matcherValue, hasNot)
+							match := Match{
+								Expect:          expectCall,
+								Comparison:      comparison,
+								Left:            left,
+								Right:           right,
+								LeftText:        operandText(ctx.SourceFile, left),
+								RightText:       operandText(ctx.SourceFile, right),
+								MatcherArgument: matcherArgument,
+								ShouldHaveNot:   shouldHaveNot,
+								ModifierText:    modifierText(expectCall.Modifiers, shouldHaveNot),
+							}
 							suggestions := make([]rule.RuleSuggestion, 0, len(equalityMatchers))
 							for _, equalityMatcher := range equalityMatchers {
 								fixes := config.BuildFixes(ctx, match, equalityMatcher)


### PR DESCRIPTION
## Motivation

Five Rstest rules still eagerly constructed autofixes or suggestions during diagnostic-only lint runs, causing unnecessary source scans, comment traversal, range calculation, and edit allocation.

Benchmarks use synthetic stress cases in diagnostic-only mode and report the median rule time from three single-threaded runs.

| Rule | Scale | Before | After |
| --- | ---: | ---: | ---: |
| `no-import-node-test` | 2,000 imports | 119.7 ms | 0.9 ms |
| `no-focused-tests` | 4,000 calls | 10.3 ms | 3.0 ms |
| `valid-title` | 4,000 registrations | 6.1 ms | 3.0 ms |
| `valid-expect` | 4,000 assertions | 7.1 ms | 7.1 ms |
| `prefer-called-exactly-once-with` | 2,000 pairs | 304.9 ms | 303.6 ms |

The last two rules remain dominated by diagnostic analysis, so their total runtime does not change materially.

## Changes

- Defer fix or suggestion construction in `no-import-node-test`, `no-focused-tests`, `valid-title`, `valid-expect`, and `prefer-called-exactly-once-with`.
- Cache `no-import-node-test` replacement-module discovery within each rule invocation.
- Move remaining fix-only work inside existing deferred builders.
- Add edit-demand regression coverage for source-only and type-aware programs.
