### PR TITLE
perf(rstest): optimize `prefer-called-exactly-once-with` interval scans

### DIFF
--- a/internal/plugins/rstest/rules/prefer_called_exactly_once_with/prefer_called_exactly_once_with.go
+++ b/internal/plugins/rstest/rules/prefer_called_exactly_once_with/prefer_called_exactly_once_with.go
@@ -161,12 +161,11 @@ type chainAssertion struct {
 // interest, which merges with a matching statement elsewhere in the block, or
 // one of each role, which already states both halves and merges with itself.
 type mergeCandidate struct {
-	hits      []chainAssertion
-	statement *ast.Node
-	arguments []*ast.Node
-	// position is the trimmed start offset of statement, used to order the
-	// pair and to bound the mock-reset search between them.
-	position int
+	hits           []chainAssertion
+	statement      *ast.Node
+	statementIndex int
+	arguments      []*ast.Node
+	position       int
 	// pairKey groups the assertions that may merge; see pairKey().
 	pairKey string
 	// fixable is false when the chain asserts more than the rule understands,
@@ -784,20 +783,19 @@ func onlyInertStatementsBetween(
 	statements []*ast.Node,
 	first, second *mergeCandidate,
 ) bool {
-	minPosition, maxPosition := first.position, second.position
-	if minPosition > maxPosition {
-		minPosition, maxPosition = maxPosition, minPosition
+	minIndex, maxIndex := first.statementIndex, second.statementIndex
+	if minIndex > maxIndex {
+		minIndex, maxIndex = maxIndex, minIndex
+	}
+	if maxIndex-minIndex == 1 {
+		return true
 	}
 	scanner := &betweenScanner{ctx: ctx, analysis: analysis, assertionNames: map[string]bool{}}
 	collectIdentifierNames(first.statement, scanner.assertionNames)
 	collectIdentifierNames(second.statement, scanner.assertionNames)
 
-	for _, statement := range statements {
+	for _, statement := range statements[minIndex+1 : maxIndex] {
 		if statement == nil {
-			continue
-		}
-		position := internalUtils.TrimNodeTextRange(ctx.SourceFile, statement).Pos()
-		if position <= minPosition || position >= maxPosition {
 			continue
 		}
 		if !scanner.isInertStatement(statement) && !scanner.isInertDeclaration(statement) {
@@ -951,11 +949,12 @@ func checkBlock(
 	var pending []pendingReport
 	var pairKeys []string
 	byPairKey := map[string][]*mergeCandidate{}
-	for _, statement := range statements {
+	for index, statement := range statements {
 		candidate := mergeCandidateForStatement(analysis, ctx.SourceFile, statement)
 		if candidate == nil {
 			continue
 		}
+		candidate.statementIndex = index
 		// A chain that states both halves needs no partner, and counting it
 		// among the candidates would only suppress it.
 		if candidate.isSelfContained() {

--- a/internal/plugins/rstest/rules/prefer_called_exactly_once_with/prefer_called_exactly_once_with_internal_test.go
+++ b/internal/plugins/rstest/rules/prefer_called_exactly_once_with/prefer_called_exactly_once_with_internal_test.go
@@ -1,11 +1,16 @@
 package prefer_called_exactly_once_with
 
 import (
+	"fmt"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/microsoft/TypeScript/tsc/shim/ast"
 	"github.com/microsoft/TypeScript/tsc/shim/core"
 	"github.com/microsoft/TypeScript/tsc/shim/parser"
+	rstestUtils "github.com/web-infra-dev/rslint/internal/plugins/rstest/utils"
+	"github.com/web-infra-dev/rslint/internal/rule"
 )
 
 func TestSourceMayContainMergePair(t *testing.T) {
@@ -72,6 +77,123 @@ func TestSourceMayContainMergePairKeepsUnknownSourceFile(t *testing.T) {
 	)
 	if !sourceMayContainMergePair(sourceFile) {
 		t.Error("the compiler must collect identifier names before checking an uncached source file")
+	}
+}
+
+func TestOnlyInertStatementIntervals(t *testing.T) {
+	tests := []struct {
+		name   string
+		middle string
+		want   bool
+	}{
+		{name: "adjacent", want: true},
+		{name: "comments", middle: "// keep\n/* keep */", want: true},
+		{name: "declarations", middle: "const unrelated = 1; let value; var other = 2;", want: true},
+		{name: "assertions", middle: "expect(other).toBe(1); expect(third).toEqual({ value: 2 });", want: true},
+		{name: "first barrier", middle: "spy.mockClear(); const unrelated = 1;"},
+		{name: "last barrier", middle: "const unrelated = 1; spy.mockClear();"},
+		{name: "empty statement", middle: ";"},
+		{name: "nested barrier", middle: "if (flag) { spy.mockReset(); }"},
+		{name: "reassignment", middle: "spy = other;"},
+		{name: "target shadow", middle: "var spy;"},
+		{name: "argument shadow", middle: "var expected;"},
+		{name: "matcher shadow", middle: "var toHaveBeenCalledWith;"},
+		{name: "unknown call without checker", middle: "console.log('checkpoint');"},
+		{name: "await", middle: "await expect(other).resolves.toBe(1);"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			source := "before();\nexpect(spy).toHaveBeenCalledOnce();\n" + tt.middle + "\nexpect(spy).toHaveBeenCalledWith(expected);\nafter();"
+			sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{FileName: "/case.ts", Path: "/case.ts"}, source, core.ScriptKindTS)
+			ctx := rule.RuleContext{SourceFile: sourceFile}
+			analysis := rstestUtils.GetRstestCallAnalysis(ctx)
+			statements := sourceFile.Statements.Nodes
+			firstIndex, secondIndex := 1, len(statements)-2
+			first := mergeCandidateForStatement(analysis, sourceFile, statements[firstIndex])
+			second := mergeCandidateForStatement(analysis, sourceFile, statements[secondIndex])
+			if first == nil || second == nil {
+				t.Fatal("expected two merge candidates")
+			}
+			first.statementIndex, second.statementIndex = firstIndex, secondIndex
+			for _, pair := range [][2]*mergeCandidate{{first, second}, {second, first}} {
+				if got := onlyInertStatementsBetween(ctx, analysis, statements, pair[0], pair[1]); got != tt.want {
+					t.Errorf("interval (%d, %d) = %t, want %t", pair[0].statementIndex, pair[1].statementIndex, got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+func TestCheckBlockStatementIndices(t *testing.T) {
+	source := `before();
+expect(first).toHaveBeenCalledOnce();
+expect(first).toHaveBeenCalledWith(1);
+between();
+expect(second).toHaveBeenCalledWith(2);
+const unrelated = 0;
+expect(second).toHaveBeenCalledOnce();
+expect(third).calledOnce.and.calledWith(3);
+expect(blocked).toHaveBeenCalledOnce();
+blocked.mockReset();
+expect(blocked).toHaveBeenCalledWith(4);
+after();`
+	for _, nested := range []bool{false, true} {
+		t.Run(fmt.Sprintf("nested=%t", nested), func(t *testing.T) {
+			code := source
+			if nested {
+				code = "{\n" + source + "\n}"
+			}
+			sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{FileName: "/case.ts", Path: "/case.ts"}, code, core.ScriptKindTS)
+			var diagnostics []rule.RuleDiagnostic
+			ctx := (rule.RuleContext{SourceFile: sourceFile}).WithReporter(PreferCalledExactlyOnceWithRule.Name, rule.SeverityError, func(diagnostic rule.RuleDiagnostic) {
+				diagnostics = append(diagnostics, diagnostic)
+			})
+			node := sourceFile.AsNode()
+			if nested {
+				node = sourceFile.Statements.Nodes[0]
+			}
+			checkBlock(ctx, rstestUtils.GetRstestCallAnalysis(ctx), node)
+			if len(diagnostics) != 3 {
+				t.Fatalf("got %d diagnostics, want 3", len(diagnostics))
+			}
+			for i, matcher := range []string{"toHaveBeenCalledWith", "toHaveBeenCalledOnce", "calledWith"} {
+				diagnostic := diagnostics[i]
+				if text := code[diagnostic.Range.Pos():diagnostic.Range.End()]; text != matcher {
+					t.Errorf("diagnostic %d: got %q, want %q", i, text, matcher)
+				}
+				wantFixes := 2
+				if i == 2 {
+					wantFixes = 0
+				}
+				if len(diagnostic.Fixes()) != wantFixes {
+					t.Errorf("diagnostic %d: got %d fixes, want %d", i, len(diagnostic.Fixes()), wantFixes)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkAdjacentPairs(b *testing.B) {
+	for _, pairs := range []int{500, 1000, 2000} {
+		b.Run(strconv.Itoa(pairs), func(b *testing.B) {
+			var source strings.Builder
+			for i := range pairs {
+				fmt.Fprintf(&source, "expect(spy%d).toHaveBeenCalledOnce();\nexpect(spy%d).toHaveBeenCalledWith(1);\n", i, i)
+			}
+			sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{FileName: "/case.ts", Path: "/case.ts"}, source.String(), core.ScriptKindTS)
+			b.ReportAllocs()
+			b.SetBytes(int64(source.Len()))
+			for b.Loop() {
+				reports := 0
+				ctx := (rule.RuleContext{SourceFile: sourceFile}).WithDiagnosticConsumer(PreferCalledExactlyOnceWithRule.Name, rule.SeverityError, rule.DiagnosticConsumer{
+					Report: func(rule.RuleDiagnostic) { reports++ },
+				})
+				PreferCalledExactlyOnceWithRule.Run(ctx, nil)
+				if reports != pairs {
+					b.Fatalf("got %d reports, want %d", reports, pairs)
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Motivation

`rstest/prefer-called-exactly-once-with` scans the entire containing block for every matched assertion pair to determine whether the statements between them are inert.

For a block with `P` pairs and `S` statements, this costs `O(P × S)` and becomes quadratic when both grow together. In the adjacent-pair stress case, 2,000 pairs take about 290 ms even though there are no statements to inspect between each pair.

The existing six-repository fixture shows no material improvement because dense mergeable assertion pairs are rare in those repositories.

## Changes

Store the containing statement index on each merge candidate and inspect only the slice strictly between paired candidates. Adjacent candidates return immediately without constructing the between-statement scanner or collecting identifier names.

The existing pair-dependent barrier checks remain unchanged for non-adjacent candidates, so this does not change pairing, diagnostics, barriers, or autofixes.

Add regression coverage for adjacent and reversed pairs, interval boundaries, barriers, declaration shadowing, top-level and nested blocks, and diagnostic ordering. Also add an adjacent-pair benchmark.

Compared against `4b04a460e`, which already includes deferred edit construction. Measurements use `--timing all --singleThreaded`, one warmup, and seven interleaved runs per version; the table reports median rule execution time.

| Pairs | Before | After | Speedup |
| ---: | ---: | ---: | ---: |
| 500 | 19.8 ms | 1.0 ms | 19.8× |
| 1,000 | 72.3 ms | 2.0 ms | 36.2× |
| 2,000 | 289.8 ms | 4.2 ms | 69.0× |

The doubling ratios improve from 3.65× / 4.01× to 2.00× / 2.10×.

With the full Rstest recommended preset, total rule execution time for 2,000 pairs drops from 286.2 ms to 7.7 ms.
