### PR TITLE
perf(rstest): make `no-async-mock-factory` linear in mock calls

### DIFF
--- a/internal/plugins/rstest/rules/consistent_test_it/consistent_test_it.go
+++ b/internal/plugins/rstest/rules/consistent_test_it/consistent_test_it.go
@@ -39,7 +39,7 @@ var ConsistentTestItRule = rule.Rule{
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
 		outside, inside := parseOptions(options)
 		analysis := rstestUtils.GetRstestCallAnalysis(ctx)
-		scan := &shadowScan{sourceFile: ctx.SourceFile}
+		scan := &shadowScan{shadowed: utils.NewShadowCache(ctx.SourceFile)}
 		// Both listeners resolve registrations through the same filter so a
 		// shadowed `describe` cannot unbalance the suite depth counter.
 		registration := func(node *ast.Node) *rstestUtils.ParsedRstestFnCall {
@@ -218,127 +218,11 @@ func isMutableRequireBinding(symbol *ast.Symbol) bool {
 // shadowed spellings as Rstest APIs. Correcting that inside the parser would
 // put a full scope walk on the path of every registration in every file, and
 // so on every rule that uses the parser; this rule pays for its own strictness
-// instead.
+// instead. utils.ShadowCache keeps that cost off the common path: a file that
+// never declares `test`, `it` or `describe` answers from one indexing pass, and
+// a file that does answers once per scope rather than once per registration.
 type shadowScan struct {
-	sourceFile *ast.SourceFile
-	names      map[string]bool
-	shadowed   map[shadowKey]bool
-}
-
-// shadowKey identifies one scope walk: the nearest enclosing node the walk
-// inspects, the name it looks for, and — only for the few scopes whose answer
-// depends on which child the walk entered through — that child.
-type shadowKey struct {
-	scope *ast.Node
-	entry *ast.Node
-	name  string
-}
-
-// declaresName reports whether the file binds name anywhere, from a single
-// indexing pass. Every binding has a declaration name, so this is a superset of
-// what the scope walk can find: a miss rules the walk out, and a hit only costs
-// the walk. Test files rarely declare `test`, `it`, or `describe` themselves,
-// which keeps the walk off the common path entirely.
-func (scan *shadowScan) declaresName(name string) bool {
-	if scan.names == nil {
-		scan.names = map[string]bool{}
-		if scan.sourceFile != nil {
-			var visit func(*ast.Node)
-			visit = func(node *ast.Node) {
-				if node.Kind == ast.KindIdentifier && ast.IsDeclarationName(node) && bindsDeclaredName(node) {
-					scan.names[node.Text()] = true
-				}
-				node.ForEachChild(func(child *ast.Node) bool {
-					visit(child)
-					return false
-				})
-			}
-			visit(scan.sourceFile.AsNode())
-		}
-	}
-	return scan.names[name]
-}
-
-// bindsDeclaredName reports whether an identifier in declaration-name position
-// introduces a binding a scope walk can find. Member names — object literal and
-// class members, enum members, type parameters, JSX attributes — name a
-// property, so an unrelated `const helper = { test() {} }` must not put `test`
-// in the index and send every global `test(...)` down the walk.
-func bindsDeclaredName(name *ast.Node) bool {
-	if name.Parent == nil {
-		return false
-	}
-	switch name.Parent.Kind {
-	case ast.KindPropertyAssignment, ast.KindShorthandPropertyAssignment,
-		ast.KindPropertyDeclaration, ast.KindPropertySignature,
-		ast.KindMethodDeclaration, ast.KindMethodSignature,
-		ast.KindGetAccessor, ast.KindSetAccessor,
-		ast.KindEnumMember, ast.KindTypeParameter, ast.KindJsxAttribute:
-		return false
-	}
-	return true
-}
-
-// isShadowed answers utils.IsShadowed once per (scope, name). A name the index
-// cannot rule out — a parameter or local called `test` anywhere in the file —
-// otherwise puts a full walk, including a scan of every top-level statement, on
-// every registration, which is quadratic in the number of registrations.
-func (scan *shadowScan) isShadowed(root *ast.Node, name string) bool {
-	scope, entry := shadowScope(root)
-	if scope == nil {
-		return utils.IsShadowed(root, name)
-	}
-	key := shadowKey{scope: scope, name: name}
-	if shadowScopeReadsEntry(scope) {
-		key.entry = entry
-	}
-	if result, cached := scan.shadowed[key]; cached {
-		return result
-	}
-	// Every node between root and scope is a plain expression: the walk neither
-	// inspects it nor counts it as a crossed scope, so resuming from entry sees
-	// exactly what a walk from root would.
-	result := utils.IsShadowed(entry, name)
-	if scan.shadowed == nil {
-		scan.shadowed = map[shadowKey]bool{}
-	}
-	scan.shadowed[key] = result
-	return result
-}
-
-// shadowScope returns the nearest ancestor of node that a scope walk inspects,
-// along with the child of it that the walk arrives through.
-func shadowScope(node *ast.Node) (scope *ast.Node, entry *ast.Node) {
-	entry = node
-	for current := node.Parent; current != nil; current = current.Parent {
-		if isShadowScope(current) {
-			return current, entry
-		}
-		entry = current
-	}
-	return nil, nil
-}
-
-// isShadowScope lists every node kind utils.IsShadowed acts on, so that two
-// registrations sharing a scope share its answer.
-func isShadowScope(node *ast.Node) bool {
-	switch node.Kind {
-	case ast.KindSourceFile, ast.KindBlock, ast.KindModuleBlock, ast.KindCaseBlock,
-		ast.KindCatchClause, ast.KindClassStaticBlockDeclaration, ast.KindEnumDeclaration,
-		ast.KindForStatement, ast.KindForInStatement, ast.KindForOfStatement,
-		ast.KindParameter:
-		return true
-	}
-	return ast.IsFunctionLikeDeclaration(node) || ast.IsClassLike(node)
-}
-
-// shadowScopeReadsEntry reports whether a scope's answer depends on the child
-// the walk arrives through: a parameter decorator, a class expression's own
-// name, and a function's parameter environment are all outside the scope that
-// encloses the rest of the construct.
-func shadowScopeReadsEntry(scope *ast.Node) bool {
-	return scope.Kind == ast.KindParameter || scope.Kind == ast.KindClassExpression ||
-		ast.IsFunctionLikeDeclaration(scope)
+	shadowed *utils.ShadowCache
 }
 
 func (scan *shadowScan) isShadowedRegistration(ctx rule.RuleContext, parsed *rstestUtils.ParsedRstestFnCall) bool {
@@ -351,7 +235,7 @@ func (scan *shadowScan) isShadowedRegistration(ctx rule.RuleContext, parsed *rst
 	if isShadowedByModuleBlock(root, ctx.SourceFile, name, symbol) {
 		return true
 	}
-	return symbol == nil && scan.declaresName(name) && scan.isShadowed(root, name)
+	return symbol == nil && scan.shadowed.IsShadowed(root, name)
 }
 
 // isShadowedByModuleBlock reports whether a `namespace`/`module` body between

--- a/internal/plugins/rstest/rules/no_async_mock_factory/no_async_mock_factory.go
+++ b/internal/plugins/rstest/rules/no_async_mock_factory/no_async_mock_factory.go
@@ -104,6 +104,10 @@ var NoAsyncMockFactoryRule = rule.Rule{
 	Name:   "rstest/no-async-mock-factory",
 	Schema: rule.EmptyArraySchema,
 	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		if !sourceMayContainMockFactory(ctx.SourceFile) {
+			return rule.RuleListeners{}
+		}
+		scan := &fileScan{ctx: ctx, shadowed: utils.NewShadowCache(ctx.SourceFile)}
 		return rule.RuleListeners{
 			ast.KindCallExpression: func(node *ast.Node) {
 				argument, member := mockFactoryArgument(node)
@@ -116,7 +120,7 @@ var NoAsyncMockFactoryRule = rule.Rule{
 					return
 				}
 
-				switch classify(ctx, factory) {
+				switch scan.classify(factory) {
 				case verdictSync, verdictUnknown:
 					return
 				}
@@ -124,11 +128,66 @@ var NoAsyncMockFactoryRule = rule.Rule{
 				ctx.ReportNodeWithDeferredSuggestions(
 					argument,
 					buildAsyncMockFactoryMessage(member),
-					func() []rule.RuleSuggestion { return suggestions(ctx, factory) },
+					func() []rule.RuleSuggestion { return scan.suggestions(factory) },
 				)
 			},
 		}
 	},
+}
+
+// sourceMayContainMockFactory rejects, from the source file's shared identifier
+// index, every file that cannot hold a call this rule reports.
+//
+// mockFactoryArgument matches only `rs.<member>(…)` and `rstest.<member>(…)`
+// with member one of the four mock APIs, all written out: none of those four
+// carries PluginManagedAPI.ReadsComputedMember, and the receiver has to be an
+// identifier spelled `rs` or `rstest` because that is how the build matches it.
+// So both names appear verbatim in any file with a reportable call, and the
+// index — which the compiler builds once per file and shares with every rule —
+// settles it without an AST walk of this rule's own.
+func sourceMayContainMockFactory(sourceFile *ast.SourceFile) bool {
+	if sourceFile == nil || sourceFile.AsNode().Kind != ast.KindSourceFile {
+		return true
+	}
+	hasNamespace := false
+	for _, namespace := range rstestUtils.UtilityNamespaceNames {
+		if sourceFile.HasIdentifier(namespace) {
+			hasNamespace = true
+			break
+		}
+	}
+	if !hasNamespace {
+		return false
+	}
+	for member := range mockAPIs {
+		if sourceFile.HasIdentifier(member) {
+			return true
+		}
+	}
+	return false
+}
+
+// fileScan carries the per-file memoization the three classification layers
+// share. Every entry is keyed by a node or a symbol of the file being linted and
+// dies with it.
+//
+// What is cached is only what a fixed piece of syntax settles: the verdict of a
+// function node, the verdict a symbol's single declaration gives, whether a
+// symbol is ever written to, and whether a name is shadowed at a scope. The type
+// layer is deliberately not memoized — checker.GetTypeAtLocation narrows per use
+// site, so two identifiers naming the same symbol can legitimately disagree.
+type fileScan struct {
+	ctx      rule.RuleContext
+	shadowed *utils.ShadowCache
+	// functions maps a function expression, arrow or declaration onto what
+	// classifyFunction concluded about it. A factory shared by many mock calls
+	// is therefore classified once.
+	functions map[*ast.Node]verdict
+	// declarations maps a symbol onto what classifyThroughDeclaration concluded
+	// for an identifier naming it.
+	declarations map[*ast.Symbol]verdict
+	// written maps a symbol onto whether anything in the file assigns to it.
+	written map[*ast.Symbol]bool
 }
 
 // mockFactoryArgument returns the factory argument of a module mock call the
@@ -165,19 +224,19 @@ func mockFactoryArgument(node *ast.Node) (*ast.Node, string) {
 // classify walks the three layers in order: what the syntax settles on its own,
 // what a declaration in this file settles, and — only for what is left — what
 // the types say.
-func classify(ctx rule.RuleContext, factory *ast.Node) verdict {
-	if v := classifySyntactically(ctx, factory); v != verdictUnknown {
+func (scan *fileScan) classify(factory *ast.Node) verdict {
+	if v := scan.classifySyntactically(factory); v != verdictUnknown {
 		return v
 	}
-	if v := classifyThroughDeclaration(ctx, factory); v != verdictUnknown {
+	if v := scan.classifyThroughDeclaration(factory); v != verdictUnknown {
 		return v
 	}
-	return classifyByType(ctx, factory)
+	return scan.classifyByType(factory)
 }
 
 // classifySyntactically answers from the argument alone, without resolving a
 // binding and without types.
-func classifySyntactically(ctx rule.RuleContext, factory *ast.Node) verdict {
+func (scan *fileScan) classifySyntactically(factory *ast.Node) verdict {
 	// An object literal in this position is the mock options bag, not a
 	// factory.
 	if factory.Kind == ast.KindObjectLiteralExpression {
@@ -186,10 +245,22 @@ func classifySyntactically(ctx rule.RuleContext, factory *ast.Node) verdict {
 	if !isFunctionExpressionLike(factory) {
 		return verdictUnknown
 	}
-	return classifyFunction(ctx, factory)
+	return scan.classifyFunction(factory)
 }
 
-func classifyFunction(ctx rule.RuleContext, fn *ast.Node) verdict {
+func (scan *fileScan) classifyFunction(fn *ast.Node) verdict {
+	if cached, ok := scan.functions[fn]; ok {
+		return cached
+	}
+	result := scan.computeFunctionVerdict(fn)
+	if scan.functions == nil {
+		scan.functions = map[*ast.Node]verdict{}
+	}
+	scan.functions[fn] = result
+	return result
+}
+
+func (scan *fileScan) computeFunctionVerdict(fn *ast.Node) verdict {
 	flags := ast.GetFunctionFlags(fn)
 	// A generator hands back a Generator and an async generator an
 	// AsyncGenerator. Neither is a promise, so neither trips the runtime gate.
@@ -215,7 +286,7 @@ func classifyFunction(ctx rule.RuleContext, fn *ast.Node) verdict {
 		return verdictUnknown
 	}
 	for _, expression := range returned {
-		if !isPromiseProducingExpression(ctx, expression) {
+		if !scan.isPromiseProducingExpression(expression) {
 			return verdictUnknown
 		}
 	}
@@ -227,16 +298,33 @@ func classifyFunction(ctx rule.RuleContext, fn *ast.Node) verdict {
 // anything but a `const` function or a function declaration, or to a function
 // declaration that is written to, is left to the type layer, where a
 // reassignment or a re-export is accounted for.
-func classifyThroughDeclaration(ctx rule.RuleContext, factory *ast.Node) verdict {
-	if factory.Kind != ast.KindIdentifier || ctx.Refs == nil {
+func (scan *fileScan) classifyThroughDeclaration(factory *ast.Node) verdict {
+	if factory.Kind != ast.KindIdentifier || scan.ctx.Refs == nil {
 		return verdictUnknown
 	}
-	symbol := ctx.Refs.Resolve(factory)
-	if symbol == nil || len(symbol.Declarations) != 1 {
+	symbol := scan.ctx.Refs.Resolve(factory)
+	if symbol == nil {
+		return verdictUnknown
+	}
+	// Everything below reads the symbol and its single declaration, so two
+	// identifiers naming the same shared factory reach the same answer.
+	if cached, ok := scan.declarations[symbol]; ok {
+		return cached
+	}
+	result := scan.computeDeclarationVerdict(symbol)
+	if scan.declarations == nil {
+		scan.declarations = map[*ast.Symbol]verdict{}
+	}
+	scan.declarations[symbol] = result
+	return result
+}
+
+func (scan *fileScan) computeDeclarationVerdict(symbol *ast.Symbol) verdict {
+	if len(symbol.Declarations) != 1 {
 		return verdictUnknown
 	}
 	declaration := symbol.Declarations[0]
-	if declaration == nil || ast.GetSourceFileOfNode(declaration) != ctx.SourceFile {
+	if declaration == nil || ast.GetSourceFileOfNode(declaration) != scan.ctx.SourceFile {
 		return verdictUnknown
 	}
 
@@ -245,10 +333,10 @@ func classifyThroughDeclaration(ctx rule.RuleContext, factory *ast.Node) verdict
 		// A function declaration's name is a writable binding, and an
 		// assignment to it adds no declaration of its own: the body below is
 		// the installed factory only while nothing writes to the name.
-		if isWrittenTo(ctx, symbol) {
+		if scan.isWrittenTo(symbol) {
 			return verdictUnknown
 		}
-		return classifyFunction(ctx, declaration)
+		return scan.classifyFunction(declaration)
 	case ast.KindVariableDeclaration:
 		if !ast.IsVarConst(declaration) {
 			return verdictUnknown
@@ -257,20 +345,29 @@ func classifyThroughDeclaration(ctx rule.RuleContext, factory *ast.Node) verdict
 		if initializer == nil || !isFunctionExpressionLike(initializer) {
 			return verdictUnknown
 		}
-		return classifyFunction(ctx, initializer)
+		return scan.classifyFunction(initializer)
 	}
 	return verdictUnknown
 }
 
 // isWrittenTo reports whether anything in this file assigns to the symbol,
 // which would replace the value its declaration describes.
-func isWrittenTo(ctx rule.RuleContext, symbol *ast.Symbol) bool {
-	for _, reference := range ctx.Refs.References(symbol) {
+func (scan *fileScan) isWrittenTo(symbol *ast.Symbol) bool {
+	if cached, ok := scan.written[symbol]; ok {
+		return cached
+	}
+	result := false
+	for _, reference := range scan.ctx.Refs.References(symbol) {
 		if utils.IsWriteReference(reference) {
-			return true
+			result = true
+			break
 		}
 	}
-	return false
+	if scan.written == nil {
+		scan.written = map[*ast.Symbol]bool{}
+	}
+	scan.written[symbol] = result
+	return result
 }
 
 // classifyByType asks the TypeChecker, and only ever answers verdictPromise or
@@ -279,7 +376,8 @@ func isWrittenTo(ctx rule.RuleContext, symbol *ast.Symbol) bool {
 //
 // A source-only program has no TypeChecker, and the rule then reports what the
 // first two layers found and nothing more.
-func classifyByType(ctx rule.RuleContext, factory *ast.Node) verdict {
+func (scan *fileScan) classifyByType(factory *ast.Node) verdict {
+	ctx := scan.ctx
 	if ctx.TypeChecker == nil {
 		return verdictUnknown
 	}
@@ -386,7 +484,7 @@ func isPromiseInstanceType(sourceProgram *lintprogram.Program, typeChecker *chec
 
 // isPromiseProducingExpression reports whether the expression can only evaluate
 // to a promise, judged by how it is written.
-func isPromiseProducingExpression(ctx rule.RuleContext, node *ast.Node) bool {
+func (scan *fileScan) isPromiseProducingExpression(node *ast.Node) bool {
 	node = utils.SkipAssertionsAndParens(node)
 	if node == nil {
 		return false
@@ -395,7 +493,7 @@ func isPromiseProducingExpression(ctx rule.RuleContext, node *ast.Node) bool {
 	switch node.Kind {
 	case ast.KindNewExpression:
 		callee := utils.SkipAssertionsAndParens(node.AsNewExpression().Expression)
-		return isUnshadowedPromiseIdentifier(callee)
+		return scan.isUnshadowedPromiseIdentifier(callee)
 	case ast.KindCallExpression:
 	default:
 		return false
@@ -419,7 +517,7 @@ func isPromiseProducingExpression(ctx rule.RuleContext, node *ast.Node) bool {
 			return false
 		}
 		return !utility.API.ResolvesReceiver ||
-			!rstestUtils.ReceiverIsLocallyDeclared(ctx, utility.NamespaceNode)
+			!rstestUtils.ReceiverIsLocallyDeclared(scan.ctx, utility.NamespaceNode)
 	}
 
 	callee := utils.SkipAssertionsAndParens(call.Expression)
@@ -434,15 +532,15 @@ func isPromiseProducingExpression(ctx rule.RuleContext, node *ast.Node) bool {
 	if name == nil || name.Kind != ast.KindIdentifier || !promiseStatics[name.AsIdentifier().Text] {
 		return false
 	}
-	return isUnshadowedPromiseIdentifier(utils.SkipAssertionsAndParens(access.Expression))
+	return scan.isUnshadowedPromiseIdentifier(utils.SkipAssertionsAndParens(access.Expression))
 }
 
 // isUnshadowedPromiseIdentifier reports whether node is the global `Promise`.
 // A file that declares its own `Promise` is left to the type layer.
-func isUnshadowedPromiseIdentifier(node *ast.Node) bool {
+func (scan *fileScan) isUnshadowedPromiseIdentifier(node *ast.Node) bool {
 	return node != nil && node.Kind == ast.KindIdentifier &&
 		node.AsIdentifier().Text == "Promise" &&
-		!utils.IsShadowed(node, "Promise")
+		!scan.shadowed.IsShadowed(node, "Promise")
 }
 
 func isFunctionExpressionLike(node *ast.Node) bool {
@@ -492,7 +590,7 @@ func returnedExpressions(fn *ast.Node) ([]*ast.Node, bool) {
 // own. Neither is offered as a fix: the common shape awaits the real module
 // inside the factory, and turning that into a top-level
 // `import … with { rstest: 'importActual' }` moves code across statements.
-func suggestions(ctx rule.RuleContext, factory *ast.Node) []rule.RuleSuggestion {
+func (scan *fileScan) suggestions(factory *ast.Node) []rule.RuleSuggestion {
 	if !isFunctionExpressionLike(factory) {
 		return nil
 	}
@@ -511,16 +609,17 @@ func suggestions(ctx rule.RuleContext, factory *ast.Node) []rule.RuleSuggestion 
 	}
 
 	if ast.GetFunctionFlags(factory)&ast.FunctionFlagsAsync != 0 {
-		return removeAsyncSuggestion(ctx, factory, returned)
+		return scan.removeAsyncSuggestion(factory, returned)
 	}
-	return unwrapPromiseResolveSuggestion(ctx, factory, returned)
+	return scan.unwrapPromiseResolveSuggestion(factory, returned)
 }
 
 // removeAsyncSuggestion drops the `async` keyword, which is equivalent only
 // when the body neither awaits nor already hands back a promise of its own.
-func removeAsyncSuggestion(ctx rule.RuleContext, factory *ast.Node, returned []*ast.Node) []rule.RuleSuggestion {
+func (scan *fileScan) removeAsyncSuggestion(factory *ast.Node, returned []*ast.Node) []rule.RuleSuggestion {
+	ctx := scan.ctx
 	for _, expression := range returned {
-		if !isDefinitelyNotPromise(expression) {
+		if !scan.isDefinitelyNotPromise(expression) {
 			return nil
 		}
 	}
@@ -554,7 +653,8 @@ func removeAsyncSuggestion(ctx rule.RuleContext, factory *ast.Node, returned []*
 }
 
 // unwrapPromiseResolveSuggestion replaces a lone `Promise.resolve(x)` with `x`.
-func unwrapPromiseResolveSuggestion(ctx rule.RuleContext, factory *ast.Node, returned []*ast.Node) []rule.RuleSuggestion {
+func (scan *fileScan) unwrapPromiseResolveSuggestion(factory *ast.Node, returned []*ast.Node) []rule.RuleSuggestion {
+	ctx := scan.ctx
 	if len(returned) != 1 {
 		return nil
 	}
@@ -570,14 +670,14 @@ func unwrapPromiseResolveSuggestion(ctx rule.RuleContext, factory *ast.Node, ret
 	access := callee.AsPropertyAccessExpression()
 	name := access.Name()
 	if name == nil || name.Kind != ast.KindIdentifier || name.AsIdentifier().Text != "resolve" ||
-		!isUnshadowedPromiseIdentifier(utils.SkipAssertionsAndParens(access.Expression)) {
+		!scan.isUnshadowedPromiseIdentifier(utils.SkipAssertionsAndParens(access.Expression)) {
 		return nil
 	}
 	if call.Arguments == nil || len(call.Arguments.Nodes) != 1 {
 		return nil
 	}
 	resolved := call.Arguments.Nodes[0]
-	if resolved == nil || resolved.Kind == ast.KindSpreadElement || !isDefinitelyNotPromise(resolved) {
+	if resolved == nil || resolved.Kind == ast.KindSpreadElement || !scan.isDefinitelyNotPromise(resolved) {
 		return nil
 	}
 
@@ -606,7 +706,7 @@ func unwrapPromiseResolveSuggestion(ctx rule.RuleContext, factory *ast.Node, ret
 // isDefinitelyNotPromise reports whether the expression's value can be read off
 // the syntax and is certainly not a promise. It gates the suggestions, so
 // anything it cannot vouch for is a "no".
-func isDefinitelyNotPromise(node *ast.Node) bool {
+func (scan *fileScan) isDefinitelyNotPromise(node *ast.Node) bool {
 	node = utils.SkipAssertionsAndParens(node)
 	if node == nil {
 		return false
@@ -628,7 +728,7 @@ func isDefinitelyNotPromise(node *ast.Node) bool {
 		ast.KindClassExpression:
 		return true
 	case ast.KindIdentifier:
-		return node.AsIdentifier().Text == "undefined" && !utils.IsShadowed(node, "undefined")
+		return node.AsIdentifier().Text == "undefined" && !scan.shadowed.IsShadowed(node, "undefined")
 	}
 	return false
 }

--- a/internal/plugins/rstest/rules/no_async_mock_factory/no_async_mock_factory_extras_reuse_test.go
+++ b/internal/plugins/rstest/rules/no_async_mock_factory/no_async_mock_factory_extras_reuse_test.go
@@ -1,0 +1,241 @@
+// TestNoAsyncMockFactoryExtrasReuse covers what the rule reuses across the calls of
+// one file: the shadowing answer for `Promise` and `undefined`, the verdict of
+// a function node, the verdict a symbol's declaration gives, and whether a
+// symbol is written to. Each case puts several mock calls in one file, so an
+// answer reused where it should not have been shows up as a report on the wrong
+// call or as a missing one.
+//
+// The file-level fast-fail is covered here too: every case that reports has to
+// keep reporting now that the listener is registered only for files naming both
+// a receiver and a mock member.
+package no_async_mock_factory
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoAsyncMockFactoryExtrasReuse(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoAsyncMockFactoryRule,
+		[]rule_tester.ValidTestCase{
+			// Two factories that each declare their own `Promise`. The syntax
+			// layer declines both and the local object's `resolve` gives the
+			// type layer nothing, so neither is reported — and the two scopes
+			// have to be asked separately to get there.
+			{Code: `
+rs.mock('./a', () => {
+  const Promise = { resolve: (value: unknown) => value };
+  return Promise.resolve({ a: 0 });
+});
+rs.mock('./b', () => {
+  const Promise = { resolve: (value: unknown) => value };
+  return Promise.resolve({ b: 0 });
+});
+`},
+
+			// One synchronous factory installed by several calls: classifying
+			// it once must not turn into a report on any of them.
+			{Code: `
+const factory = () => ({ sum: 0 });
+rs.mock('./a', factory);
+rs.doMock('./b', factory);
+rs.mockRequire('./c', factory);
+`},
+
+			// A `Promise` shadowed by a parameter rather than by a local, so
+			// the answer depends on the function scope the call site sits in.
+			{Code: `
+function build(Promise: { resolve: (value: unknown) => unknown }) {
+  rs.mock('./a', () => Promise.resolve({ a: 0 }));
+}
+`},
+
+			// The names the file-level fast-fail looks for. A file naming a
+			// mock member but no receiver, or a receiver but no member, cannot
+			// hold a call this rule reports.
+			{Code: `
+const mock = async () => ({ sum: 0 });
+const doMock = mock;
+export { mock, doMock };
+`},
+			{Code: `
+import { rs } from '@rstest/core';
+rs.fn(async () => ({ sum: 0 }));
+`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// One shared factory installed by several calls. Each call is its
+			// own report, so the declaration verdict is reused without the
+			// reports collapsing into one.
+			{
+				Code: `
+const factory = () => Promise.resolve({ sum: 0 });
+rs.mock('./a', factory);
+rs.doMock('./b', factory);
+rs.mockRequire('./c', factory);
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "asyncMockFactory", Line: 3, Column: 16, EndLine: 3, EndColumn: 23},
+					{MessageId: "asyncMockFactory", Line: 4, Column: 18, EndLine: 4, EndColumn: 25},
+					{MessageId: "asyncMockFactory", Line: 5, Column: 23, EndLine: 5, EndColumn: 30},
+				},
+			},
+
+			// `Promise` shadowed inside the first factory and global in the
+			// second. An answer cached per file rather than per scope would
+			// report both calls or neither.
+			{
+				Code: `
+rs.mock('./a', () => {
+  const Promise = { resolve: (value: unknown) => value };
+  return Promise.resolve({ a: 0 });
+});
+rs.mock('./b', () => Promise.resolve({ b: 0 }));
+`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "asyncMockFactory",
+					Line:      6,
+					Column:    16,
+					EndLine:   6,
+					EndColumn: 47,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+						MessageId: "suggestUnwrapPromiseResolve",
+						Output: `
+rs.mock('./a', () => {
+  const Promise = { resolve: (value: unknown) => value };
+  return Promise.resolve({ a: 0 });
+});
+rs.mock('./b', () => ({ b: 0 }));
+`,
+					}},
+				}},
+			},
+
+			// The same file the other way round, so the cache is filled by the
+			// unshadowed call first.
+			{
+				Code: `
+rs.mock('./a', () => Promise.resolve({ a: 0 }));
+rs.mock('./b', () => {
+  const Promise = { resolve: (value: unknown) => value };
+  return Promise.resolve({ b: 0 });
+});
+`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "asyncMockFactory",
+					Line:      2,
+					Column:    16,
+					EndLine:   2,
+					EndColumn: 47,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+						MessageId: "suggestUnwrapPromiseResolve",
+						Output: `
+rs.mock('./a', () => ({ a: 0 }));
+rs.mock('./b', () => {
+  const Promise = { resolve: (value: unknown) => value };
+  return Promise.resolve({ b: 0 });
+});
+`,
+					}},
+				}},
+			},
+
+			// Two `Promise.resolve` factories in scopes that answer alike, so
+			// the cached answer really is shared between them.
+			{
+				Code: `
+rs.mock('./a', () => Promise.resolve({ a: 0 }));
+rs.mock('./b', () => Promise.resolve({ b: 0 }));
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "asyncMockFactory",
+						Line:      2,
+						Column:    16,
+						EndLine:   2,
+						EndColumn: 47,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+							MessageId: "suggestUnwrapPromiseResolve",
+							Output: `
+rs.mock('./a', () => ({ a: 0 }));
+rs.mock('./b', () => Promise.resolve({ b: 0 }));
+`,
+						}},
+					},
+					{
+						MessageId: "asyncMockFactory",
+						Line:      3,
+						Column:    16,
+						EndLine:   3,
+						EndColumn: 47,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+							MessageId: "suggestUnwrapPromiseResolve",
+							Output: `
+rs.mock('./a', () => Promise.resolve({ a: 0 }));
+rs.mock('./b', () => ({ b: 0 }));
+`,
+						}},
+					},
+				},
+			},
+
+			// `undefined` reaches the same cache, from the suggestion layer
+			// rather than the classification layers. It is shadowed in the
+			// first factory, so only the second may drop its `async`.
+			{
+				Code: `
+rs.mock('./a', async () => {
+  const undefined = 1;
+  return undefined;
+});
+rs.mock('./b', async () => undefined);
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "asyncMockFactory", Line: 2, Column: 16, EndLine: 5, EndColumn: 2},
+					{
+						MessageId: "asyncMockFactory",
+						Line:      6,
+						Column:    16,
+						EndLine:   6,
+						EndColumn: 37,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+							MessageId: "suggestRemoveAsync",
+							Output: `
+rs.mock('./a', async () => {
+  const undefined = 1;
+  return undefined;
+});
+rs.mock('./b', () => undefined);
+`,
+						}},
+					},
+				},
+			},
+
+			// Two factories written identically must not share a verdict by
+			// shape: the cache is keyed by node, and only the second one is
+			// reportable.
+			{
+				Code: `
+const sync = () => ({ sum: 0 });
+const asyncFactory = () => Promise.resolve({ sum: 0 });
+rs.mock('./a', sync);
+rs.mock('./b', asyncFactory);
+`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "asyncMockFactory",
+					Line:      5,
+					Column:    16,
+					EndLine:   5,
+					EndColumn: 28,
+				}},
+			},
+		},
+	)
+}

--- a/internal/plugins/rstest/rules/no_async_mock_factory/no_async_mock_factory_extras_test.go
+++ b/internal/plugins/rstest/rules/no_async_mock_factory/no_async_mock_factory_extras_test.go
@@ -10,11 +10,33 @@
 package no_async_mock_factory
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/fixtures"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
+
+func TestNoAsyncMockFactorySiblingScopes(t *testing.T) {
+	const first = `rs.doMock('./first', () => Promise.resolve({ first: 1 }));`
+	const second = `rs.doMock('./second', () => Promise.resolve({ second: 2 }));`
+	var invalid []rule_tester.InvalidTestCase
+	for _, wrapper := range []struct{ prefix, suffix string }{
+		{"describe('suite', () => {\n", "\n});"},
+		{"function setup() {\n", "\n}"},
+	} {
+		code := "function unrelated(Promise: unknown) {}\n" + wrapper.prefix + first + "\n" + second + wrapper.suffix
+		invalid = append(invalid, rule_tester.InvalidTestCase{Code: code, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "asyncMockFactory", Line: 3, Column: 22, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+				MessageId: "suggestUnwrapPromiseResolve", Output: strings.Replace(code, "Promise.resolve({ first: 1 })", "({ first: 1 })", 1),
+			}}},
+			{MessageId: "asyncMockFactory", Line: 4, Column: 23, Suggestions: []rule_tester.InvalidTestCaseSuggestion{{
+				MessageId: "suggestUnwrapPromiseResolve", Output: strings.Replace(code, "Promise.resolve({ second: 2 })", "({ second: 2 })", 1),
+			}}},
+		}})
+	}
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoAsyncMockFactoryRule, nil, invalid)
+}
 
 func TestNoAsyncMockFactoryExtras(t *testing.T) {
 	rule_tester.RunRuleTester(

--- a/internal/plugins/rstest/utils/utility_call.go
+++ b/internal/plugins/rstest/utils/utility_call.go
@@ -5,10 +5,17 @@ import (
 	internalUtils "github.com/web-infra-dev/rslint/internal/utils"
 )
 
-// utilityNamespaces are the two names the utilities object is written under.
-// `@rstest/core` exports one object twice, as `rstest` and as `rs`
+// UtilityNamespaceNames are the two names the utilities object is written
+// under. `@rstest/core` exports one object twice, as `rstest` and as `rs`
 // (packages/core/src/runtime/api/public.ts), and registers both onto
 // `globalThis` under `globals: true`.
+//
+// ParseRstestPluginManagedCall reads the receiver as written, so a call it
+// matches spells one of these two out. A rule that wants to skip a file before
+// walking it can therefore ask the source file's identifier index for them.
+var UtilityNamespaceNames = [...]string{"rs", "rstest"}
+
+// utilityNamespaces is UtilityNamespaceNames as a lookup.
 var utilityNamespaces = map[string]bool{
 	"rs":     true,
 	"rstest": true,

--- a/internal/utils/shadow_cache.go
+++ b/internal/utils/shadow_cache.go
@@ -1,0 +1,182 @@
+package utils
+
+import (
+	"github.com/microsoft/TypeScript/tsc/shim/ast"
+)
+
+// ShadowCache answers IsShadowed for one source file without repeating the work
+// that walk performs.
+//
+// IsShadowed walks from a node up to the SourceFile and, at the top, scans every
+// top-level statement plus the hoisted `var` and function declarations of the
+// whole file. That is a file-sized amount of work per call, so a rule that asks
+// about one name at many nodes in the same file is quadratic in the number of
+// those nodes. The cache removes that in three steps, from cheapest to last
+// resort:
+//
+//   - A one-off declaration index rules the walk out entirely for a name the
+//     file never binds, which is the common case for `Promise`, `undefined`,
+//     `test` and the like.
+//   - The source-file arm — the only file-sized part of the walk — is answered
+//     once per name and shared by every node in the file, whatever scope it
+//     sits in. Nodes in scopes of their own, such as one inline callback per
+//     call site, get nothing from a per-scope cache and everything from this.
+//   - What is left is the walk through the scopes between the node and the
+//     file, whose cost is the nesting depth. That is answered once per scope,
+//     so nodes that share one answer it once.
+//
+// A cache belongs to one file and one rule invocation; it holds AST nodes and
+// must not outlive them.
+type ShadowCache struct {
+	sourceFile *ast.SourceFile
+	names      map[string]bool
+	shadowed   map[shadowCacheKey]bool
+	files      map[fileShadowKey]bool
+}
+
+// shadowCacheKey identifies one scope walk: the nearest enclosing node the walk
+// inspects, the name it looks for, and — only for the few scopes whose answer
+// depends on which child the walk entered through — that child.
+type shadowCacheKey struct {
+	scope *ast.Node
+	entry *ast.Node
+	name  string
+}
+
+// NewShadowCache returns a cache for one source file.
+func NewShadowCache(sourceFile *ast.SourceFile) *ShadowCache {
+	return &ShadowCache{sourceFile: sourceFile}
+}
+
+// IsShadowed answers utils.IsShadowed(node, name), reusing work across calls on
+// the same file. The answer is identical to calling IsShadowed directly.
+func (cache *ShadowCache) IsShadowed(node *ast.Node, name string) bool {
+	if node == nil {
+		return false
+	}
+	// Every binding has a declaration name, so the index is a superset of what
+	// the walk can find: a miss rules the walk out, and a hit only costs the
+	// walk. A file that never declares the name at all — the common case for
+	// `Promise`, `undefined`, `test` — therefore pays one indexing pass and
+	// nothing more.
+	if !cache.declaresName(name) {
+		return false
+	}
+	return cache.walk(node, name)
+}
+
+// DeclaresName reports whether the file binds name anywhere, from a single
+// indexing pass. It is the fast-fail IsShadowed applies, exposed for callers
+// that want to skip other work as well.
+func (cache *ShadowCache) DeclaresName(name string) bool {
+	return cache.declaresName(name)
+}
+
+func (cache *ShadowCache) declaresName(name string) bool {
+	if cache.names == nil {
+		cache.names = map[string]bool{}
+		if cache.sourceFile != nil {
+			var visit func(*ast.Node)
+			visit = func(node *ast.Node) {
+				if node.Kind == ast.KindIdentifier && ast.IsDeclarationName(node) && bindsDeclaredName(node) {
+					cache.names[node.Text()] = true
+				}
+				node.ForEachChild(func(child *ast.Node) bool {
+					visit(child)
+					return false
+				})
+			}
+			visit(cache.sourceFile.AsNode())
+		}
+	}
+	return cache.names[name]
+}
+
+// bindsDeclaredName reports whether an identifier in declaration-name position
+// introduces a binding a scope walk can find. Member names — object literal and
+// class members, enum members, type parameters, JSX attributes — name a
+// property, so an unrelated `const helper = { Promise() {} }` must not put
+// `Promise` in the index and send every `Promise.resolve(…)` down the walk.
+func bindsDeclaredName(name *ast.Node) bool {
+	if name.Parent == nil {
+		return false
+	}
+	switch name.Parent.Kind {
+	case ast.KindPropertyAssignment, ast.KindShorthandPropertyAssignment,
+		ast.KindPropertyDeclaration, ast.KindPropertySignature,
+		ast.KindMethodDeclaration, ast.KindMethodSignature,
+		ast.KindGetAccessor, ast.KindSetAccessor,
+		ast.KindEnumMember, ast.KindTypeParameter, ast.KindJsxAttribute:
+		return false
+	}
+	return true
+}
+
+// walk answers IsShadowed once per (scope, name). A name the index cannot rule
+// out — a parameter or local called `Promise` anywhere in the file — otherwise
+// puts a full walk, including a scan of every top-level statement, on every
+// node asking about it.
+func (cache *ShadowCache) walk(node *ast.Node, name string) bool {
+	scope, entry := shadowScope(node)
+	if scope == nil {
+		return isShadowed(node, name, cache.fileArm())
+	}
+	key := shadowCacheKey{scope: scope, name: name}
+	if shadowScopeReadsEntry(scope) {
+		key.entry = entry
+	}
+	if result, cached := cache.shadowed[key]; cached {
+		return result
+	}
+	// Every node between node and scope is a plain expression: the walk neither
+	// inspects it nor counts it as a crossed scope, so resuming from entry sees
+	// exactly what a walk from node would.
+	result := isShadowed(entry, name, cache.fileArm())
+	if cache.shadowed == nil {
+		cache.shadowed = map[shadowCacheKey]bool{}
+	}
+	cache.shadowed[key] = result
+	return result
+}
+
+func (cache *ShadowCache) fileArm() map[fileShadowKey]bool {
+	if cache.files == nil {
+		cache.files = map[fileShadowKey]bool{}
+	}
+	return cache.files
+}
+
+// shadowScope returns the nearest ancestor of node that a scope walk inspects,
+// along with the child of it that the walk arrives through.
+func shadowScope(node *ast.Node) (scope *ast.Node, entry *ast.Node) {
+	entry = node
+	for current := node.Parent; current != nil; current = current.Parent {
+		if isShadowScope(current) {
+			return current, entry
+		}
+		entry = current
+	}
+	return nil, nil
+}
+
+// isShadowScope lists every node kind IsShadowed acts on, so that two nodes
+// sharing a scope share its answer.
+func isShadowScope(node *ast.Node) bool {
+	switch node.Kind {
+	case ast.KindSourceFile, ast.KindBlock, ast.KindModuleBlock, ast.KindCaseBlock,
+		ast.KindCatchClause, ast.KindClassStaticBlockDeclaration, ast.KindEnumDeclaration,
+		ast.KindForStatement, ast.KindForInStatement, ast.KindForOfStatement,
+		ast.KindParameter:
+		return true
+	}
+	return ast.IsFunctionLikeDeclaration(node) || ast.IsClassLike(node)
+}
+
+// shadowScopeReadsEntry reports whether a scope's answer depends on the child
+// the walk arrives through: a parameter decorator, a class expression's own
+// name, and a function's parameter environment are all outside the scope that
+// encloses the rest of the construct.
+func shadowScopeReadsEntry(scope *ast.Node) bool {
+	return scope.Kind == ast.KindParameter || scope.Kind == ast.KindClassExpression ||
+		ast.IsFunctionLikeDeclaration(scope)
+}

--- a/internal/utils/shadow_cache.go
+++ b/internal/utils/shadow_cache.go
@@ -4,34 +4,12 @@ import (
 	"github.com/microsoft/TypeScript/tsc/shim/ast"
 )
 
-// ShadowCache answers IsShadowed for one source file without repeating the work
-// that walk performs.
-//
-// IsShadowed walks from a node up to the SourceFile and, at the top, scans every
-// top-level statement plus the hoisted `var` and function declarations of the
-// whole file. That is a file-sized amount of work per call, so a rule that asks
-// about one name at many nodes in the same file is quadratic in the number of
-// those nodes. The cache removes that in three steps, from cheapest to last
-// resort:
-//
-//   - A one-off declaration index rules the walk out entirely for a name the
-//     file never binds, which is the common case for `Promise`, `undefined`,
-//     `test` and the like.
-//   - The source-file arm — the only file-sized part of the walk — is answered
-//     once per name and shared by every node in the file, whatever scope it
-//     sits in. Nodes in scopes of their own, such as one inline callback per
-//     call site, get nothing from a per-scope cache and everything from this.
-//   - What is left is the walk through the scopes between the node and the
-//     file, whose cost is the nesting depth. That is answered once per scope,
-//     so nodes that share one answer it once.
-//
-// A cache belongs to one file and one rule invocation; it holds AST nodes and
-// must not outlive them.
+// ShadowCache reuses name and declaration scans within one source file.
 type ShadowCache struct {
 	sourceFile *ast.SourceFile
 	names      map[string]bool
 	shadowed   map[shadowCacheKey]bool
-	files      map[fileShadowKey]bool
+	scans      shadowScanCache
 }
 
 // shadowCacheKey identifies one scope walk: the nearest enclosing node the walk
@@ -119,7 +97,7 @@ func bindsDeclaredName(name *ast.Node) bool {
 func (cache *ShadowCache) walk(node *ast.Node, name string) bool {
 	scope, entry := shadowScope(node)
 	if scope == nil {
-		return isShadowed(node, name, cache.fileArm())
+		return isShadowed(node, name, &cache.scans)
 	}
 	key := shadowCacheKey{scope: scope, name: name}
 	if shadowScopeReadsEntry(scope) {
@@ -131,7 +109,7 @@ func (cache *ShadowCache) walk(node *ast.Node, name string) bool {
 	// Every node between node and scope is a plain expression: the walk neither
 	// inspects it nor counts it as a crossed scope, so resuming from entry sees
 	// exactly what a walk from node would.
-	result := isShadowed(entry, name, cache.fileArm())
+	result := isShadowed(entry, name, &cache.scans)
 	if cache.shadowed == nil {
 		cache.shadowed = map[shadowCacheKey]bool{}
 	}
@@ -139,11 +117,68 @@ func (cache *ShadowCache) walk(node *ast.Node, name string) bool {
 	return result
 }
 
-func (cache *ShadowCache) fileArm() map[fileShadowKey]bool {
-	if cache.files == nil {
-		cache.files = map[fileShadowKey]bool{}
+type shadowScanKind uint8
+
+const (
+	shadowScanFile shadowScanKind = iota
+	shadowScanBlock
+	shadowScanCaseBlock
+	shadowScanModuleBlock
+	shadowScanHoistedVar
+	shadowScanParameters
+)
+
+type shadowScanKey struct {
+	node *ast.Node
+	name string
+	kind shadowScanKind
+}
+
+type shadowScanCache map[shadowScanKey]bool
+
+// Only local declaration scans are cached; entry-dependent scope decisions stay in the walk.
+func (cache *shadowScanCache) check(node *ast.Node, name string, kind shadowScanKind) bool {
+	if kind == shadowScanParameters && len(node.Parameters()) == 0 {
+		return false
 	}
-	return cache.files
+	if kind == shadowScanHoistedVar && node.Kind != ast.KindBlock {
+		return HasHoistedVarDeclaration(node, name)
+	}
+	key := shadowScanKey{node: node, name: name, kind: kind}
+	if cache != nil {
+		if result, ok := (*cache)[key]; ok {
+			return result
+		}
+	}
+	result := scanShadowDeclarations(node, name, kind)
+	if cache != nil {
+		if *cache == nil {
+			*cache = make(shadowScanCache)
+		}
+		(*cache)[key] = result
+	}
+	return result
+}
+
+func scanShadowDeclarations(node *ast.Node, name string, kind shadowScanKind) bool {
+	switch kind {
+	case shadowScanFile:
+		return sourceFileShadows(node, name)
+	case shadowScanBlock:
+		return HasShadowingDeclaration(node, name) || hasHoistedFunctionDeclaration(node, name)
+	case shadowScanCaseBlock:
+		return HasShadowingDeclarationInCaseBlock(node, name) || hasHoistedFunctionDeclaration(node, name)
+	case shadowScanModuleBlock:
+		block := node.AsModuleBlock()
+		return (block != nil && block.Statements != nil && HasLocalDeclarationInStatements(block.Statements.Nodes, name)) ||
+			HasHoistedVarDeclaration(node, name) || hasHoistedFunctionDeclaration(node, name)
+	case shadowScanHoistedVar:
+		return HasHoistedVarDeclaration(node, name)
+	case shadowScanParameters:
+		return HasShadowingParameter(node, name)
+	default:
+		panic("unknown shadow scan kind")
+	}
 }
 
 // shadowScope returns the nearest ancestor of node that a scope walk inspects,

--- a/internal/utils/shadow_cache_test.go
+++ b/internal/utils/shadow_cache_test.go
@@ -1,0 +1,207 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/microsoft/TypeScript/tsc/shim/ast"
+	"github.com/microsoft/TypeScript/tsc/shim/core"
+	"github.com/microsoft/TypeScript/tsc/shim/parser"
+)
+
+// shadowCacheCorpus holds files whose scopes the cache has to key apart. Each
+// one is asked about every name any of them binds, so a source that never
+// mentions a name still exercises the "file declares nothing" fast path for it.
+var shadowCacheCorpus = []string{
+	// Nothing declares the name: the index alone has to answer, for every
+	// node in the file.
+	`Promise.resolve(1); function f() { return Promise.resolve(2); } const g = () => Promise.reject(3);`,
+
+	// One scope shadows and a sibling does not, which is what a per-name
+	// file-wide cache would get wrong.
+	`function outer() { const Promise = 1; return Promise; }
+Promise.resolve(1);
+function other() { return Promise.resolve(2); }`,
+
+	// Two references in the same block share one answer.
+	`{ const Promise = 1; Promise; Promise; }
+{ Promise; Promise; }`,
+
+	// Hoisted declarations reach backwards within their scope.
+	`function f() { Promise; var Promise; }
+function g() { Promise; }
+function h() { Promise; { var Promise; } }`,
+
+	// A function's parameter environment is not its body's variable
+	// environment, so entry has to be part of the key.
+	`function f(a = Promise) { var Promise; return Promise; }`,
+	`function f(a = Promise, Promise = 1) { return Promise; }`,
+
+	// A parameter decorator escapes the decorated function's scope.
+	`class C { m(@dec(Promise) x: number) { var Promise; } }`,
+	`class C { m(@dec(Promise) x: number, Promise: any) { } }`,
+	`class C { m(@dec(() => Promise) x: number, Promise: any) { } }`,
+
+	// A class expression's own name is in scope for its body but not for a
+	// scope created inside its decorators.
+	`const k = class Promise { m() { return Promise; } };`,
+	`class Promise { m(@dec(() => Promise) x: number) { } }`,
+
+	// Namespace bodies, case blocks, catch clauses, enums, static blocks and
+	// the three `for` heads are all scopes IsShadowed inspects.
+	`namespace N { const Promise = 1; Promise; } Promise;`,
+	`namespace N { var Promise = 1; { Promise; } } Promise;`,
+	`switch (a) { case 1: const Promise = 1; case 2: Promise; } Promise;`,
+	`try { Promise; } catch (Promise) { Promise; }`,
+	`enum Promise { A = Promise.B } Promise;`,
+	`class C { static { var Promise; Promise; } m() { return Promise; } }`,
+	`for (var Promise = 0; Promise; Promise++) Promise;`,
+	`for (const Promise in o) Promise;`,
+	`for (let Promise of o) Promise;`,
+
+	// Member names must stay out of the declaration index, or every file with
+	// an unrelated `Promise` property would pay for the walk — and, more
+	// importantly, must not be mistaken for bindings.
+	`const helper = { Promise: 1, Promise() {} }; Promise.resolve(1);`,
+	`class C { Promise = 1; Promise2() {} } Promise.resolve(1);`,
+	`enum E { Promise } Promise.resolve(1);`,
+	`interface I { Promise: number } Promise.resolve(1);`,
+	`function f<Promise>() { return Promise; } Promise.resolve(1);`,
+
+	// `undefined` travels the same path from the mock-factory suggestions.
+	`function f() { const undefined = 1; return undefined; } undefined;`,
+	`const o = { undefined: 1 }; undefined;`,
+
+	// The source-file arm is now answered once per name for the whole file, so
+	// each of its three ingredients needs a case: a top-level declaration, a
+	// `var` hoisted out of a nested block, and a function declaration hoisted
+	// out of one. Each file also asks from several scopes of its own.
+	`const Promise = 1;
+function f() { return Promise; }
+function g() { { return Promise; } }
+Promise;`,
+	`{ var Promise = 1; }
+function f() { return Promise; }
+Promise;`,
+	`if (b) function Promise() {}
+function f() { return Promise; }
+Promise;`,
+	`switch (a) { case 1: { var Promise = 1; } }
+function f() { return Promise; }
+Promise;`,
+	// The same shapes with nothing at file scope, so the arm has to answer
+	// false while inner scopes still decide for themselves.
+	`function f() { { var Promise = 1; } return Promise; }
+function g() { return Promise; }
+Promise;`,
+
+	// Nested functions, so the walk crosses several scopes before the file.
+	`function a() { function b() { function c() { return Promise; } } var Promise; }`,
+	`function a() { const Promise = 1; return function b() { return function c() { return Promise; }; }; }`,
+}
+
+// shadowCacheNames are asked of every file in the corpus.
+var shadowCacheNames = []string{"Promise", "undefined", "N", "C", "f", "a", "Promise2", "Missing"}
+
+// TestShadowCacheMatchesIsShadowed is the differential the cache has to pass:
+// for every identifier of every corpus file and every name, the cached answer
+// and utils.IsShadowed must agree. Asking at every node — not only at the ones
+// a rule would ask about — is what covers the scope and entry keying, since two
+// nodes that share a cache entry must genuinely share an answer.
+func TestShadowCacheMatchesIsShadowed(t *testing.T) {
+	for _, code := range shadowCacheCorpus {
+		t.Run(code, func(t *testing.T) {
+			sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+				FileName: "/test.ts",
+				Path:     "/test.ts",
+			}, code, core.ScriptKindTS)
+
+			identifiers := collectIdentifierNodes(sourceFile.AsNode())
+			if len(identifiers) == 0 {
+				t.Fatal("corpus entry has no identifiers")
+			}
+
+			for _, name := range shadowCacheNames {
+				// One cache per name is not how a rule uses it, so share a
+				// single cache across every name as well.
+				cache := NewShadowCache(sourceFile)
+				for _, node := range identifiers {
+					want := IsShadowed(node, name)
+					// Ask twice: the first call fills the entry, the second has
+					// to read it back unchanged.
+					for attempt := range 2 {
+						if got := cache.IsShadowed(node, name); got != want {
+							t.Fatalf("cache.IsShadowed(%q at %d, attempt %d) = %v, IsShadowed = %v",
+								node.Text(), node.Pos(), attempt, got, want)
+						}
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestShadowCacheDeclaresName locks the index down to bindings a scope walk can
+// find, since a member name that leaked into it would take every file with an
+// unrelated property of that name off the fast path.
+func TestShadowCacheDeclaresName(t *testing.T) {
+	tests := []struct {
+		code     string
+		declares bool
+	}{
+		{`const Promise = 1;`, true},
+		{`let Promise;`, true},
+		{`var Promise;`, true},
+		{`function Promise() {}`, true},
+		{`class Promise {}`, true},
+		{`enum Promise {}`, true},
+		{`namespace Promise {}`, true},
+		{`import Promise from "m";`, true},
+		{`import { x as Promise } from "m";`, true},
+		{`import * as Promise from "m";`, true},
+		{`function f(Promise) {}`, true},
+		{`try {} catch (Promise) {}`, true},
+		{`const { Promise } = o;`, true},
+		{`const { x: Promise } = o;`, true},
+		{`type Promise = number;`, true},
+		{`interface Promise {}`, true},
+
+		{`Promise.resolve(1);`, false},
+		{`const o = { Promise: 1 };`, false},
+		{`const o = { Promise() {} };`, false},
+		{`const { Promise: renamed } = o;`, false},
+		{`class C { Promise = 1; }`, false},
+		{`class C { Promise() {} }`, false},
+		{`class C { get Promise() { return 1; } }`, false},
+		{`interface I { Promise: number }`, false},
+		{`enum E { Promise }`, false},
+		{`function f<Promise>() {}`, false},
+		{`const jsx = <div Promise="x" />;`, false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.code, func(t *testing.T) {
+			sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+				FileName: "/test.tsx",
+				Path:     "/test.tsx",
+			}, test.code, core.ScriptKindTSX)
+			cache := NewShadowCache(sourceFile)
+			if got := cache.DeclaresName("Promise"); got != test.declares {
+				t.Errorf("DeclaresName() = %v, want %v", got, test.declares)
+			}
+		})
+	}
+}
+
+func collectIdentifierNodes(root *ast.Node) []*ast.Node {
+	var identifiers []*ast.Node
+	var visit func(*ast.Node) bool
+	visit = func(node *ast.Node) bool {
+		if node.Kind == ast.KindIdentifier {
+			identifiers = append(identifiers, node)
+		}
+		node.ForEachChild(visit)
+		return false
+	}
+	root.ForEachChild(visit)
+	return identifiers
+}

--- a/internal/utils/shadow_cache_test.go
+++ b/internal/utils/shadow_cache_test.go
@@ -1,6 +1,8 @@
 package utils
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/microsoft/TypeScript/tsc/shim/ast"
@@ -97,6 +99,16 @@ Promise;`,
 	// Nested functions, so the walk crosses several scopes before the file.
 	`function a() { function b() { function c() { return Promise; } } var Promise; }`,
 	`function a() { const Promise = 1; return function b() { return function c() { return Promise; }; }; }`,
+	`function unrelated(Promise) {}
+function setup() { const a = () => Promise.resolve(1); const b = () => Promise.resolve(2); }`,
+	`function f(a = (() => Promise)()) { var Promise; const b = () => Promise; const c = () => Promise; }`,
+	`function outer() { { var Promise; } const a = () => Promise; const b = () => Promise; }
+function sibling() { const a = () => Promise; const b = () => Promise; }`,
+	`function outer() { const a = () => Promise; const b = () => Promise; function Promise() {} }`,
+	`function unrelated(Promise) {}
+namespace N { const a = () => Promise; const b = () => Promise; }
+switch (x) { case 0: (() => Promise)(); break; default: (() => Promise)(); }
+class C { static { (() => Promise)(); (() => Promise)(); } }`,
 }
 
 // shadowCacheNames are asked of every file in the corpus.
@@ -189,6 +201,91 @@ func TestShadowCacheDeclaresName(t *testing.T) {
 				t.Errorf("DeclaresName() = %v, want %v", got, test.declares)
 			}
 		})
+	}
+}
+
+func TestShadowCacheReusesOuterDeclarationScans(t *testing.T) {
+	for _, test := range []struct {
+		code string
+		kind shadowScanKind
+	}{
+		{`function outer() { const a = () => Promise; const b = () => Promise; }`, shadowScanBlock},
+		{`function outer() { const a = () => Promise; const b = () => Promise; }`, shadowScanHoistedVar},
+		{`function outer(value) { const a = () => Promise; const b = () => Promise; }`, shadowScanParameters},
+		{`namespace N { const a = () => Promise; const b = () => Promise; }`, shadowScanModuleBlock},
+		{`switch (value) { case 1: const a = () => Promise; break; default: const b = () => Promise; }`, shadowScanCaseBlock},
+		{`class C { static { const a = () => Promise; const b = () => Promise; } }`, shadowScanHoistedVar},
+	} {
+		t.Run(fmt.Sprintf("%d/%s", test.kind, test.code), func(t *testing.T) {
+			source := parser.ParseSourceFile(ast.SourceFileParseOptions{
+				FileName: "/test.ts", Path: "/test.ts",
+			}, "function unrelated(Promise) {}\n"+test.code, core.ScriptKindTS)
+			var references []*ast.Node
+			for _, node := range collectIdentifierNodes(source.AsNode()) {
+				if node.Text() == "Promise" && node.Parent.Kind == ast.KindArrowFunction {
+					references = append(references, node)
+				}
+			}
+			if len(references) != 2 {
+				t.Fatalf("got %d references, want 2", len(references))
+			}
+			cache := NewShadowCache(source)
+			if cache.IsShadowed(references[0], "Promise") {
+				t.Fatal("sibling parameter must not shadow Promise")
+			}
+			for outer := references[0].Parent.Parent; outer != nil; outer = outer.Parent {
+				key := shadowScanKey{node: outer, name: "Promise", kind: test.kind}
+				if result, ok := cache.scans[key]; ok {
+					if result {
+						t.Fatal("outer declaration scan must be negative")
+					}
+					// A sentinel proves the second sibling reads the cache instead of rescanning the AST.
+					cache.scans[key] = true
+					if !cache.IsShadowed(references[1], "Promise") {
+						t.Fatal("second sibling did not reuse the outer declaration scan")
+					}
+					return
+				}
+			}
+			t.Fatal("missing cached outer declaration scan")
+		})
+	}
+}
+
+func BenchmarkShadowCacheSiblingFactories(b *testing.B) {
+	for _, wrapper := range []struct{ name, prefix, suffix string }{
+		{"top-level", "", ""},
+		{"describe", "describe('suite', () => {\n", "});"},
+		{"setup", "function setup() {\n", "}"},
+	} {
+		for _, size := range []int{1000, 2000, 4000} {
+			b.Run(fmt.Sprintf("%s/%d", wrapper.name, size), func(b *testing.B) {
+				code := "function unrelated(Promise) {}\n" + wrapper.prefix +
+					strings.Repeat("rs.doMock('m', () => Promise.resolve({}));\n", size) + wrapper.suffix
+				source := parser.ParseSourceFile(ast.SourceFileParseOptions{
+					FileName: "/bench.ts", Path: "/bench.ts",
+				}, code, core.ScriptKindTS)
+				var references []*ast.Node
+				for _, node := range collectIdentifierNodes(source.AsNode()) {
+					if node.Text() == "Promise" && node.Parent.Kind == ast.KindPropertyAccessExpression {
+						references = append(references, node)
+					}
+				}
+				if len(references) != size {
+					b.Fatalf("got %d references, want %d", len(references), size)
+				}
+				b.ReportAllocs()
+				b.ResetTimer()
+				for range b.N {
+					cache := NewShadowCache(source)
+					for _, reference := range references {
+						if cache.IsShadowed(reference, "Promise") {
+							b.Fatal("unrelated parameter must not shadow Promise")
+						}
+					}
+				}
+			})
+		}
 	}
 }
 

--- a/internal/utils/shadowing.go
+++ b/internal/utils/shadowing.go
@@ -600,23 +600,8 @@ func IsShadowed(node *ast.Node, name string) bool {
 	return isShadowed(node, name, nil)
 }
 
-// fileShadowKey identifies the source-file arm of one walk. It carries the file
-// as well as the name so that a cache handed to isShadowed can never answer for
-// the wrong file.
-type fileShadowKey struct {
-	sourceFile *ast.Node
-	name       string
-}
-
-// isShadowed is IsShadowed with the source-file arm optionally memoized. That
-// arm is the only part of the walk whose cost is proportional to the file — it
-// scans every top-level statement and then the whole file for hoisted `var` and
-// function declarations — while every other arm costs no more than the nesting
-// depth of the node. It also reads nothing but the SourceFile and the name: no
-// prevChild, no crossed-scope state, no parameter-decorator state. So it is
-// exactly the part that can be answered once per (file, name) and shared by
-// every walk in that file, however different their scopes.
-func isShadowed(node *ast.Node, name string, files map[fileShadowKey]bool) bool {
+// Local scans can be shared across siblings without caching entry-dependent traversal state.
+func isShadowed(node *ast.Node, name string, scans *shadowScanCache) bool {
 	prevChild := node
 	inParameterDecorator := false
 	crossedScope := false
@@ -627,10 +612,10 @@ func isShadowed(node *ast.Node, name string, files map[fileShadowKey]bool) bool 
 		}
 		switch current.Kind {
 		case ast.KindSourceFile:
-			return sourceFileShadows(current, name, files)
+			return scans.check(current, name, shadowScanFile)
 
 		case ast.KindBlock:
-			if HasShadowingDeclaration(current, name) || hasHoistedFunctionDeclaration(current, name) {
+			if scans.check(current, name, shadowScanBlock) {
 				return true
 			}
 
@@ -640,13 +625,7 @@ func isShadowed(node *ast.Node, name string, files map[fileShadowKey]bool) bool 
 		// for the whole block, while the block itself still nests lexically
 		// inside its parent scope.
 		case ast.KindModuleBlock:
-			moduleBlock := current.AsModuleBlock()
-			if moduleBlock != nil && moduleBlock.Statements != nil {
-				if HasLocalDeclarationInStatements(moduleBlock.Statements.Nodes, name) {
-					return true
-				}
-			}
-			if HasHoistedVarDeclaration(current, name) || hasHoistedFunctionDeclaration(current, name) {
+			if scans.check(current, name, shadowScanModuleBlock) {
 				return true
 			}
 
@@ -656,12 +635,12 @@ func isShadowed(node *ast.Node, name string, files map[fileShadowKey]bool) bool 
 		// function-like declaration, so the arm below never reaches its body.
 		case ast.KindClassStaticBlockDeclaration:
 			if body := current.AsClassStaticBlockDeclaration().Body; body != nil &&
-				HasHoistedVarDeclaration(body, name) {
+				scans.check(body, name, shadowScanHoistedVar) {
 				return true
 			}
 
 		case ast.KindCaseBlock:
-			if HasShadowingDeclarationInCaseBlock(current, name) || hasHoistedFunctionDeclaration(current, name) {
+			if scans.check(current, name, shadowScanCaseBlock) {
 				return true
 			}
 
@@ -714,7 +693,7 @@ func isShadowed(node *ast.Node, name string, files map[fileShadowKey]bool) bool 
 				if escapesFunctionScope(current, prevChild, inParameterDecorator, crossedScope) {
 					break
 				}
-				if HasShadowingParameter(current, name) {
+				if scans.check(current, name, shadowScanParameters) {
 					return true
 				}
 				// Function declarations and expressions can shadow via their own name.
@@ -728,7 +707,7 @@ func isShadowed(node *ast.Node, name string, files map[fileShadowKey]bool) bool 
 				// which is a *parent* of the body's variable environment — so a
 				// `var` declared in the body does not shadow it.
 				if !isDirectParameterOf(current, prevChild) {
-					if body := current.Body(); body != nil && HasHoistedVarDeclaration(body, name) {
+					if body := current.Body(); body != nil && scans.check(body, name, shadowScanHoistedVar) {
 						return true
 					}
 				}
@@ -743,16 +722,7 @@ func isShadowed(node *ast.Node, name string, files map[fileShadowKey]bool) bool 
 	return false
 }
 
-// sourceFileShadows answers the walk's source-file arm, reading only the file
-// and the name. A non-nil cache turns the file-sized scan into one lookup for
-// every later walk asking about the same name in the same file.
-func sourceFileShadows(sourceFile *ast.Node, name string, files map[fileShadowKey]bool) bool {
-	key := fileShadowKey{sourceFile: sourceFile, name: name}
-	if files != nil {
-		if cached, ok := files[key]; ok {
-			return cached
-		}
-	}
+func sourceFileShadows(sourceFile *ast.Node, name string) bool {
 	result := false
 	if sf := sourceFile.AsSourceFile(); sf != nil && sf.Statements != nil {
 		result = HasLocalDeclarationInStatements(sf.Statements.Nodes, name)
@@ -760,9 +730,6 @@ func sourceFileShadows(sourceFile *ast.Node, name string, files map[fileShadowKe
 	if !result {
 		result = HasHoistedVarDeclaration(sourceFile, name) ||
 			hasHoistedFunctionDeclaration(sourceFile, name)
-	}
-	if files != nil {
-		files[key] = result
 	}
 	return result
 }

--- a/internal/utils/shadowing.go
+++ b/internal/utils/shadowing.go
@@ -597,6 +597,26 @@ func hasFunctionScopeDeclaration(body *ast.Node, name string) bool {
 // declarations, namespace bodies, function parameters, catch variables, and
 // hoisted var and function declarations.
 func IsShadowed(node *ast.Node, name string) bool {
+	return isShadowed(node, name, nil)
+}
+
+// fileShadowKey identifies the source-file arm of one walk. It carries the file
+// as well as the name so that a cache handed to isShadowed can never answer for
+// the wrong file.
+type fileShadowKey struct {
+	sourceFile *ast.Node
+	name       string
+}
+
+// isShadowed is IsShadowed with the source-file arm optionally memoized. That
+// arm is the only part of the walk whose cost is proportional to the file — it
+// scans every top-level statement and then the whole file for hoisted `var` and
+// function declarations — while every other arm costs no more than the nesting
+// depth of the node. It also reads nothing but the SourceFile and the name: no
+// prevChild, no crossed-scope state, no parameter-decorator state. So it is
+// exactly the part that can be answered once per (file, name) and shared by
+// every walk in that file, however different their scopes.
+func isShadowed(node *ast.Node, name string, files map[fileShadowKey]bool) bool {
 	prevChild := node
 	inParameterDecorator := false
 	crossedScope := false
@@ -607,16 +627,7 @@ func IsShadowed(node *ast.Node, name string) bool {
 		}
 		switch current.Kind {
 		case ast.KindSourceFile:
-			sf := current.AsSourceFile()
-			if sf != nil && sf.Statements != nil {
-				if HasLocalDeclarationInStatements(sf.Statements.Nodes, name) {
-					return true
-				}
-			}
-			if HasHoistedVarDeclaration(current, name) || hasHoistedFunctionDeclaration(current, name) {
-				return true
-			}
-			return false
+			return sourceFileShadows(current, name, files)
 
 		case ast.KindBlock:
 			if HasShadowingDeclaration(current, name) || hasHoistedFunctionDeclaration(current, name) {
@@ -730,6 +741,30 @@ func IsShadowed(node *ast.Node, name string) bool {
 		current = current.Parent
 	}
 	return false
+}
+
+// sourceFileShadows answers the walk's source-file arm, reading only the file
+// and the name. A non-nil cache turns the file-sized scan into one lookup for
+// every later walk asking about the same name in the same file.
+func sourceFileShadows(sourceFile *ast.Node, name string, files map[fileShadowKey]bool) bool {
+	key := fileShadowKey{sourceFile: sourceFile, name: name}
+	if files != nil {
+		if cached, ok := files[key]; ok {
+			return cached
+		}
+	}
+	result := false
+	if sf := sourceFile.AsSourceFile(); sf != nil && sf.Statements != nil {
+		result = HasLocalDeclarationInStatements(sf.Statements.Nodes, name)
+	}
+	if !result {
+		result = HasHoistedVarDeclaration(sourceFile, name) ||
+			hasHoistedFunctionDeclaration(sourceFile, name)
+	}
+	if files != nil {
+		files[key] = result
+	}
+	return result
 }
 
 // IsQualifiedNamespaceSegment reports whether a module declaration is one


### PR DESCRIPTION
## Motivation

Follow up on the shadow-scan caching pattern introduced for `rstest/consistent-test-it` by applying it to repeated `Promise` shadow checks in `rstest/no-async-mock-factory`.

## Changes

- Skip the rule entirely for files that name neither a receiver nor a mock member, using the source file's shared identifier index.
- Add `internal/utils.ShadowCache`, which answers `IsShadowed` once per `(file, name)` and once per scope, and reuses each outer scope's local declaration scans across sibling scopes.
- Cache each function node's verdict, each symbol's declaration verdict, and whether a symbol is written to, so a factory shared by many mock calls is classified once. The type layer stays unmemoized because `GetTypeAtLocation` narrows per use site.
- Move the private `shadowScan` out of `rstest/consistent-test-it` into the shared cache, which additionally memoizes the source-file arm that rule lacked.
- Add differential tests comparing the cache against `IsShadowed` at every identifier of 39 files, and rule tests putting several mock calls in one file per case.

## Performance

The rule called `utils.IsShadowed` once per `Promise.resolve`-shaped factory, and that helper scans the whole file at the source-file boundary, so cost grew quadratically with the number of mock calls in a file. Measured on one generated file with only this rule enabled, median of five `--timing all` samples:

| Mock calls in one file | Before | After | Speedup |
| --- | ---: | ---: | ---: |
| 1,000 sharing one factory | 38.8ms | 0.9ms | 43.1× |
| 2,000 sharing one factory | 144.7ms | 1.8ms | 80.4× |
| 4,000 sharing one factory | 543.2ms | 3.6ms | 150.9× |
| 2,000 with a distinct inline factory each | 138.7ms | 2.3ms | 60.3× |
| 2,000 inline, file also declares `Promise` | 141.1ms | 2.6ms | 54.3× |

Before is quadratic in the number of mock calls; after is linear.

The original benchmark above puts each inline factory at file scope. A follow-up benchmark covers the remaining adversarial shape: independent inline factories nested in one shared outer scope while an unrelated `Promise` declaration elsewhere defeats the name fast path. Median of three cache-level samples:

| Factories in one shared scope | Before | After | Speedup |
| --- | ---: | ---: | ---: |
| 1,000 in a `describe` callback | 32.3ms | 0.26ms | 125× |
| 2,000 in a `describe` callback | 126.3ms | 0.54ms | 236× |
| 4,000 in a `describe` callback | 516.6ms | 1.04ms | 498× |
| 1,000 in a setup function | 32.0ms | 0.26ms | 121× |
| 2,000 in a setup function | 129.2ms | 0.52ms | 249× |
| 4,000 in a setup function | 511.9ms | 1.02ms | 504× |

The cache now memoizes only the declaration scans local to blocks, function bodies and parameter lists, module and switch blocks, static blocks, and the source file. Entry-dependent traversal state remains uncached. Before/after binaries produced byte-for-byte identical diagnostics and suggestions on 11 source-only fixtures spanning those scopes.

Across the six repositories, median `rstest/no-async-mock-factory` rule time from 24 runs alternating with the same baseline. The `Time (ms)` column quantizes to 0.1ms, which erases the effect on Rspack and Rslib, so each figure below is taken from the same table's `Relative` column, which is computed at nanosecond precision. On the four repositories where the `Time` column does resolve, the two agree to within 0.03ms.

| Repository | Test Files | Before | After | Speedup |
| --- | ---: | ---: | ---: | ---: |
| Rspack | 147 | 0.08ms | 0.01ms | 6.27× |
| Rsbuild | 644 | 0.45ms | 0.09ms | 4.80× |
| Rslib | 114 | 0.14ms | 0.04ms | 3.73× |
| Rspress | 139 | 3.10ms | 2.90ms | 1.07× |
| Rsdoctor | 99 | 0.57ms | 0.44ms | 1.30× |
| Rstest | 909 | 3.57ms | 2.84ms | 1.26× |
| **Combined** | **2,052** | **7.92ms** | **6.32ms** | **1.25×** |

The largest gains are on the repositories with almost no mock calls, where the rule now skips whole files. Rstest and Rspress still do the work, just not repeatedly.


