### PR TITLE
perf(rstest): cache call-chain candidate roots

### DIFF
--- a/internal/plugins/rstest/rules/expect_expect/expect_expect.go
+++ b/internal/plugins/rstest/rules/expect_expect/expect_expect.go
@@ -39,7 +39,8 @@ var ExpectExpectRule = shared.NewRule(shared.Config{
 			}
 		}
 		return shared.Runtime{
-			IsAssertion: isAssertion,
+			IsAssertion:     isAssertion,
+			FirstIdentifier: analysis.FirstIdentifier,
 			ClassifyTest: func(node *ast.Node) shared.TestClassification {
 				parsed := analysis.ParseTestCall(node)
 				if parsed == nil {

--- a/internal/plugins/rstest/utils/call_analysis.go
+++ b/internal/plugins/rstest/utils/call_analysis.go
@@ -8,13 +8,14 @@ import (
 )
 
 type RstestCallAnalysis struct {
-	ctx         rule.RuleContext
-	candidates  map[string]rstestCandidateKind
-	fnCalls     map[*ast.Node]*ParsedRstestFnCall
-	expectCalls map[*ast.Node]*ParsedRstestExpectCall
-	isExpect    map[*ast.Node]bool
-	expectRoots map[*ast.Symbol]rstestExpectRoot
-	calls       []*ast.Node
+	ctx              rule.RuleContext
+	candidates       map[string]rstestCandidateKind
+	fnCalls          map[*ast.Node]*ParsedRstestFnCall
+	expectCalls      map[*ast.Node]*ParsedRstestExpectCall
+	isExpect         map[*ast.Node]bool
+	expectRoots      map[*ast.Symbol]rstestExpectRoot
+	firstIdentifiers map[*ast.Node]*ast.Node
+	calls            []*ast.Node
 	// functions indexes named function declarations by name so a callback
 	// passed by an identifier the checker could not resolve still has a
 	// candidate. The index is file-wide and carries no scope information, so
@@ -71,6 +72,9 @@ func newRstestCallAnalysis(ctx rule.RuleContext) *RstestCallAnalysis {
 func (analysis *RstestCallAnalysis) ParseFnCall(node *ast.Node) *ParsedRstestFnCall {
 	if node == nil || node.Kind != ast.KindCallExpression {
 		return nil
+	}
+	if parsed, ok := analysis.fnCalls[node]; ok {
+		return parsed
 	}
 	if !analysis.isFnCallCandidate(node) {
 		return nil
@@ -142,11 +146,11 @@ func (analysis *RstestCallAnalysis) IsExpectCall(node *ast.Node) bool {
 	// callbacks must be complete before the candidate gate runs. Reordering
 	// these calls would silently reject ctx.expect and destructured aliases.
 	analysis.Callbacks()
-	if !analysis.isExpectCandidate(node) {
-		return false
-	}
 	if result, ok := analysis.isExpect[node]; ok {
 		return result
+	}
+	if !analysis.isExpectCandidate(node) {
+		return false
 	}
 	result := isRstestExpectCall(node, analysis)
 	analysis.isExpect[node] = result
@@ -161,11 +165,11 @@ func (analysis *RstestCallAnalysis) ParseExpectCall(
 ) *ParsedRstestExpectCall {
 	// See IsExpectCall: callback collection widens the expect candidate set.
 	analysis.Callbacks()
-	if !analysis.isExpectCandidate(node) {
-		return nil
-	}
 	if parsed, ok := analysis.expectCalls[node]; ok {
 		return parsed
+	}
+	if !analysis.isExpectCandidate(node) {
+		return nil
 	}
 	parsed := parseRstestExpectCall(node, analysis)
 	analysis.expectCalls[node] = parsed
@@ -189,13 +193,70 @@ func (analysis *RstestCallAnalysis) callbacksRef() *RstestTestCallbacks {
 	return &analysis.callbacks
 }
 
+func (analysis *RstestCallAnalysis) firstIdentifier(node *ast.Node) *ast.Node {
+	if node == nil {
+		return nil
+	}
+	// Identifier roots are already their own answer and dominate ordinary
+	// unchained calls. Avoid growing the memo table for this constant-time case;
+	// recursive callers still cache their expression node below.
+	if node.Kind == ast.KindIdentifier {
+		return node
+	}
+	if root, ok := analysis.firstIdentifiers[node]; ok {
+		return root
+	}
+	root := analysis.resolveFirstIdentifier(node)
+	if analysis.firstIdentifiers == nil {
+		analysis.firstIdentifiers = map[*ast.Node]*ast.Node{}
+	}
+	analysis.firstIdentifiers[node] = root
+	return root
+}
+
+func (analysis *RstestCallAnalysis) resolveFirstIdentifier(node *ast.Node) *ast.Node {
+	if node == nil {
+		return nil
+	}
+	var root *ast.Node
+	switch node.Kind {
+	case ast.KindIdentifier:
+		root = node
+	case ast.KindParenthesizedExpression:
+		root = analysis.resolveFirstIdentifier(node.AsParenthesizedExpression().Expression)
+	case ast.KindCallExpression:
+		// A later CallExpression candidate asks about this exact callee, so cache
+		// it while walking the outer chain. The CallExpression node itself is not
+		// a candidate key and does not need another map entry.
+		root = analysis.firstIdentifier(node.AsCallExpression().Expression)
+	case ast.KindPropertyAccessExpression:
+		root = analysis.resolveFirstIdentifier(node.AsPropertyAccessExpression().Expression)
+	case ast.KindElementAccessExpression:
+		root = analysis.resolveFirstIdentifier(node.AsElementAccessExpression().Expression)
+	case ast.KindTaggedTemplateExpression:
+		root = analysis.resolveFirstIdentifier(node.AsTaggedTemplateExpression().Tag)
+	case ast.KindBinaryExpression:
+		if internalUtils.IsCommaOperator(node) {
+			root = analysis.resolveFirstIdentifier(node.AsBinaryExpression().Right)
+		}
+	}
+	return root
+}
+
+// FirstIdentifier returns the cached first identifier of a call/member chain.
+// Rstest adapters use it when a shared rule needs the same candidate decision
+// as ParseFnCall and ParseExpectCall without starting another chain walk.
+func (analysis *RstestCallAnalysis) FirstIdentifier(node *ast.Node) *ast.Node {
+	return analysis.firstIdentifier(node)
+}
+
 // isFnCallCandidate reports whether syntax and local aliases permit any Rstest
 // registration kind at node.
 func (analysis *RstestCallAnalysis) isFnCallCandidate(node *ast.Node) bool {
 	if node == nil || node.Kind != ast.KindCallExpression {
 		return false
 	}
-	root := testFramework.ResolveFirstIdentifier(node.AsCallExpression().Expression)
+	root := analysis.firstIdentifier(node.AsCallExpression().Expression)
 	return root == nil ||
 		root.Kind != ast.KindIdentifier ||
 		analysis.candidates[root.AsIdentifier().Text]&rstestCandidateFn != 0
@@ -207,7 +268,7 @@ func (analysis *RstestCallAnalysis) isTestCandidate(node *ast.Node) bool {
 	if node == nil || node.Kind != ast.KindCallExpression {
 		return false
 	}
-	root := testFramework.ResolveFirstIdentifier(node.AsCallExpression().Expression)
+	root := analysis.firstIdentifier(node.AsCallExpression().Expression)
 	return root == nil ||
 		root.Kind != ast.KindIdentifier ||
 		analysis.candidates[root.AsIdentifier().Text]&rstestCandidateTest != 0
@@ -219,7 +280,7 @@ func (analysis *RstestCallAnalysis) isExpectCandidate(node *ast.Node) bool {
 	if node == nil || node.Kind != ast.KindCallExpression {
 		return false
 	}
-	root := testFramework.ResolveFirstIdentifier(node.AsCallExpression().Expression)
+	root := analysis.firstIdentifier(node.AsCallExpression().Expression)
 	return root == nil ||
 		root.Kind != ast.KindIdentifier ||
 		analysis.candidates[root.AsIdentifier().Text]&rstestCandidateExpect != 0
@@ -395,7 +456,7 @@ func (analysis *RstestCallAnalysis) collectVariableCandidates(
 		analysis.candidates[localName] |= rstestCandidateAll
 		return
 	}
-	root := testFramework.ResolveFirstIdentifier(initializer)
+	root := analysis.firstIdentifier(initializer)
 	if root != nil && root.Kind == ast.KindIdentifier {
 		*aliases = append(*aliases, rstestAliasCandidate{
 			localName: localName,

--- a/internal/plugins/rstest/utils/call_analysis_cache_test.go
+++ b/internal/plugins/rstest/utils/call_analysis_cache_test.go
@@ -1,12 +1,15 @@
 package utils
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/microsoft/TypeScript/tsc/shim/ast"
 	"github.com/microsoft/TypeScript/tsc/shim/core"
 	"github.com/microsoft/TypeScript/tsc/shim/parser"
 	"github.com/web-infra-dev/rslint/internal/rule"
+	testFramework "github.com/web-infra-dev/rslint/internal/utils/test_framework"
 )
 
 func parseAnalysisCacheFixture() *ast.SourceFile {
@@ -18,6 +21,128 @@ func parseAnalysisCacheFixture() *ast.SourceFile {
 		`test("case", () => {});`,
 		core.ScriptKindTS,
 	)
+}
+
+func TestRstestFirstIdentifierCacheMatchesUncached(t *testing.T) {
+	for _, expression := range []string{
+		`builder().step().step()`, `((builder)()).step()`,
+		"tag`value`.step()", `(ignored(), builder).step()`,
+		`builder[key()].step()`, `builder?.['step']?.()`,
+		`import.meta.rstest.expect(1).toBe(1)`, `(() => {})().step()`,
+		`(left && right).step()`, `(left ? a : b).step()`,
+		`(builder as any).step()`, `builder!.step()`,
+		`(builder satisfies Callable).step()`, `new Builder().step()`,
+	} {
+		t.Run(expression, func(t *testing.T) {
+			source := parser.ParseSourceFile(ast.SourceFileParseOptions{
+				FileName: "/chain.ts", Path: "/chain.ts",
+			}, expression+";", core.ScriptKindTS)
+			analysis := newRstestCallAnalysis(rule.RuleContext{SourceFile: source})
+			var visit func(*ast.Node)
+			visit = func(node *ast.Node) {
+				want := testFramework.ResolveFirstIdentifier(node)
+				if got := analysis.firstIdentifier(node); got != want {
+					t.Fatalf("kind %v: root = %p, want %p", node.Kind, got, want)
+				}
+				if got, ok := analysis.firstIdentifiers[node]; node.Kind != ast.KindIdentifier && (!ok || got != want) {
+					t.Fatalf("kind %v: cached root = (%p, %t), want (%p, true)", node.Kind, got, ok, want)
+				}
+				if got := analysis.firstIdentifier(node); got != want {
+					t.Fatal("cached lookup changed the result")
+				}
+				node.ForEachChild(func(child *ast.Node) bool { visit(child); return false })
+			}
+			visit(source.Node.AsNode())
+		})
+	}
+}
+
+func TestRstestOuterCallMatchesTopMost(t *testing.T) {
+	for _, expression := range []string{
+		`expect(1).toBe(1).then(done)`, `((expect(1)).toBe)(1)`,
+		`consume(expect(1).toBe(1))`, `object[expect(1).toBe(1)]()`,
+		`expect(expect(1).toBe(1)).toBe(1)`, `expect(1).to.be.ok`,
+		`expect?.(1)?.['toBe']?.(1)`, "expect(1).tag`value`",
+		`(0, expect(1)).toBe(1)`, `(expect(1) as any).toBe(1)`,
+		`expect(1)!.toBe(1)`, `(expect(1) satisfies Assertion).toBe(1)`,
+	} {
+		t.Run(expression, func(t *testing.T) {
+			source := parser.ParseSourceFile(ast.SourceFileParseOptions{
+				FileName: "/chain.ts", Path: "/chain.ts",
+			}, expression+";", core.ScriptKindTS)
+			var visit func(*ast.Node) bool
+			visit = func(node *ast.Node) bool {
+				if node.Kind == ast.KindCallExpression {
+					if got, want := hasOuterCallOnCallee(node), FindTopMostCallExpression(node) != node; got != want {
+						t.Fatalf("call at %d: outer = %t, want %t", node.Pos(), got, want)
+					}
+				}
+				return node.ForEachChild(visit)
+			}
+			source.Node.ForEachChild(visit)
+		})
+	}
+}
+
+func TestRstestFirstIdentifierCachesWholeChain(t *testing.T) {
+	for _, head := range []string{"builder()", "import.meta.rstest.expect(1)"} {
+		source := parser.ParseSourceFile(ast.SourceFileParseOptions{
+			FileName: "/chain.ts", Path: "/chain.ts",
+		}, `test("case", () => { `+head+strings.Repeat(".step()", 2000)+`; });`, core.ScriptKindTS)
+		analysis := newRstestCallAnalysis(rule.RuleContext{SourceFile: source})
+		outer := analysis.calls[1].AsCallExpression().Expression
+		want := testFramework.ResolveFirstIdentifier(outer)
+		analysis.firstIdentifier(outer)
+		count := len(analysis.firstIdentifiers)
+		for _, call := range analysis.calls[1:] {
+			expression := call.AsCallExpression().Expression
+			if expression.Kind == ast.KindIdentifier {
+				if got := analysis.firstIdentifier(expression); got != want {
+					t.Fatalf("identifier root = %p, want %p", got, want)
+				}
+				continue
+			}
+			if got, ok := analysis.firstIdentifiers[expression]; !ok || got != want {
+				t.Fatalf("child chain was not cached: (%p, %t), want (%p, true)", got, ok, want)
+			}
+			analysis.firstIdentifier(expression)
+		}
+		if len(analysis.firstIdentifiers) != count {
+			t.Fatal("inner calls repeated chain-head resolution")
+		}
+	}
+}
+
+func BenchmarkRstestCallAnalysisChains(b *testing.B) {
+	for _, kind := range []string{"ordinary", "extend", "expect"} {
+		for _, size := range []int{500, 1000, 2000} {
+			b.Run(fmt.Sprintf("%s/%d", kind, size), func(b *testing.B) {
+				var code string
+				switch kind {
+				case "ordinary":
+					code = `test("case", () => { builder()` + strings.Repeat(".step()", size) + `; });`
+				case "extend":
+					code = `test` + strings.Repeat(".extend({})", size) + `("case", () => {});`
+				case "expect":
+					code = `test("case", () => { expect(1)` + strings.Repeat(`.a("number")`, size) + `; });`
+				}
+				source := parser.ParseSourceFile(ast.SourceFileParseOptions{
+					FileName: "/chain.ts", Path: "/chain.ts",
+				}, code, core.ScriptKindTS)
+				b.ReportAllocs()
+				b.SetBytes(int64(len(code)))
+				b.ResetTimer()
+				for b.Loop() {
+					analysis := newRstestCallAnalysis(rule.RuleContext{SourceFile: source})
+					for _, call := range analysis.calls {
+						analysis.ParseFnCall(call)
+						analysis.ParseExpectCall(call)
+						analysis.IsExpectCall(call)
+					}
+				}
+			})
+		}
+	}
 }
 
 func TestGetRstestCallAnalysisSharesWithinFileCache(t *testing.T) {

--- a/internal/plugins/rstest/utils/parse_rstest_expect.go
+++ b/internal/plugins/rstest/utils/parse_rstest_expect.go
@@ -136,7 +136,7 @@ func isRstestExpectCall(
 	node *ast.Node,
 	analysis *RstestCallAnalysis,
 ) bool {
-	if node == nil || node.Kind != ast.KindCallExpression || FindTopMostCallExpression(node) != node {
+	if node == nil || node.Kind != ast.KindCallExpression || hasOuterCallOnCallee(node) {
 		return false
 	}
 	if isImportMetaRstestExpectCall(node) {
@@ -231,7 +231,7 @@ func parseRstestExpectCall(
 	node *ast.Node,
 	analysis *RstestCallAnalysis,
 ) *ParsedRstestExpectCall {
-	if node == nil || node.Kind != ast.KindCallExpression || FindTopMostCallExpression(node) != node {
+	if node == nil || node.Kind != ast.KindCallExpression || hasOuterCallOnCallee(node) {
 		return nil
 	}
 	expression := findTopMostRstestExpectExpression(node)
@@ -276,6 +276,27 @@ func ShouldRstestExpectBeAwaited(parsed *ParsedRstestExpectCall, asyncMatchers [
 		}
 	}
 	return slices.Contains(asyncMatchers, parsed.Matcher)
+}
+
+func hasOuterCallOnCallee(node *ast.Node) bool {
+	for parent := node.Parent; parent != nil; node, parent = parent, parent.Parent {
+		switch parent.Kind {
+		case ast.KindParenthesizedExpression:
+		case ast.KindCallExpression:
+			return parent.AsCallExpression().Expression == node
+		case ast.KindPropertyAccessExpression:
+			if parent.AsPropertyAccessExpression().Expression != node {
+				return false
+			}
+		case ast.KindElementAccessExpression:
+			if parent.AsElementAccessExpression().Expression != node {
+				return false
+			}
+		default:
+			return false
+		}
+	}
+	return false
 }
 
 // FindTopMostCallExpression walks up the call/member chain that node is the

--- a/internal/plugins/rstest/utils/parse_rstest_expect_source_only_test.go
+++ b/internal/plugins/rstest/utils/parse_rstest_expect_source_only_test.go
@@ -1,6 +1,7 @@
 package utils_test
 
 import (
+	"fmt"
 	"sort"
 	"testing"
 
@@ -12,10 +13,21 @@ import (
 	rstestUtils "github.com/web-infra-dev/rslint/internal/plugins/rstest/utils"
 	lintprogram "github.com/web-infra-dev/rslint/internal/program"
 	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
-func TestParseRstestExpectCallResolvesInSourceOnlyProgram(t *testing.T) {
+func TestParseRstestExpectCallResolvesAcrossProgramModes(t *testing.T) {
+	for _, typed := range []bool{false, true} {
+		for _, identityFirst := range []bool{false, true} {
+			t.Run(fmt.Sprintf("typed=%t/identityFirst=%t", typed, identityFirst), func(t *testing.T) {
+				testRstestExpectCallProgram(t, typed, identityFirst)
+			})
+		}
+	}
+}
+
+func testRstestExpectCallProgram(t *testing.T, typed, identityFirst bool) {
 	code := `
 expect(globalValue).toBe(1);
 
@@ -41,12 +53,24 @@ function localAssertion() {
 `
 
 	probe := rule.Rule{
-		Name: "rstest/source-only-expect-probe",
+		Name: "rstest/expect-cache-probe",
 		Run: func(ctx rule.RuleContext, _ []any) rule.RuleListeners {
 			analysis := rstestUtils.GetRstestCallAnalysis(ctx)
 			return rule.RuleListeners{
 				ast.KindCallExpression: func(node *ast.Node) {
-					parsed := analysis.ParseExpectCall(node)
+					var parsed *rstestUtils.ParsedRstestExpectCall
+					if identityFirst {
+						isExpect := analysis.IsExpectCall(node)
+						parsed = analysis.ParseExpectCall(node)
+						if isExpect != (parsed != nil) {
+							t.Fatalf("identity/full parse mismatch at %d", node.Pos())
+						}
+					} else {
+						parsed = analysis.ParseExpectCall(node)
+						if analysis.IsExpectCall(node) != (parsed != nil) {
+							t.Fatalf("full parse/identity mismatch at %d", node.Pos())
+						}
+					}
 					if parsed == nil || parsed.MatcherEntry == nil {
 						return
 					}
@@ -61,19 +85,34 @@ function localAssertion() {
 
 	root := fixtures.GetRootDir()
 	fileName := tspath.ResolvePath(root.Dir, "parse-rstest-expect-source-only.ts")
-	fs := utils.NewOverlayVFS(root.FS, map[string]string{fileName: code})
-	host := utils.CreateCompilerHost(root.Dir, fs)
-	sourceProgram, err := lintprogram.NewFromRoots(lintprogram.RootOptions{
-		RootFileNames:   []string{fileName},
-		Host:            host,
-		CompilerOptions: &core.CompilerOptions{Module: core.ModuleKindESNext},
-		SingleThreaded:  true,
-	})
-	if err != nil {
-		t.Fatalf("NewFromRoots: %v", err)
+	var sourceProgram *lintprogram.Program
+	if typed {
+		rawProgram, sourceFile, err := rule_tester.NewProgramHelper(root).CreateTestProgram(
+			code,
+			"parse-rstest-expect-source-only.ts",
+			"tsconfig.json",
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		sourceProgram = lintprogram.NewFromCompiler(rawProgram)
+		fileName = sourceFile.FileName()
+	} else {
+		fs := utils.NewOverlayVFS(root.FS, map[string]string{fileName: code})
+		host := utils.CreateCompilerHost(root.Dir, fs)
+		var err error
+		sourceProgram, err = lintprogram.NewFromRoots(lintprogram.RootOptions{
+			RootFileNames:   []string{fileName},
+			Host:            host,
+			CompilerOptions: &core.CompilerOptions{Module: core.ModuleKindESNext},
+			SingleThreaded:  true,
+		})
+		if err != nil {
+			t.Fatalf("NewFromRoots: %v", err)
+		}
 	}
-	if sourceProgram.CanProvideTypeChecker(sourceProgram.SourceFiles()[0]) {
-		t.Fatal("expected a source-only Program with no TypeChecker")
+	if got := sourceProgram.CanProvideTypeChecker(sourceProgram.GetSourceFile(fileName)); got != typed {
+		t.Fatalf("CanProvideTypeChecker = %t, want %t", got, typed)
 	}
 
 	lintPlan, err := linter.PrepareLintPlan(linter.PrepareLintPlanOptions{
@@ -82,8 +121,9 @@ function localAssertion() {
 		SingleThreaded:   true,
 		GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
 			return []rule.ConfiguredRule{{
-				Name:     probe.Name,
-				Severity: rule.SeverityError,
+				Name:             probe.Name,
+				Severity:         rule.SeverityError,
+				RequiresTypeInfo: typed,
 				Run: func(ctx rule.RuleContext) rule.RuleListeners {
 					return probe.Run(ctx, nil)
 				},

--- a/internal/plugins/rstest/utils/parse_rstest_fn.go
+++ b/internal/plugins/rstest/utils/parse_rstest_fn.go
@@ -68,6 +68,9 @@ func parseRstestFnCall(
 	}
 
 	call := node.AsCallExpression()
+	if isRstestFactoryCallee(call.Expression) {
+		return nil
+	}
 	root, parts, rootInvoked, ok := parseRstestChain(call.Expression)
 	var resolved rstestResolvedAPI
 	consumed := 0
@@ -169,6 +172,33 @@ func parseRstestFnCall(
 		parsed.focus = &rstestFocus{entries: resolved.focusEntries}
 	}
 	return parsed
+}
+
+func isRstestFactoryCallee(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	node = ast.SkipParentheses(node)
+	name := ""
+	switch node.Kind {
+	case ast.KindPropertyAccessExpression:
+		property := node.AsPropertyAccessExpression().Name()
+		if property != nil && property.Kind == ast.KindIdentifier {
+			name = property.AsIdentifier().Text
+		}
+	case ast.KindElementAccessExpression:
+		property := node.AsElementAccessExpression().ArgumentExpression
+		if property != nil {
+			name, _ = internalUtils.GetStaticStringLiteralValue(ast.SkipParentheses(property))
+		}
+	}
+	// These members require a factory invocation before a registration call.
+	switch name {
+	case "extend", "each", "for", "runIf", "skipIf":
+		return true
+	default:
+		return false
+	}
 }
 
 func parseRstestChain(node *ast.Node) (*ast.Node, []rstestChainPart, bool, bool) {

--- a/internal/plugins/rstest/utils/parse_rstest_hooks_test.go
+++ b/internal/plugins/rstest/utils/parse_rstest_hooks_test.go
@@ -1,5 +1,7 @@
 package utils_test
 
+// cspell:ignore xtend
+
 import (
 	"fmt"
 	"testing"
@@ -38,6 +40,38 @@ func parsedHookError(kind string, name string) []rule_tester.InvalidTestCaseErro
 		MessageId: "parsedFn",
 		Message:   fmt.Sprintf("kind=%s name=%s", kind, name),
 	}}
+}
+
+func TestParseRstestFnCallFactoryBoundaries(t *testing.T) {
+	var valid []rule_tester.ValidTestCase
+	var invalid []rule_tester.InvalidTestCase
+	for _, root := range []string{
+		`test`, `import.meta.rstest.test`,
+		`import { test as check } from '@rstest/core'; check`,
+		`import * as api from 'rstack/test'; api.test`,
+		`const { test: check } = require('@rstest/core'); check`,
+		`import { test } from '@rstest/playwright'; test`,
+	} {
+		for _, factory := range []string{
+			`.extend({})`, `.each([1])`, `.for([1])`, `.runIf(true)`, `.skipIf(false)`,
+			`['extend']({})`, `["\u0065xtend"]({})`, ".each`value\n${1}`",
+			`.extend({}).extend({})`, `?.extend?.({})`,
+		} {
+			valid = append(valid, rule_tester.ValidTestCase{Code: root + factory + `;`})
+			invalid = append(invalid, rule_tester.InvalidTestCase{
+				Code: root + factory + `('case', () => {});`, Errors: parsedHookError("test", "test"),
+			})
+		}
+	}
+	for _, code := range []string{
+		`(test.extend)({})('case', () => {});`,
+		`(0, test.extend({}))('case', () => {});`,
+		`const check = test.extend({}).extend({}); check('case', () => {});`,
+		`test.extend({}).only('case', () => {});`,
+	} {
+		invalid = append(invalid, rule_tester.InvalidTestCase{Code: code, Errors: parsedHookError("test", "test")})
+	}
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &hookParseProbe, valid, invalid)
 }
 
 func TestParseRstestFnCallHooks(t *testing.T) {

--- a/internal/plugins/rstest/utils/test_callback_candidate_test.go
+++ b/internal/plugins/rstest/utils/test_callback_candidate_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/microsoft/TypeScript/tsc/shim/ast"
+	"github.com/microsoft/TypeScript/tsc/shim/binder"
 	"github.com/microsoft/TypeScript/tsc/shim/core"
 	"github.com/microsoft/TypeScript/tsc/shim/parser"
 	"github.com/web-infra-dev/rslint/internal/rule"
@@ -118,6 +119,42 @@ func TestRstestCallAnalysisCallbacksWidenExpectCandidates(t *testing.T) {
 	analysis.Callbacks()
 	if !analysis.isExpectCandidate(checkCall) {
 		t.Fatal("callbacks did not add the context expect candidate")
+	}
+}
+
+func TestRstestCallAnalysisCachesDoNotFreezeContextCandidates(t *testing.T) {
+	for _, parseFirst := range []bool{false, true} {
+		source := parser.ParseSourceFile(ast.SourceFileParseOptions{
+			FileName: "/context.ts", Path: "/context.ts",
+		}, `test("case", ({ expect: check }) => { check(1).toBe(1); ordinary().step(); });`, core.ScriptKindTS)
+		binder.BindSourceFile(source)
+		analysis := newRstestCallAnalysis(rule.RuleContext{
+			SourceFile: source,
+			Refs:       rule.NewRefStore(source, &core.CompilerOptions{}, nil, rule.RefStoreInit{}),
+		})
+		call := analysis.calls[1]
+		if analysis.isExpectCandidate(call) {
+			t.Fatal("context alias unexpectedly indexed before callbacks")
+		}
+		if analysis.ParseFnCall(call) != nil {
+			t.Fatal("assertion parsed as registration")
+		}
+		if parseFirst {
+			if analysis.ParseExpectCall(call) == nil || !analysis.IsExpectCall(call) {
+				t.Fatal("full parse failed after caching the context chain head")
+			}
+		} else if !analysis.IsExpectCall(call) || analysis.ParseExpectCall(call) == nil {
+			t.Fatal("identity failed after caching the context chain head")
+		}
+		ordinary := analysis.calls[3]
+		for range 2 {
+			if analysis.ParseFnCall(ordinary) != nil || analysis.ParseExpectCall(ordinary) != nil || analysis.IsExpectCall(ordinary) {
+				t.Fatal("ordinary call passed candidate gates")
+			}
+		}
+		if _, ok := analysis.firstIdentifiers[ordinary.AsCallExpression().Expression]; !ok {
+			t.Fatal("missing negative candidate chain cache")
+		}
 	}
 }
 

--- a/internal/utils/test_framework/rules/expect_expect/expect_expect.go
+++ b/internal/utils/test_framework/rules/expect_expect/expect_expect.go
@@ -64,6 +64,10 @@ type Runtime struct {
 	// assertFunctionNames is configured without `expect`: the option names extra
 	// asserting calls, it does not hide the framework's own.
 	IsAssertion func(node *ast.Node) bool
+	// FirstIdentifier optionally reuses a framework adapter's file-level chain
+	// cache for the configured assertion-pattern candidate check. Adapters that leave
+	// it nil keep the framework-neutral syntax walk.
+	FirstIdentifier func(node *ast.Node) *ast.Node
 }
 
 type Config struct {
@@ -184,11 +188,19 @@ func (matcher assertMatcher) matches(name string) bool {
 // looking only at its first identifier. It is deliberately conservative: a
 // dynamic root, non-ASCII root, or any non-literal pattern falls back to the
 // full callee-name construction and regexp match.
-func (matcher assertMatcher) mayMatchCallee(expr *ast.Node) bool {
+func (matcher assertMatcher) mayMatchCallee(
+	expr *ast.Node,
+	firstIdentifier func(*ast.Node) *ast.Node,
+) bool {
 	if matcher.hasFallback {
 		return true
 	}
-	root := testFramework.ResolveFirstIdentifier(expr)
+	root := (*ast.Node)(nil)
+	if firstIdentifier != nil {
+		root = firstIdentifier(expr)
+	} else {
+		root = testFramework.ResolveFirstIdentifier(expr)
+	}
 	if root == nil || root.Kind != ast.KindIdentifier {
 		return true
 	}
@@ -424,7 +436,7 @@ func NewRule(config Config) rule.Rule {
 					// whatever the framework can resolve; patterns run first because
 					// they answer the overwhelmingly common bare `expect(...)`
 					// without touching the framework analysis.
-					if calleeName == "" && matcher.mayMatchCallee(callExpr.Expression) {
+					if calleeName == "" && matcher.mayMatchCallee(callExpr.Expression, runtime.FirstIdentifier) {
 						calleeName = testFramework.CalleeChainName(callExpr.Expression)
 					}
 					if !matcher.matches(calleeName) &&


### PR DESCRIPTION
## Motivation

Rstest call analysis checks the first identifier of each call expression before consulting its parse caches. In a nested call chain such as:

```ts
builder().step().step().step();
```

each inner call walks back through the chain again, making candidate filtering quadratic in the chain length.

Expect parsing has a similar repeated upward walk when determining whether each call is the outermost call in its callee chain. Rstest registration factory chains such as repeated `test.extend({})` also fully parse factory calls that cannot themselves be final registrations.

## Changes

- Cache expression-to-first-identifier resolution in `RstestCallAnalysis`, including negative results.
- Reuse the cache from `ParseFnCall`, `ParseExpectCall`, `IsExpectCall`, alias collection, and the Rstest `expect-expect` candidate gate.
- Avoid allocating the cache for ordinary unchained identifier calls.
- Replace repeated top-most expect-call searches with an outer-callee-call existence check.
- Reject `.extend()`, `.each()`, `.for()`, `.runIf()`, and `.skipIf()` factory invocations before full registration parsing.
- Add regression coverage for aliases, TestContext expect, `import.meta.rstest`, source-only and type-aware programs, static accessors, optional chains, and factory boundaries.

## Performance

Measurements use `--timing all --singleThreaded`, one warmup, and three interleaved runs per version. The table reports median total rule execution time for the Rstest recommended preset.

| Scenario | Size | Before | After |
| --- | ---: | ---: | ---: |
| Ordinary non-Rstest chain | 500 | 18.6 ms | 0.2 ms |
| Ordinary non-Rstest chain | 1,000 | 74.3 ms | 0.5 ms |
| Ordinary non-Rstest chain | 2,000 | 290.6 ms | 1.7 ms |
| Rstest `extend` chain | 500 | 31.3 ms | 0.4 ms |
| Rstest `extend` chain | 1,000 | 122.5 ms | 0.7 ms |
| Rstest `extend` chain | 2,000 | 472.1 ms | 1.6 ms |
| Ordinary tests | 1,000 | 2.9 ms | 2.8 ms |
| Ordinary tests | 2,000 | 5.7 ms | 5.7 ms |
| Ordinary tests | 4,000 | 12.1 ms | 12.0 ms |

The ordinary and `extend` chain benchmarks change from quadratic growth to approximately linear growth.

Seven interleaved timing runs across the six-repository fixture produced:

| Repository | Before | After |
| --- | ---: | ---: |
| rspack | 3.5 ms | 3.6 ms |
| rsbuild | 16.7 ms | 17.3 ms |
| rslib | 6.8 ms | 6.8 ms |
| rspress | 10.3 ms | 10.9 ms |
| rsdoctor | 6.9 ms | 7.3 ms |
| rstest | 50.8 ms | 50.2 ms |

All synthetic and repository runs produced identical diagnostics.
