### PR TITLE
feat(rstest): add prefer-to-contain rule

### DIFF
--- a/internal/plugins/jest/rules/prefer_to_contain/prefer_to_contain.go
+++ b/internal/plugins/jest/rules/prefer_to_contain/prefer_to_contain.go
@@ -1,168 +1,58 @@
 package prefer_to_contain
 
 import (
-	"slices"
 	"strings"
 
 	"github.com/microsoft/TypeScript/tsc/shim/ast"
 	"github.com/microsoft/TypeScript/tsc/shim/core"
 	jestUtils "github.com/web-infra-dev/rslint/internal/plugins/jest/utils"
 	"github.com/web-infra-dev/rslint/internal/rule"
-	rslintUtils "github.com/web-infra-dev/rslint/internal/utils"
+	"github.com/web-infra-dev/rslint/internal/utils"
+	testFramework "github.com/web-infra-dev/rslint/internal/utils/test_framework"
+	shared "github.com/web-infra-dev/rslint/internal/utils/test_framework/rules/prefer_to_contain"
 )
 
-// Message Builder
+func buildFixes(ctx rule.RuleContext, matched shared.Match) []rule.RuleFix {
+	chain := make([]string, 0, len(matched.Expect.Modifiers)+1)
+	for _, modifier := range matched.Expect.Modifiers {
+		if modifier.Name != "not" {
+			chain = append(chain, modifier.Name)
+		}
+	}
+	if matched.ShouldHaveNot {
+		chain = append(chain, "not")
+	}
+	chain = append(chain, "toContain")
 
-func buildUseToContainErrorMessage() rule.RuleMessage {
-	return rule.RuleMessage{
-		Id:          "useToContain",
-		Description: "Use toContain() instead",
+	return []rule.RuleFix{
+		rule.RuleFixReplace(ctx.SourceFile, matched.IncludesCall, utils.TrimmedNodeText(ctx.SourceFile, matched.Receiver)),
+		rule.RuleFixReplaceRange(core.NewTextRange(matched.Expect.HeadCall.End(), matched.Expect.MatcherCall.AsCallExpression().Expression.End()), "."+strings.Join(chain, ".")),
+		rule.RuleFixReplace(ctx.SourceFile, matched.MatcherValue, utils.TrimmedNodeText(ctx.SourceFile, matched.Item)),
 	}
 }
 
-func getIncludesCalleeName(callee *ast.Node) (receiver *ast.Node, ok bool) {
-	if callee == nil {
-		return nil, false
-	}
-	switch callee.Kind {
-	case ast.KindPropertyAccessExpression:
-		prop := callee.AsPropertyAccessExpression()
-		if !jestUtils.IsNamedMember(prop.Name(), "includes") {
-			return nil, false
-		}
-
-		return prop.Expression, true
-	case ast.KindElementAccessExpression:
-		el := callee.AsElementAccessExpression()
-		arg := ast.SkipParentheses(el.ArgumentExpression)
-		if arg == nil {
-			return nil, false
-		}
-		if !jestUtils.IsNamedMember(arg, "includes") {
-			return nil, false
-		}
-		return el.Expression, true
-	}
-
-	return nil, false
-}
-
-var PreferToContainRule = rule.Rule{
-	Name:   "jest/prefer-to-contain",
-	Schema: rule.EmptyArraySchema,
-	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
-		return rule.RuleListeners{
-			ast.KindCallExpression: func(node *ast.Node) {
-				jestFnCall := jestUtils.ParseJestFnCall(node, ctx)
-				if jestFnCall == nil || jestFnCall.Kind != jestUtils.JestFnTypeExpect || len(jestFnCall.Members) == 0 {
-					return
-				}
-
-				lastMember := jestFnCall.Members[len(jestFnCall.Members)-1]
-				if !jestUtils.EQUALITY_METHOD_NAMES[lastMember] {
-					return
-				}
-
-				expectCall := jestFnCall.Head.Local.Node.Parent
-				if expectCall == nil || expectCall.Kind != ast.KindCallExpression {
-					return
-				}
-
-				expectArgs := expectCall.Arguments()
-				if len(expectArgs) == 0 {
-					return
-				}
-
-				includesCall := ast.SkipParentheses(expectArgs[0])
-				if includesCall == nil || includesCall.Kind != ast.KindCallExpression {
-					return
-				}
-
-				includesExpr := includesCall.AsCallExpression()
-				receiver, ok := getIncludesCalleeName(includesExpr.Expression)
-				if !ok || includesExpr.Arguments == nil || len(includesExpr.Arguments.Nodes) != 1 {
-					return
-				}
-
-				includesArg := includesExpr.Arguments.Nodes[0]
-				if includesArg.Kind == ast.KindSpreadElement {
-					return
-				}
-
-				matcherCall := node.AsCallExpression()
-				if matcherCall.Arguments == nil || len(matcherCall.Arguments.Nodes) != 1 {
-					return
-				}
-
-				matcherArg := matcherCall.Arguments.Nodes[0]
-				if matcherArg.Kind == ast.KindSpreadElement {
-					return
-				}
-
-				unwrapped := jestUtils.UnwrapTypeAssertions(matcherArg)
-				if unwrapped == nil {
-					return
-				}
-
-				var isTrueLiteral bool
-				switch unwrapped.Kind {
-				case ast.KindTrueKeyword:
-					isTrueLiteral = true
-				case ast.KindFalseKeyword:
-				default:
-					return
-				}
-
-				hasNotModifier := slices.Contains(jestFnCall.Modifiers, "not")
-				shouldNegate := isTrueLiteral == hasNotModifier
-				if jestUtils.ReceiverBeforeInvocation(node) == nil {
-					return
-				}
-
-				sourceFile := ctx.SourceFile
-				receiverText := rslintUtils.TrimmedNodeText(sourceFile, receiver)
-				includesArgText := rslintUtils.TrimmedNodeText(sourceFile, includesArg)
-
-				// Preserve non-`not` modifiers (e.g. `resolves`, `rejects`) so the
-				// asynchronous semantics of the original matcher chain are kept.
-				var chainParts []string
-				for _, modifier := range jestFnCall.Modifiers {
-					if modifier == "not" {
-						continue
-					}
-					chainParts = append(chainParts, modifier)
-				}
-				if shouldNegate {
-					chainParts = append(chainParts, "not")
-				}
-				chainParts = append(chainParts, "toContain")
-				chainReplacement := "." + strings.Join(chainParts, ".")
-
-				reportNode := node
-				if n := len(jestFnCall.MemberEntries); n > 0 {
-					if entry := jestFnCall.MemberEntries[n-1].Node; entry != nil {
-						reportNode = entry
-					}
-				}
-
-				ctx.ReportNodeWithFixes(
-					reportNode,
-					buildUseToContainErrorMessage(),
-					// Replace the `.includes(...)` argument of `expect(...)` with the
-					// receiver, preserving the surrounding `expect(<callee>, ...)` tokens
-					// (including any trailing comma after the first argument).
-					rule.RuleFixReplace(sourceFile, expectArgs[0], receiverText),
-					// Normalize the matcher chain (e.g. `.not.toEqual`, `['toEqual']`,
-					// `['not'].toEqual`) into `.toContain` or `.not.toContain`.
-					rule.RuleFixReplaceRange(
-						core.NewTextRange(expectCall.End(), matcherCall.Expression.End()),
-						chainReplacement,
-					),
-					// Replace the matcher's boolean argument with the original
-					// `.includes` argument, preserving trailing commas/whitespace.
-					rule.RuleFixReplace(sourceFile, matcherArg, includesArgText),
-				)
-			},
-		}
+var PreferToContainRule = shared.NewRule(shared.Config{
+	Name: "jest/prefer-to-contain",
+	Prepare: func(ctx rule.RuleContext) shared.Runtime {
+		return shared.Runtime{Parse: func(node *ast.Node) *shared.ExpectCall {
+			parsed := jestUtils.ParseJestFnCall(node, ctx)
+			if parsed == nil || parsed.Kind != jestUtils.JestFnTypeExpect || parsed.MatcherEntry == nil ||
+				testFramework.IsComputedIdentifierAccessor(parsed.MatcherEntry.Node) {
+				return nil
+			}
+			matcherCall := testFramework.InvokedAccessorCall(parsed.MatcherEntry)
+			if matcherCall == nil {
+				return nil
+			}
+			headCall := parsed.Head.Local.Node.Parent
+			if headCall == nil || headCall.Kind != ast.KindCallExpression {
+				return nil
+			}
+			return &shared.ExpectCall{
+				HeadCall: headCall, MatcherCall: matcherCall, MatcherEntry: *parsed.MatcherEntry,
+				Matcher: parsed.Matcher, Modifiers: parsed.ModifierEntries,
+			}
+		}}
 	},
-}
+	BuildFixes: buildFixes,
+})

--- a/internal/plugins/rstest/all.go
+++ b/internal/plugins/rstest/all.go
@@ -50,6 +50,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/prefer_to_be"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/prefer_to_be_falsy"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/prefer_to_be_truthy"
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/prefer_to_contain"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/prefer_todo"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/require_awaited_expect_poll"
 	"github.com/web-infra-dev/rslint/internal/plugins/rstest/rules/require_local_test_context_for_concurrent_snapshots"
@@ -114,6 +115,7 @@ func GetAllRules() []rule.Rule {
 		prefer_to_be.PreferToBeRule,
 		prefer_to_be_falsy.PreferToBeFalsyRule,
 		prefer_to_be_truthy.PreferToBeTruthyRule,
+		prefer_to_contain.PreferToContainRule,
 		prefer_todo.PreferTodoRule,
 		require_awaited_expect_poll.RequireAwaitedExpectPollRule,
 		require_local_test_context_for_concurrent_snapshots.RequireLocalTestContextForConcurrentSnapshotsRule,

--- a/internal/plugins/rstest/rules/prefer_to_contain/prefer_to_contain.go
+++ b/internal/plugins/rstest/rules/prefer_to_contain/prefer_to_contain.go
@@ -67,7 +67,7 @@ func isSafeToMove(node *ast.Node) bool {
 		return true
 	case ast.KindPrefixUnaryExpression:
 		unary := node.AsPrefixUnaryExpression()
-		return unary != nil && unary.Operator != ast.KindPlusPlusToken && unary.Operator != ast.KindMinusMinusToken &&
+		return unary != nil && unary.Operator == ast.KindExclamationToken &&
 			isSafeToMove(unary.Operand)
 	case ast.KindArrayLiteralExpression:
 		array := node.AsArrayLiteralExpression()

--- a/internal/plugins/rstest/rules/prefer_to_contain/prefer_to_contain.go
+++ b/internal/plugins/rstest/rules/prefer_to_contain/prefer_to_contain.go
@@ -9,14 +9,80 @@ import (
 	shared "github.com/web-infra-dev/rslint/internal/utils/test_framework/rules/prefer_to_contain"
 )
 
-func isGlobalIdentifier(ctx rule.RuleContext, node *ast.Node, name string) bool {
+func isUnshadowedRuntimeGlobal(ctx rule.RuleContext, node *ast.Node, name string) bool {
 	if node == nil || node.Kind != ast.KindIdentifier || node.AsIdentifier().Text != name {
 		return false
 	}
 	if ctx.Refs != nil {
-		return ctx.Refs.IsGlobalNameReference(node, name, ast.SymbolFlagsValue|ast.SymbolFlagsAlias)
+		return ctx.Refs.ResolveInFileWithMeaning(node, ast.SymbolFlagsValue|ast.SymbolFlagsAlias) == nil &&
+			!ctx.Refs.HasImplicitWrapperBinding(name)
 	}
 	return !utils.IsShadowed(node, name)
+}
+
+type nanGlobalWritesCacheKey struct{}
+
+func nanGlobalWrites(ctx rule.RuleContext) map[string]bool {
+	return rule.CachedByFile(ctx, nanGlobalWritesCacheKey{}, func() map[string]bool {
+		writes := map[string]bool{}
+		if ctx.SourceFile == nil {
+			return writes
+		}
+		var visit func(*ast.Node)
+		visit = func(node *ast.Node) {
+			if node == nil {
+				return
+			}
+			if node.Kind == ast.KindIdentifier {
+				name := node.AsIdentifier().Text
+				if name == "Number" || name == "globalThis" {
+					affected := nanGlobalsWrittenFrom(node)
+					if len(affected) > 0 && isUnshadowedRuntimeGlobal(ctx, node, name) {
+						for _, globalName := range affected {
+							writes[globalName] = true
+						}
+					}
+				}
+			}
+			node.ForEachChild(func(child *ast.Node) bool {
+				visit(child)
+				return false
+			})
+		}
+		visit(ctx.SourceFile.AsNode())
+		return writes
+	})
+}
+
+func nanGlobalsWrittenFrom(node *ast.Node) []string {
+	if utils.IsWriteReference(node) {
+		return []string{node.AsIdentifier().Text}
+	}
+	current := node
+	for current.Parent != nil && ast.IsOuterExpression(current.Parent, ast.OEKAll) {
+		current = current.Parent
+	}
+	path := []string{node.AsIdentifier().Text}
+	for current.Parent != nil && ast.IsAccessExpression(current.Parent) &&
+		utils.AccessExpressionObject(current.Parent) == current {
+		access := current.Parent
+		name, ok := utils.AccessExpressionStaticName(access)
+		if !ok {
+			return nil
+		}
+		path = append(path, name)
+		current = access
+		for current.Parent != nil && ast.IsOuterExpression(current.Parent, ast.OEKAll) {
+			current = current.Parent
+		}
+	}
+	if !ast.IsAssignmentTarget(current) {
+		return nil
+	}
+	if len(path) == 2 && path[0] == "globalThis" && path[1] == "Number" {
+		return []string{"Number"}
+	}
+	return nil
 }
 
 func isExplicitNaN(ctx rule.RuleContext, node *ast.Node) bool {
@@ -25,7 +91,7 @@ func isExplicitNaN(ctx rule.RuleContext, node *ast.Node) bool {
 		return false
 	}
 	if node.Kind == ast.KindIdentifier {
-		return isGlobalIdentifier(ctx, node, "NaN")
+		return isUnshadowedRuntimeGlobal(ctx, node, "NaN")
 	}
 	var receiver *ast.Node
 	switch node.Kind {
@@ -51,7 +117,8 @@ func isExplicitNaN(ctx rule.RuleContext, node *ast.Node) bool {
 		return false
 	}
 	name := receiver.AsIdentifier().Text
-	return (name == "Number" || name == "globalThis") && isGlobalIdentifier(ctx, receiver, name)
+	return (name == "Number" || name == "globalThis") &&
+		isUnshadowedRuntimeGlobal(ctx, receiver, name) && !nanGlobalWrites(ctx)[name]
 }
 
 func shouldIgnoreRegexpItem(receiver, item *ast.Node) bool {

--- a/internal/plugins/rstest/rules/prefer_to_contain/prefer_to_contain.go
+++ b/internal/plugins/rstest/rules/prefer_to_contain/prefer_to_contain.go
@@ -48,7 +48,9 @@ func isKnownStringRegexpDifference(receiver, item *ast.Node) bool {
 	receiver = testFramework.FollowTypeAssertionChain(receiver)
 	item = testFramework.FollowTypeAssertionChain(item)
 	return receiver != nil && item != nil &&
-		(receiver.Kind == ast.KindStringLiteral || receiver.Kind == ast.KindNoSubstitutionTemplateLiteral) &&
+		(receiver.Kind == ast.KindStringLiteral ||
+			receiver.Kind == ast.KindNoSubstitutionTemplateLiteral ||
+			receiver.Kind == ast.KindTemplateExpression) &&
 		item.Kind == ast.KindRegularExpressionLiteral
 }
 

--- a/internal/plugins/rstest/rules/prefer_to_contain/prefer_to_contain.go
+++ b/internal/plugins/rstest/rules/prefer_to_contain/prefer_to_contain.go
@@ -21,71 +21,6 @@ func isUnshadowedRuntimeGlobal(ctx rule.RuleContext, node *ast.Node, name string
 	return !utils.IsShadowed(node, name)
 }
 
-type nanGlobalWritesCacheKey struct{}
-
-func nanGlobalWrites(ctx rule.RuleContext) map[string]bool {
-	return rule.CachedByFile(ctx, nanGlobalWritesCacheKey{}, func() map[string]bool {
-		writes := map[string]bool{}
-		if ctx.SourceFile == nil {
-			return writes
-		}
-		var visit func(*ast.Node)
-		visit = func(node *ast.Node) {
-			if node == nil {
-				return
-			}
-			if node.Kind == ast.KindIdentifier {
-				name := node.AsIdentifier().Text
-				if name == "Number" || name == "globalThis" {
-					affected := nanGlobalsWrittenFrom(node)
-					if len(affected) > 0 && isUnshadowedRuntimeGlobal(ctx, node, name) {
-						for _, globalName := range affected {
-							writes[globalName] = true
-						}
-					}
-				}
-			}
-			node.ForEachChild(func(child *ast.Node) bool {
-				visit(child)
-				return false
-			})
-		}
-		visit(ctx.SourceFile.AsNode())
-		return writes
-	})
-}
-
-func nanGlobalsWrittenFrom(node *ast.Node) []string {
-	if utils.IsWriteReference(node) {
-		return []string{node.AsIdentifier().Text}
-	}
-	current := node
-	for current.Parent != nil && ast.IsOuterExpression(current.Parent, ast.OEKAll) {
-		current = current.Parent
-	}
-	path := []string{node.AsIdentifier().Text}
-	for current.Parent != nil && ast.IsAccessExpression(current.Parent) &&
-		utils.AccessExpressionObject(current.Parent) == current {
-		access := current.Parent
-		name, ok := utils.AccessExpressionStaticName(access)
-		if !ok {
-			return nil
-		}
-		path = append(path, name)
-		current = access
-		for current.Parent != nil && ast.IsOuterExpression(current.Parent, ast.OEKAll) {
-			current = current.Parent
-		}
-	}
-	if !ast.IsAssignmentTarget(current) {
-		return nil
-	}
-	if len(path) == 2 && path[0] == "globalThis" && path[1] == "Number" {
-		return []string{"Number"}
-	}
-	return nil
-}
-
 func isExplicitNaN(ctx rule.RuleContext, node *ast.Node) bool {
 	node = testFramework.FollowTypeAssertionChain(node)
 	if node == nil {
@@ -119,7 +54,7 @@ func isExplicitNaN(ctx rule.RuleContext, node *ast.Node) bool {
 	}
 	name := receiver.AsIdentifier().Text
 	return (name == "Number" || name == "globalThis") &&
-		isUnshadowedRuntimeGlobal(ctx, receiver, name) && !nanGlobalWrites(ctx)[name]
+		isUnshadowedRuntimeGlobal(ctx, receiver, name)
 }
 
 func shouldIgnoreRegexpItem(receiver, item *ast.Node) bool {

--- a/internal/plugins/rstest/rules/prefer_to_contain/prefer_to_contain.go
+++ b/internal/plugins/rstest/rules/prefer_to_contain/prefer_to_contain.go
@@ -29,28 +29,16 @@ func isExplicitNaN(ctx rule.RuleContext, node *ast.Node) bool {
 	if node.Kind == ast.KindIdentifier {
 		return isUnshadowedRuntimeGlobal(ctx, node, "NaN")
 	}
-	var receiver *ast.Node
-	switch node.Kind {
-	case ast.KindPropertyAccessExpression:
-		property := node.AsPropertyAccessExpression()
-		name := property.Name()
-		if name == nil || name.Kind != ast.KindIdentifier || name.AsIdentifier().Text != "NaN" {
-			return false
-		}
-		receiver = property.Expression
-	case ast.KindElementAccessExpression:
-		element := node.AsElementAccessExpression()
-		key := ast.SkipParentheses(element.ArgumentExpression)
-		if key == nil || key.Kind != ast.KindStringLiteral || key.AsStringLiteral().Text != "NaN" {
-			return false
-		}
-		receiver = element.Expression
-	default:
+	if name, ok := utils.AccessExpressionStaticName(node); !ok || name != "NaN" {
 		return false
 	}
-	receiver = ast.SkipParentheses(receiver)
+	receiver := testFramework.FollowTypeAssertionChain(utils.AccessExpressionObject(node))
 	if receiver == nil || receiver.Kind != ast.KindIdentifier {
-		return false
+		if name, ok := utils.AccessExpressionStaticName(receiver); !ok || name != "Number" {
+			return false
+		}
+		receiver = testFramework.FollowTypeAssertionChain(utils.AccessExpressionObject(receiver))
+		return isUnshadowedRuntimeGlobal(ctx, receiver, "globalThis")
 	}
 	name := receiver.AsIdentifier().Text
 	return (name == "Number" || name == "globalThis") &&

--- a/internal/plugins/rstest/rules/prefer_to_contain/prefer_to_contain.go
+++ b/internal/plugins/rstest/rules/prefer_to_contain/prefer_to_contain.go
@@ -9,13 +9,23 @@ import (
 	shared "github.com/web-infra-dev/rslint/internal/utils/test_framework/rules/prefer_to_contain"
 )
 
-func isExplicitNaN(node *ast.Node) bool {
+func isGlobalIdentifier(ctx rule.RuleContext, node *ast.Node, name string) bool {
+	if node == nil || node.Kind != ast.KindIdentifier || node.AsIdentifier().Text != name {
+		return false
+	}
+	if ctx.Refs != nil {
+		return ctx.Refs.IsGlobalNameReference(node, name, ast.SymbolFlagsValue|ast.SymbolFlagsAlias)
+	}
+	return !utils.IsShadowed(node, name)
+}
+
+func isExplicitNaN(ctx rule.RuleContext, node *ast.Node) bool {
 	node = testFramework.FollowTypeAssertionChain(node)
 	if node == nil {
 		return false
 	}
 	if node.Kind == ast.KindIdentifier {
-		return node.AsIdentifier().Text == "NaN"
+		return isGlobalIdentifier(ctx, node, "NaN")
 	}
 	var receiver *ast.Node
 	switch node.Kind {
@@ -41,7 +51,7 @@ func isExplicitNaN(node *ast.Node) bool {
 		return false
 	}
 	name := receiver.AsIdentifier().Text
-	return name == "Number" || name == "globalThis"
+	return (name == "Number" || name == "globalThis") && isGlobalIdentifier(ctx, receiver, name)
 }
 
 func isKnownStringRegexpDifference(receiver, item *ast.Node) bool {
@@ -150,11 +160,11 @@ var PreferToContainRule = shared.NewRule(shared.Config{
 			}
 		}}
 	},
-	IgnoreMatch: func(_ rule.RuleContext, matched shared.Match) bool {
+	IgnoreMatch: func(ctx rule.RuleContext, matched shared.Match) bool {
 		// Array.prototype.includes uses SameValueZero, while Rstest's current
 		// Vitest matcher layer delegates array containment to indexOf. Rewriting
 		// an explicit NaN would therefore reverse a passing assertion.
-		return isExplicitNaN(matched.Item) || isKnownStringRegexpDifference(matched.Receiver, matched.Item)
+		return isExplicitNaN(ctx, matched.Item) || isKnownStringRegexpDifference(matched.Receiver, matched.Item)
 	},
 	BuildFixes: func(ctx rule.RuleContext, matched shared.Match) []rule.RuleFix {
 		if !isSafeToMove(matched.Item) {

--- a/internal/plugins/rstest/rules/prefer_to_contain/prefer_to_contain.go
+++ b/internal/plugins/rstest/rules/prefer_to_contain/prefer_to_contain.go
@@ -188,13 +188,7 @@ func isSafeToMove(node *ast.Node) bool {
 }
 
 func isSafePropertyName(node *ast.Node) bool {
-	if node == nil {
-		return false
-	}
-	if node.Kind != ast.KindComputedPropertyName {
-		return true
-	}
-	return isSafeToMove(node.AsComputedPropertyName().Expression)
+	return node != nil && node.Kind != ast.KindComputedPropertyName
 }
 
 var PreferToContainRule = shared.NewRule(shared.Config{

--- a/internal/plugins/rstest/rules/prefer_to_contain/prefer_to_contain.go
+++ b/internal/plugins/rstest/rules/prefer_to_contain/prefer_to_contain.go
@@ -1,0 +1,173 @@
+package prefer_to_contain
+
+import (
+	"github.com/microsoft/TypeScript/tsc/shim/ast"
+	rstestUtils "github.com/web-infra-dev/rslint/internal/plugins/rstest/utils"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+	testFramework "github.com/web-infra-dev/rslint/internal/utils/test_framework"
+	shared "github.com/web-infra-dev/rslint/internal/utils/test_framework/rules/prefer_to_contain"
+)
+
+func isExplicitNaN(node *ast.Node) bool {
+	node = testFramework.FollowTypeAssertionChain(node)
+	if node == nil {
+		return false
+	}
+	if node.Kind == ast.KindIdentifier {
+		return node.AsIdentifier().Text == "NaN"
+	}
+	var receiver *ast.Node
+	switch node.Kind {
+	case ast.KindPropertyAccessExpression:
+		property := node.AsPropertyAccessExpression()
+		name := property.Name()
+		if name == nil || name.Kind != ast.KindIdentifier || name.AsIdentifier().Text != "NaN" {
+			return false
+		}
+		receiver = property.Expression
+	case ast.KindElementAccessExpression:
+		element := node.AsElementAccessExpression()
+		key := ast.SkipParentheses(element.ArgumentExpression)
+		if key == nil || key.Kind != ast.KindStringLiteral || key.AsStringLiteral().Text != "NaN" {
+			return false
+		}
+		receiver = element.Expression
+	default:
+		return false
+	}
+	receiver = ast.SkipParentheses(receiver)
+	if receiver == nil || receiver.Kind != ast.KindIdentifier {
+		return false
+	}
+	name := receiver.AsIdentifier().Text
+	return name == "Number" || name == "globalThis"
+}
+
+func isKnownStringRegexpDifference(receiver, item *ast.Node) bool {
+	receiver = testFramework.FollowTypeAssertionChain(receiver)
+	item = testFramework.FollowTypeAssertionChain(item)
+	return receiver != nil && item != nil &&
+		(receiver.Kind == ast.KindStringLiteral || receiver.Kind == ast.KindNoSubstitutionTemplateLiteral) &&
+		item.Kind == ast.KindRegularExpressionLiteral
+}
+
+func isSafeToMove(node *ast.Node) bool {
+	node = testFramework.FollowTypeAssertionChain(node)
+	if node == nil {
+		return false
+	}
+	switch node.Kind {
+	case ast.KindIdentifier, ast.KindThisKeyword, ast.KindSuperKeyword,
+		ast.KindStringLiteral, ast.KindNoSubstitutionTemplateLiteral,
+		ast.KindNumericLiteral, ast.KindBigIntLiteral, ast.KindRegularExpressionLiteral,
+		ast.KindTrueKeyword, ast.KindFalseKeyword, ast.KindNullKeyword:
+		return true
+	case ast.KindPrefixUnaryExpression:
+		unary := node.AsPrefixUnaryExpression()
+		return unary != nil && unary.Operator != ast.KindPlusPlusToken && unary.Operator != ast.KindMinusMinusToken &&
+			isSafeToMove(unary.Operand)
+	case ast.KindArrayLiteralExpression:
+		array := node.AsArrayLiteralExpression()
+		if array == nil {
+			return false
+		}
+		for _, element := range array.Elements.Nodes {
+			if element.Kind == ast.KindSpreadElement || !isSafeToMove(element) {
+				return false
+			}
+		}
+		return true
+	case ast.KindObjectLiteralExpression:
+		object := node.AsObjectLiteralExpression()
+		if object == nil {
+			return false
+		}
+		for _, property := range object.Properties.Nodes {
+			switch property.Kind {
+			case ast.KindPropertyAssignment:
+				assignment := property.AsPropertyAssignment()
+				if assignment == nil || !isSafePropertyName(assignment.Name()) || !isSafeToMove(assignment.Initializer) {
+					return false
+				}
+			case ast.KindShorthandPropertyAssignment:
+				shorthand := property.AsShorthandPropertyAssignment()
+				if shorthand == nil || shorthand.ObjectAssignmentInitializer != nil || !isSafeToMove(shorthand.Name()) {
+					return false
+				}
+			default:
+				return false
+			}
+		}
+		return true
+	default:
+		return false
+	}
+}
+
+func isSafePropertyName(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	if node.Kind != ast.KindComputedPropertyName {
+		return true
+	}
+	return isSafeToMove(node.AsComputedPropertyName().Expression)
+}
+
+var PreferToContainRule = shared.NewRule(shared.Config{
+	Name: "rstest/prefer-to-contain",
+	Prepare: func(ctx rule.RuleContext) shared.Runtime {
+		analysis := rstestUtils.GetRstestCallAnalysis(ctx)
+		return shared.Runtime{Parse: func(node *ast.Node) *shared.ExpectCall {
+			parsed := analysis.ParseExpectCall(node)
+			if parsed == nil ||
+				parsed.Reason != rstestUtils.RstestExpectParseReasonNone ||
+				parsed.Head == nil ||
+				(parsed.Entry != rstestUtils.RstestExpectEntryCall && parsed.Entry != rstestUtils.RstestExpectEntrySoft) ||
+				parsed.MatcherEntry == nil ||
+				len(parsed.Matchers) == 0 ||
+				parsed.Matchers[0].Kind != rstestUtils.RstestExpectMatcherCall ||
+				testFramework.IsComputedIdentifierAccessor(parsed.MatcherEntry.Node) {
+				return nil
+			}
+
+			for _, modifier := range parsed.Modifiers {
+				if modifier == "resolves" || modifier == "rejects" {
+					return nil
+				}
+			}
+
+			matcherCall := testFramework.InvokedAccessorCall(parsed.MatcherEntry)
+			if matcherCall == nil {
+				return nil
+			}
+			return &shared.ExpectCall{
+				HeadCall: parsed.Head, MatcherCall: matcherCall, MatcherEntry: *parsed.MatcherEntry,
+				Matcher: parsed.Matcher, Modifiers: parsed.ModifierEntries,
+			}
+		}}
+	},
+	IgnoreMatch: func(_ rule.RuleContext, matched shared.Match) bool {
+		// Array.prototype.includes uses SameValueZero, while Rstest's current
+		// Vitest matcher layer delegates array containment to indexOf. Rewriting
+		// an explicit NaN would therefore reverse a passing assertion.
+		return isExplicitNaN(matched.Item) || isKnownStringRegexpDifference(matched.Receiver, matched.Item)
+	},
+	BuildFixes: func(ctx rule.RuleContext, matched shared.Match) []rule.RuleFix {
+		if !isSafeToMove(matched.Item) {
+			return nil
+		}
+		fixes := shared.BuildFixes(ctx, matched)
+		if len(fixes) == 0 {
+			return nil
+		}
+		if typeArguments, ok := testFramework.CallTypeArgumentListRange(ctx.SourceFile, matched.Expect.MatcherCall); ok {
+			if utils.HasCommentInSpan(ctx.Comments.All(), typeArguments.Pos(), typeArguments.End()) {
+				return nil
+			}
+			fixes = append(fixes, rule.RuleFixRemoveRange(typeArguments))
+		}
+		return fixes
+	},
+})

--- a/internal/plugins/rstest/rules/prefer_to_contain/prefer_to_contain.go
+++ b/internal/plugins/rstest/rules/prefer_to_contain/prefer_to_contain.go
@@ -10,7 +10,8 @@ import (
 )
 
 func isUnshadowedRuntimeGlobal(ctx rule.RuleContext, node *ast.Node, name string) bool {
-	if node == nil || node.Kind != ast.KindIdentifier || node.AsIdentifier().Text != name {
+	if node == nil || node.Kind != ast.KindIdentifier || node.AsIdentifier().Text != name ||
+		!ctx.Globals.Access(name).IsDeclared() {
 		return false
 	}
 	if ctx.Refs != nil {

--- a/internal/plugins/rstest/rules/prefer_to_contain/prefer_to_contain.go
+++ b/internal/plugins/rstest/rules/prefer_to_contain/prefer_to_contain.go
@@ -54,14 +54,17 @@ func isExplicitNaN(ctx rule.RuleContext, node *ast.Node) bool {
 	return (name == "Number" || name == "globalThis") && isGlobalIdentifier(ctx, receiver, name)
 }
 
-func isKnownStringRegexpDifference(receiver, item *ast.Node) bool {
+func shouldIgnoreRegexpItem(receiver, item *ast.Node) bool {
 	receiver = testFramework.FollowTypeAssertionChain(receiver)
 	item = testFramework.FollowTypeAssertionChain(item)
-	return receiver != nil && item != nil &&
-		(receiver.Kind == ast.KindStringLiteral ||
-			receiver.Kind == ast.KindNoSubstitutionTemplateLiteral ||
-			receiver.Kind == ast.KindTemplateExpression) &&
-		item.Kind == ast.KindRegularExpressionLiteral
+	if receiver == nil || item == nil || item.Kind != ast.KindRegularExpressionLiteral {
+		return false
+	}
+	// A RegExp is a valid array item, but String.prototype.includes throws for
+	// one while Rstest's matcher delegates to Chai's string indexOf path. In a
+	// source-only rule an arbitrary receiver cannot be proven non-string, so
+	// only the syntactically certain array case is safe to recommend and fix.
+	return receiver.Kind != ast.KindArrayLiteralExpression
 }
 
 func isSafeToMove(node *ast.Node) bool {
@@ -164,7 +167,7 @@ var PreferToContainRule = shared.NewRule(shared.Config{
 		// Array.prototype.includes uses SameValueZero, while Rstest's current
 		// Vitest matcher layer delegates array containment to indexOf. Rewriting
 		// an explicit NaN would therefore reverse a passing assertion.
-		return isExplicitNaN(ctx, matched.Item) || isKnownStringRegexpDifference(matched.Receiver, matched.Item)
+		return isExplicitNaN(ctx, matched.Item) || shouldIgnoreRegexpItem(matched.Receiver, matched.Item)
 	},
 	BuildFixes: func(ctx rule.RuleContext, matched shared.Match) []rule.RuleFix {
 		if !isSafeToMove(matched.Item) {

--- a/internal/plugins/rstest/rules/prefer_to_contain/prefer_to_contain.md
+++ b/internal/plugins/rstest/rules/prefer_to_contain/prefer_to_contain.md
@@ -6,7 +6,7 @@ This rule requires `toContain()` when an equality assertion checks the boolean r
 
 The rule recognizes `toBe()`, `toEqual()` and `toStrictEqual()`, including negated forms, and preserves the assertion's meaning when deciding whether the replacement needs `.not`. It recognizes Rstest globals, imports and aliases, namespace and `require` bindings, `rstack/test`, `import.meta.rstest`, `expect.soft()`, Playwright's ordinary value assertions, and the `expect` supplied by a [test context](https://rstest.rs/api/runtime-api/test-api/test#testcontext).
 
-Polling assertions, promise modifiers, browser-only `expect.element()` assertions, Chai-style assertions, dynamic accessors and explicit `NaN` items are left unchanged. A string literal with a regular-expression item is also excluded. These cases differ at runtime: Rstest's array `toContain()` does not match `Array.prototype.includes()` for `NaN`, while native string `includes()` rejects regular expressions.
+Polling assertions, promise modifiers, browser-only `expect.element()` assertions, Chai-style assertions, dynamic accessors and explicit `NaN` items are left unchanged. A statically known string with a regular-expression item is also excluded. These cases differ at runtime: Rstest's array `toContain()` does not match `Array.prototype.includes()` for `NaN`, while native string `includes()` rejects regular expressions.
 
 ## Incorrect
 

--- a/internal/plugins/rstest/rules/prefer_to_contain/prefer_to_contain.md
+++ b/internal/plugins/rstest/rules/prefer_to_contain/prefer_to_contain.md
@@ -6,7 +6,7 @@ This rule requires `toContain()` when an equality assertion checks the boolean r
 
 The rule recognizes `toBe()`, `toEqual()` and `toStrictEqual()`, including negated forms, and preserves the assertion's meaning when deciding whether the replacement needs `.not`. It recognizes Rstest globals, imports and aliases, namespace and `require` bindings, `rstack/test`, `import.meta.rstest`, `expect.soft()`, Playwright's ordinary value assertions, and the `expect` supplied by a [test context](https://rstest.rs/api/runtime-api/test-api/test#testcontext).
 
-Polling assertions, promise modifiers, browser-only `expect.element()` assertions, Chai-style assertions, dynamic accessors and explicit `NaN` items are left unchanged. A statically known string with a regular-expression item is also excluded. These cases differ at runtime: Rstest's array `toContain()` does not match `Array.prototype.includes()` for `NaN`, while native string `includes()` rejects regular expressions.
+Polling assertions, promise modifiers, browser-only `expect.element()` assertions, Chai-style assertions, dynamic accessors and explicit `NaN` items are left unchanged. A regular-expression item is also excluded unless the receiver is visibly an array literal. This avoids suggesting a non-equivalent matcher for a possibly string-valued receiver because native string `includes()` rejects regular expressions. Rstest's array `toContain()` also does not match `Array.prototype.includes()` for `NaN`.
 
 ## Incorrect
 

--- a/internal/plugins/rstest/rules/prefer_to_contain/prefer_to_contain.md
+++ b/internal/plugins/rstest/rules/prefer_to_contain/prefer_to_contain.md
@@ -1,0 +1,29 @@
+# prefer-to-contain
+
+## Rule Details
+
+This rule requires `toContain()` when an equality assertion checks the boolean result of a single-argument `includes()` call. The dedicated matcher states the intended containment check directly and produces a more useful failure message.
+
+The rule recognizes `toBe()`, `toEqual()` and `toStrictEqual()`, including negated forms, and preserves the assertion's meaning when deciding whether the replacement needs `.not`. It recognizes Rstest globals, imports and aliases, namespace and `require` bindings, `rstack/test`, `import.meta.rstest`, `expect.soft()`, Playwright's ordinary value assertions, and the `expect` supplied by a [test context](https://rstest.rs/api/runtime-api/test-api/test#testcontext).
+
+Polling assertions, promise modifiers, browser-only `expect.element()` assertions, Chai-style assertions, dynamic accessors and explicit `NaN` items are left unchanged. A string literal with a regular-expression item is also excluded. These cases differ at runtime: Rstest's array `toContain()` does not match `Array.prototype.includes()` for `NaN`, while native string `includes()` rejects regular expressions.
+
+## Incorrect
+
+```ts
+expect(flavors.includes('lime')).toBe(true);
+expect(roles.includes('admin')).not.toEqual(false);
+expect(tags.includes('deprecated')).toStrictEqual(false);
+```
+
+## Correct
+
+```ts
+expect(flavors).toContain('lime');
+expect(roles).toContain('admin');
+expect(tags).not.toContain('deprecated');
+```
+
+## Autofix
+
+The autofix moves the `includes()` receiver and item into `expect(receiver).toContain(item)`, removes equality-matcher type arguments, then adds or removes `.not` to preserve the boolean assertion. Quoted and template-literal matcher accessors retain their delimiters. If the moved item may have side effects, `expect()` has a custom message argument, or an edited expression contains a comment, the rule reports the assertion without a fix.

--- a/internal/plugins/rstest/rules/prefer_to_contain/prefer_to_contain_extras_test.go
+++ b/internal/plugins/rstest/rules/prefer_to_contain/prefer_to_contain_extras_test.go
@@ -122,6 +122,12 @@ func TestPreferToContainExtras(t *testing.T) {
 				Code:   `expect(list.includes(item.value)).toBe(true);`,
 				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToContain", Line: 1, Column: 35}},
 			},
+			// Unary numeric coercion can invoke user code, so moving it past
+			// expect() would change the observable evaluation order.
+			{
+				Code:   `expect(list.includes(+item)).toBe(true);`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToContain", Line: 1, Column: 30}},
+			},
 			// ---- Rstest source resolution ----
 			{
 				Code: `import { expect as check } from '@rstest/core';

--- a/internal/plugins/rstest/rules/prefer_to_contain/prefer_to_contain_extras_test.go
+++ b/internal/plugins/rstest/rules/prefer_to_contain/prefer_to_contain_extras_test.go
@@ -35,6 +35,7 @@ func TestPreferToContainExtras(t *testing.T) {
 			{Code: `expect(values.includes(Number.NaN)).toBe(true);`},
 			{Code: `expect(values.includes(globalThis['NaN'])).toBe(false);`},
 			{Code: `expect('abc'.includes(/a/ as any)).toBe(false);`},
+			{Code: "expect(`a${value}`.includes(/a/ as any)).toBe(false);"},
 			// ---- Rstest provenance: foreign and locally shadowed expect values ----
 			{Code: `import { expect } from 'vitest'; expect(list.includes(item)).toBe(true);`},
 			{Code: `import { expect } from '@jest/globals'; expect(list.includes(item)).toBe(true);`},

--- a/internal/plugins/rstest/rules/prefer_to_contain/prefer_to_contain_extras_test.go
+++ b/internal/plugins/rstest/rules/prefer_to_contain/prefer_to_contain_extras_test.go
@@ -137,6 +137,10 @@ func TestPreferToContainExtras(t *testing.T) {
 				Code:   `expect(list.includes(+item)).toBe(true);`,
 				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToContain", Line: 1, Column: 30}},
 			},
+			{
+				Code:   `expect(list.includes({ [item]: 1 })).toBe(true);`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToContain"}},
+			},
 			// A locally shadowed NaN spelling is an ordinary value, so the
 			// built-in NaN semantic exclusion must not suppress the rule.
 			{

--- a/internal/plugins/rstest/rules/prefer_to_contain/prefer_to_contain_extras_test.go
+++ b/internal/plugins/rstest/rules/prefer_to_contain/prefer_to_contain_extras_test.go
@@ -1,0 +1,276 @@
+// TestPreferToContainExtras covers Rstest expect sources, runtime-semantic
+// exclusions, tsgo edge shapes, fix safety and shared-engine branch lock-ins.
+// The complete upstream baseline is in prefer_to_contain_upstream_test.go.
+package prefer_to_contain
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/microsoft/TypeScript/tsc/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/linter"
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/fixtures"
+	lintprogram "github.com/web-infra-dev/rslint/internal/program"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestPreferToContainExtras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&PreferToContainRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Rstest runtime boundary: poll retries its callback ----
+			{Code: `await expect.poll(() => list.includes(item)).toBe(true);`},
+			// ---- Rstest runtime boundary: promise modifiers assert a settled value ----
+			{Code: `await expect(Promise.resolve(list.includes(item))).resolves.toBe(true);`},
+			{Code: `await expect(Promise.reject(list.includes(item))).rejects.toEqual(true);`},
+			// ---- Rstest runtime boundary: browser element expect has another matcher set ----
+			{Code: `expect.element(locator).toEqual(true);`},
+			// ---- Rstest runtime boundary: Array#includes and toContain disagree on NaN ----
+			{Code: `expect([NaN].includes(NaN)).toBe(true);`},
+			{Code: `expect(values.includes(NaN as number)).toEqual(false);`},
+			{Code: `expect(values.includes(Number.NaN)).toBe(true);`},
+			{Code: `expect(values.includes(globalThis['NaN'])).toBe(false);`},
+			{Code: `expect('abc'.includes(/a/ as any)).toBe(false);`},
+			// ---- Rstest provenance: foreign and locally shadowed expect values ----
+			{Code: `import { expect } from 'vitest'; expect(list.includes(item)).toBe(true);`},
+			{Code: `import { expect } from '@jest/globals'; expect(list.includes(item)).toBe(true);`},
+			{Code: `const expect = createExpect(); expect(list.includes(item)).toBe(true);`},
+			{Code: `import { expect } from '@rstest/core'; function f(expect: any) { expect(list.includes(item)).toBe(true); }`},
+			// ---- Dimension 4: unsupported and dynamic accessors ----
+			{Code: `expect(list[includes](item)).toBe(true);`},
+			{Code: `const key = "incl" + suffix; expect(list[key](item)).toBe(true);`},
+			{Code: `expect(list.includes?.(item)).toBe(true);`},
+			{Code: `expect(list?.includes(item)).toBe(true);`},
+			{Code: `expect(list.includes(item))[matcher](true);`},
+			{Code: `expect(list.includes(item))[0](true);`},
+			// ---- Dimension 4: calls and arguments that do not match the rule grammar ----
+			{Code: `expect(list.includes()).toBe(true);`},
+			{Code: `expect(list.includes(item, 0)).toBe(true);`},
+			{Code: `expect(list.includes(...items)).toBe(true);`},
+			{Code: `expect(list.includes(item)).toBe();`},
+			{Code: `expect(list.includes(item)).toBe(true, false);`},
+			{Code: `expect(list.includes(item)).toBe(...values);`},
+			{Code: `expect(list.includes(item)).toBeTruthy();`},
+			{Code: `expect(list.includes(item)).to.equal(true);`},
+			{Code: `(expect(list.includes(item)) as any).toBe(true);`},
+			{Code: `expect(list.includes(item))!.toBe(true);`},
+			// N/A: declarations, functions, class members, object keys and binding
+			// patterns are not nodes inspected by this assertion-call rule.
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Dimension 4: parentheses and assertion wrappers ----
+			{
+				Code:   `expect(((list.includes(item)))).toEqual((true as boolean));`,
+				Output: []string{`expect(((list))).toContain(item);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToContain", Message: "Use toContain() instead", Line: 1, Column: 33}},
+			},
+			{
+				Code:   `expect(list["includes"]((item as Item))).toStrictEqual(false as boolean);`,
+				Output: []string{`expect(list).not.toContain((item as Item));`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToContain", Line: 1, Column: 42}},
+			},
+			// ---- Dimension 4: authored matcher accessor spelling survives ----
+			{
+				Code:   `expect(list.includes(item))["toEqual"](true);`,
+				Output: []string{`expect(list)["toContain"](item);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToContain", Line: 1, Column: 29}},
+			},
+			{
+				Code:   `expect(list.includes(item)).toEqual<boolean>(true);`,
+				Output: []string{`expect(list).toContain(item);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToContain", Line: 1, Column: 29}},
+			},
+			{
+				Code:   `expect(list.includes(item)).toEqual</* keep */ boolean>(true);`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToContain", Line: 1, Column: 29}},
+			},
+			{
+				Code:   "expect(list[`includes`](item))[`toBe`](false);",
+				Output: []string{"expect(list).not[`toContain`](item);"},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToContain", Line: 1, Column: 32}},
+			},
+			// ---- Dimension 3: comments outside replaced expressions survive ----
+			{
+				Code:   `expect(list.includes(item)). /* matcher */ toBe(true);`,
+				Output: []string{`expect(list). /* matcher */ toContain(item);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToContain", Line: 1, Column: 44}},
+			},
+			// ---- Dimension 3: comments inside replaced expressions withhold fixes ----
+			{
+				Code:   `expect(list.includes(/* keep */ item)).toBe(true);`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToContain", Line: 1, Column: 40}},
+			},
+			{
+				Code:   `expect(list.includes(item)).toBe(/* keep */ true);`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToContain", Line: 1, Column: 29}},
+			},
+			// Moving the item after expect(message()) would reorder evaluation.
+			{
+				Code:   `expect(list.includes(nextItem()), message()).toBe(true);`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToContain", Line: 1, Column: 46}},
+			},
+			{
+				Code:   `expect(list.includes(nextItem())).toBe(true);`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToContain", Line: 1, Column: 35}},
+			},
+			{
+				Code:   `expect(list.includes(item.value)).toBe(true);`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToContain", Line: 1, Column: 35}},
+			},
+			// ---- Rstest source resolution ----
+			{
+				Code: `import { expect as check } from '@rstest/core';
+check(list.includes(item)).toBe(true);`,
+				Output: []string{`import { expect as check } from '@rstest/core';
+check(list).toContain(item);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToContain", Line: 2, Column: 28}},
+			},
+			{
+				Code: `import * as core from '@rstest/core';
+core.expect(list.includes(item)).not.toEqual(false);`,
+				Output: []string{`import * as core from '@rstest/core';
+core.expect(list).toContain(item);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToContain", Line: 2, Column: 38}},
+			},
+			{
+				Code: `const { expect } = require('rstack/test');
+expect(list.includes(item)).toStrictEqual(false);`,
+				Output: []string{`const { expect } = require('rstack/test');
+expect(list).not.toContain(item);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToContain", Line: 2, Column: 29}},
+			},
+			{
+				Code:   `import.meta.rstest.expect(list.includes(item)).toBe(true);`,
+				Output: []string{`import.meta.rstest.expect(list).toContain(item);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToContain", Line: 1, Column: 48}},
+			},
+			{
+				Code: `import { expect } from '@rstest/playwright';
+expect(list.includes(item)).toEqual(true);`,
+				Output: []string{`import { expect } from '@rstest/playwright';
+expect(list).toContain(item);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToContain", Line: 2, Column: 29}},
+			},
+			{
+				Code:   `test('contains', ({ expect: check }) => check(list.includes(item)).toBe(true));`,
+				Output: []string{`test('contains', ({ expect: check }) => check(list).toContain(item));`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToContain", Line: 1, Column: 68}},
+			},
+			// ---- Rstest factory: soft assertions preserve soft behavior ----
+			{
+				Code:   `expect.soft(list.includes(item)).not.toBe(false);`,
+				Output: []string{`expect.soft(list).toContain(item);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToContain", Line: 1, Column: 38}},
+			},
+			// Locks in equality matcher, boolean literal and negation truth table.
+			{
+				Code:   `expect(list.includes(item)).not.toStrictEqual(true);`,
+				Output: []string{`expect(list).not.toContain(item);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToContain", Message: "Use toContain() instead", Line: 1, Column: 33, EndLine: 1, EndColumn: 46}},
+			},
+			{
+				Code: `expect(list.includes(item))
+  .toEqual(true);`,
+				Output: []string{`expect(list)
+  .toContain(item);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToContain", Message: "Use toContain() instead", Line: 2, Column: 4, EndLine: 2, EndColumn: 11}},
+			},
+			// Array.from() materializes sparse holes before Rstest's matcher checks
+			// containment, so this remains equivalent to includes(undefined).
+			{
+				Code:   `expect([,].includes(undefined)).toBe(true);`,
+				Output: []string{`expect([,]).toContain(undefined);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToContain", Line: 1, Column: 33}},
+			},
+			{
+				Code:   `expect('123'.includes(2 as any)).toBe(true);`,
+				Output: []string{`expect('123').toContain(2 as any);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToContain", Line: 1, Column: 34}},
+			},
+			// ---- Real-user: jest#1009 bracket accessor regression ----
+			{
+				Code:   `expect(list['includes'](item))['not']['toEqual'](false);`,
+				Output: []string{`expect(list)['toContain'](item);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToContain", Line: 1, Column: 39}},
+			},
+			// ---- Real-user: jest#1282 trailing-comma regression ----
+			{
+				Code:   `expect(list.includes(item,),).toBe(false,);`,
+				Output: []string{`expect(list,).not.toContain(item,);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToContain", Line: 1, Column: 31}},
+			},
+			// A trailing call reaches the matcher through two call nodes but reports once.
+			{
+				Code:   `expect(list.includes(item)).toBe(true).then(done);`,
+				Output: []string{`expect(list).toContain(item).then(done);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToContain", Line: 1, Column: 29}},
+			},
+		},
+	)
+}
+
+func TestPreferToContainEditDemand(t *testing.T) {
+	t.Parallel()
+	help := rule_tester.NewProgramHelper(fixtures.GetRootDir())
+	program, sourceFile, err := help.CreateTestProgram(
+		`expect(list.includes(item)).not.toEqual(false);`,
+		"edit-demand.ts",
+		"tsconfig.json",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	run := func(demand rule.EditDemand) rule.RuleDiagnostic {
+		t.Helper()
+		var diagnostics []rule.RuleDiagnostic
+		linter.LintSingleFile(linter.LintSingleFileOptions{
+			Program: lintprogram.NewFromCompiler(program), File: sourceFile.FileName(), HasTypeInfo: true,
+			GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+				return []rule.ConfiguredRule{{Name: PreferToContainRule.Name, Severity: rule.SeverityError, Run: func(ctx rule.RuleContext) rule.RuleListeners {
+					return PreferToContainRule.Run(ctx, nil)
+				}}}
+			},
+			Consumer: rule.DiagnosticConsumer{Demand: demand, Report: func(diagnostic rule.RuleDiagnostic) {
+				diagnostics = append(diagnostics, diagnostic)
+			}},
+		})
+		if len(diagnostics) != 1 {
+			t.Fatalf("demand %d: diagnostics = %d, want 1", demand, len(diagnostics))
+		}
+		return diagnostics[0]
+	}
+
+	diagnosticsOnly := run(rule.EditDemandNone)
+	autofixOnly := run(rule.EditDemandAutofix)
+	suggestionOnly := run(rule.EditDemandSuggestion)
+	allEdits := run(rule.EditDemandAll)
+	withoutEdits := func(diagnostic rule.RuleDiagnostic) rule.RuleDiagnostic {
+		diagnostic.FixesPtr = nil
+		diagnostic.Suggestions = nil
+		return diagnostic
+	}
+	want := withoutEdits(allEdits)
+	for demand, diagnostic := range map[rule.EditDemand]rule.RuleDiagnostic{
+		rule.EditDemandNone: diagnosticsOnly, rule.EditDemandAutofix: autofixOnly, rule.EditDemandSuggestion: suggestionOnly,
+	} {
+		if got := withoutEdits(diagnostic); !reflect.DeepEqual(got, want) {
+			t.Errorf("demand %d diagnostic changed:\ngot  %#v\nwant %#v", demand, got, want)
+		}
+	}
+	if diagnosticsOnly.FixesPtr != nil || suggestionOnly.FixesPtr != nil {
+		t.Fatal("autofixes were materialized without being requested")
+	}
+	if autofixOnly.FixesPtr == nil || allEdits.FixesPtr == nil || !reflect.DeepEqual(*autofixOnly.FixesPtr, *allEdits.FixesPtr) {
+		t.Fatal("requested autofixes do not match all-edits output")
+	}
+	for _, diagnostic := range []rule.RuleDiagnostic{diagnosticsOnly, autofixOnly, suggestionOnly, allEdits} {
+		if diagnostic.Suggestions != nil {
+			t.Fatal("prefer-to-contain unexpectedly materialized suggestions")
+		}
+	}
+}

--- a/internal/plugins/rstest/rules/prefer_to_contain/prefer_to_contain_extras_test.go
+++ b/internal/plugins/rstest/rules/prefer_to_contain/prefer_to_contain_extras_test.go
@@ -128,6 +128,21 @@ func TestPreferToContainExtras(t *testing.T) {
 				Code:   `expect(list.includes(+item)).toBe(true);`,
 				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToContain", Line: 1, Column: 30}},
 			},
+			// A locally shadowed NaN spelling is an ordinary value, so the
+			// built-in NaN semantic exclusion must not suppress the rule.
+			{
+				Code:   `const NaN = 1; expect([1].includes(NaN)).toBe(true);`,
+				Output: []string{`const NaN = 1; expect([1]).toContain(NaN);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToContain"}},
+			},
+			{
+				Code:   `function f(Number: any) { expect([1].includes(Number.NaN)).toBe(true); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToContain"}},
+			},
+			{
+				Code:   `function f(globalThis: any) { expect([1].includes(globalThis.NaN)).toBe(true); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToContain"}},
+			},
 			// ---- Rstest source resolution ----
 			{
 				Code: `import { expect as check } from '@rstest/core';

--- a/internal/plugins/rstest/rules/prefer_to_contain/prefer_to_contain_extras_test.go
+++ b/internal/plugins/rstest/rules/prefer_to_contain/prefer_to_contain_extras_test.go
@@ -34,6 +34,8 @@ func TestPreferToContainExtras(t *testing.T) {
 			{Code: `expect(values.includes(NaN as number)).toEqual(false);`},
 			{Code: `expect(values.includes(Number.NaN)).toBe(true);`},
 			{Code: `expect(values.includes(globalThis['NaN'])).toBe(false);`},
+			{Code: "expect(values.includes(Number[`NaN`])).toBe(true);"},
+			{Code: `expect(values.includes(globalThis.Number.NaN)).toBe(false);`},
 			{Code: `type NaN = number; expect([NaN].includes(NaN)).toBe(true);`},
 			{Code: `interface Number {} expect([Number.NaN].includes(Number.NaN)).toBe(true);`},
 			{Code: `Number = { NaN: 1 } as any; expect([1].includes(Number.NaN)).toBe(true);`},

--- a/internal/plugins/rstest/rules/prefer_to_contain/prefer_to_contain_extras_test.go
+++ b/internal/plugins/rstest/rules/prefer_to_contain/prefer_to_contain_extras_test.go
@@ -164,6 +164,17 @@ func TestPreferToContainExtras(t *testing.T) {
 				Code:   `globalThis.Number = { NaN: 1 } as any; expect([1].includes(Number.NaN)).toBe(true);`,
 				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToContain"}},
 			},
+			{
+				Code:    `expect([NaN].includes(NaN)).toBe(true);`,
+				Globals: map[string]any{"NaN": "off"},
+				Output:  []string{`expect([NaN]).toContain(NaN);`},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "useToContain"}},
+			},
+			{
+				Code:    `expect([Number.NaN].includes(Number.NaN)).toBe(true);`,
+				Globals: map[string]any{"Number": "off"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "useToContain"}},
+			},
 			// ---- Rstest source resolution ----
 			{
 				Code: `import { expect as check } from '@rstest/core';

--- a/internal/plugins/rstest/rules/prefer_to_contain/prefer_to_contain_extras_test.go
+++ b/internal/plugins/rstest/rules/prefer_to_contain/prefer_to_contain_extras_test.go
@@ -36,6 +36,8 @@ func TestPreferToContainExtras(t *testing.T) {
 			{Code: `expect(values.includes(globalThis['NaN'])).toBe(false);`},
 			{Code: `expect('abc'.includes(/a/ as any)).toBe(false);`},
 			{Code: "expect(`a${value}`.includes(/a/ as any)).toBe(false);"},
+			{Code: `expect(('a' + suffix).includes(/a/ as any)).toBe(false);`},
+			{Code: `expect(value.includes(/a/ as any)).toBe(false);`},
 			// ---- Rstest provenance: foreign and locally shadowed expect values ----
 			{Code: `import { expect } from 'vitest'; expect(list.includes(item)).toBe(true);`},
 			{Code: `import { expect } from '@jest/globals'; expect(list.includes(item)).toBe(true);`},
@@ -63,6 +65,11 @@ func TestPreferToContainExtras(t *testing.T) {
 			// patterns are not nodes inspected by this assertion-call rule.
 		},
 		[]rule_tester.InvalidTestCase{
+			{
+				Code:   `expect([/a/].includes(/a/)).toBe(true);`,
+				Output: []string{`expect([/a/]).toContain(/a/);`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToContain"}},
+			},
 			// ---- Dimension 4: parentheses and assertion wrappers ----
 			{
 				Code:   `expect(((list.includes(item)))).toEqual((true as boolean));`,

--- a/internal/plugins/rstest/rules/prefer_to_contain/prefer_to_contain_extras_test.go
+++ b/internal/plugins/rstest/rules/prefer_to_contain/prefer_to_contain_extras_test.go
@@ -34,6 +34,8 @@ func TestPreferToContainExtras(t *testing.T) {
 			{Code: `expect(values.includes(NaN as number)).toEqual(false);`},
 			{Code: `expect(values.includes(Number.NaN)).toBe(true);`},
 			{Code: `expect(values.includes(globalThis['NaN'])).toBe(false);`},
+			{Code: `type NaN = number; expect([NaN].includes(NaN)).toBe(true);`},
+			{Code: `interface Number {} expect([Number.NaN].includes(Number.NaN)).toBe(true);`},
 			{Code: `expect('abc'.includes(/a/ as any)).toBe(false);`},
 			{Code: "expect(`a${value}`.includes(/a/ as any)).toBe(false);"},
 			{Code: `expect(('a' + suffix).includes(/a/ as any)).toBe(false);`},
@@ -148,6 +150,14 @@ func TestPreferToContainExtras(t *testing.T) {
 			},
 			{
 				Code:   `function f(globalThis: any) { expect([1].includes(globalThis.NaN)).toBe(true); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToContain"}},
+			},
+			{
+				Code:   `Number = { NaN: 1 } as any; expect([1].includes(Number.NaN)).toBe(true);`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToContain"}},
+			},
+			{
+				Code:   `globalThis.Number = { NaN: 1 } as any; expect([1].includes(Number.NaN)).toBe(true);`,
 				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToContain"}},
 			},
 			// ---- Rstest source resolution ----

--- a/internal/plugins/rstest/rules/prefer_to_contain/prefer_to_contain_extras_test.go
+++ b/internal/plugins/rstest/rules/prefer_to_contain/prefer_to_contain_extras_test.go
@@ -36,6 +36,8 @@ func TestPreferToContainExtras(t *testing.T) {
 			{Code: `expect(values.includes(globalThis['NaN'])).toBe(false);`},
 			{Code: `type NaN = number; expect([NaN].includes(NaN)).toBe(true);`},
 			{Code: `interface Number {} expect([Number.NaN].includes(Number.NaN)).toBe(true);`},
+			{Code: `Number = { NaN: 1 } as any; expect([1].includes(Number.NaN)).toBe(true);`},
+			{Code: `globalThis.Number = { NaN: 1 } as any; expect([1].includes(Number.NaN)).toBe(true);`},
 			{Code: `expect('abc'.includes(/a/ as any)).toBe(false);`},
 			{Code: "expect(`a${value}`.includes(/a/ as any)).toBe(false);"},
 			{Code: `expect(('a' + suffix).includes(/a/ as any)).toBe(false);`},
@@ -154,14 +156,6 @@ func TestPreferToContainExtras(t *testing.T) {
 			},
 			{
 				Code:   `function f(globalThis: any) { expect([1].includes(globalThis.NaN)).toBe(true); }`,
-				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToContain"}},
-			},
-			{
-				Code:   `Number = { NaN: 1 } as any; expect([1].includes(Number.NaN)).toBe(true);`,
-				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToContain"}},
-			},
-			{
-				Code:   `globalThis.Number = { NaN: 1 } as any; expect([1].includes(Number.NaN)).toBe(true);`,
 				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToContain"}},
 			},
 			{

--- a/internal/plugins/rstest/rules/prefer_to_contain/prefer_to_contain_source_only_test.go
+++ b/internal/plugins/rstest/rules/prefer_to_contain/prefer_to_contain_source_only_test.go
@@ -33,6 +33,9 @@ function local() { const expect = createExpect(); expect(localList.includes(item
 const NaN = 1; expect([1].includes(NaN)).toBe(true);
 function shadowNumber(Number: any) { expect([1].includes(Number.NaN)).toBe(true); }
 function shadowGlobalThis(globalThis: any) { expect([1].includes(globalThis.NaN)).toBe(true); }
+Number = { NaN: 1 } as any; expect([1].includes(Number.NaN)).toBe(true);
+type LocalNaN = NaN; expect([NaN].includes(NaN)).toBe(true);
+interface Number {} expect([Number.NaN].includes(Number.NaN)).toBe(true);
 `
 	root := fixtures.GetRootDir()
 	fileName := tspath.ResolvePath(root.Dir, "prefer-to-contain-source-only.ts")
@@ -67,7 +70,7 @@ function shadowGlobalThis(globalThis: any) { expect([1].includes(globalThis.NaN)
 		t.Fatalf("RunLinter: %v", err)
 	}
 	sort.Ints(positions)
-	if len(positions) != 8 {
-		t.Fatalf("reported %d assertions, want 8 at %v", len(positions), positions)
+	if len(positions) != 11 {
+		t.Fatalf("reported %d assertions, want 11 at %v", len(positions), positions)
 	}
 }

--- a/internal/plugins/rstest/rules/prefer_to_contain/prefer_to_contain_source_only_test.go
+++ b/internal/plugins/rstest/rules/prefer_to_contain/prefer_to_contain_source_only_test.go
@@ -30,6 +30,9 @@ rstestTest('context', ({ expect: localExpect }) => { localExpect(contextList.inc
 import { expect as vitestExpect } from 'vitest';
 vitestExpect(foreignList.includes(item)).toBe(true);
 function local() { const expect = createExpect(); expect(localList.includes(item)).toBe(true); }
+const NaN = 1; expect([1].includes(NaN)).toBe(true);
+function shadowNumber(Number: any) { expect([1].includes(Number.NaN)).toBe(true); }
+function shadowGlobalThis(globalThis: any) { expect([1].includes(globalThis.NaN)).toBe(true); }
 `
 	root := fixtures.GetRootDir()
 	fileName := tspath.ResolvePath(root.Dir, "prefer-to-contain-source-only.ts")
@@ -64,7 +67,7 @@ function local() { const expect = createExpect(); expect(localList.includes(item
 		t.Fatalf("RunLinter: %v", err)
 	}
 	sort.Ints(positions)
-	if len(positions) != 5 {
-		t.Fatalf("reported %d assertions, want 5 at %v", len(positions), positions)
+	if len(positions) != 8 {
+		t.Fatalf("reported %d assertions, want 8 at %v", len(positions), positions)
 	}
 }

--- a/internal/plugins/rstest/rules/prefer_to_contain/prefer_to_contain_source_only_test.go
+++ b/internal/plugins/rstest/rules/prefer_to_contain/prefer_to_contain_source_only_test.go
@@ -1,0 +1,70 @@
+package prefer_to_contain
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/microsoft/TypeScript/tsc/shim/ast"
+	"github.com/microsoft/TypeScript/tsc/shim/core"
+	"github.com/microsoft/TypeScript/tsc/shim/tspath"
+	"github.com/web-infra-dev/rslint/internal/linter"
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/fixtures"
+	lintprogram "github.com/web-infra-dev/rslint/internal/program"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+func TestPreferToContainResolvesInSourceOnlyProgram(t *testing.T) {
+	if PreferToContainRule.RequiresTypeInfo {
+		t.Fatal("rstest/prefer-to-contain must not require type information")
+	}
+	code := `
+expect(globalList.includes(item)).toBe(true);
+import { expect as check, test as rstestTest } from '@rstest/core';
+import * as rstest from '@rstest/playwright';
+const { expect: requiredExpect } = require('rstack/test');
+check(importedList.includes(item)).toBe(true);
+rstest.expect(browserList.includes(item)).toBe(true);
+requiredExpect(requiredList.includes(item)).toBe(true);
+rstestTest('context', ({ expect: localExpect }) => { localExpect(contextList.includes(item)).toBe(true); });
+import { expect as vitestExpect } from 'vitest';
+vitestExpect(foreignList.includes(item)).toBe(true);
+function local() { const expect = createExpect(); expect(localList.includes(item)).toBe(true); }
+`
+	root := fixtures.GetRootDir()
+	fileName := tspath.ResolvePath(root.Dir, "prefer-to-contain-source-only.ts")
+	fs := utils.NewOverlayVFS(root.FS, map[string]string{fileName: code})
+	host := utils.CreateCompilerHost(root.Dir, fs)
+	sourceProgram, err := lintprogram.NewFromRoots(lintprogram.RootOptions{
+		RootFileNames: []string{fileName}, Host: host,
+		CompilerOptions: &core.CompilerOptions{Module: core.ModuleKindESNext}, SingleThreaded: true,
+	})
+	if err != nil {
+		t.Fatalf("NewFromRoots: %v", err)
+	}
+	if sourceProgram.CanProvideTypeChecker(sourceProgram.SourceFiles()[0]) {
+		t.Fatal("expected a source-only Program with no TypeChecker")
+	}
+	lintPlan, err := linter.PrepareLintPlan(linter.PrepareLintPlanOptions{
+		Programs: []*lintprogram.Program{sourceProgram}, TargetsByProgram: [][]string{{fileName}}, SingleThreaded: true,
+		GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+			return []rule.ConfiguredRule{{Name: PreferToContainRule.Name, Severity: rule.SeverityError, Run: func(ctx rule.RuleContext) rule.RuleListeners {
+				return PreferToContainRule.Run(ctx, nil)
+			}}}
+		},
+	})
+	if err != nil {
+		t.Fatalf("PrepareLintPlan: %v", err)
+	}
+	var positions []int
+	if _, err := linter.RunLinter(linter.RunLinterOptions{
+		SingleThreaded: true, LintPlan: lintPlan,
+		Consumer: rule.DiagnosticConsumer{Report: func(diagnostic rule.RuleDiagnostic) { positions = append(positions, diagnostic.Range.Pos()) }},
+	}); err != nil {
+		t.Fatalf("RunLinter: %v", err)
+	}
+	sort.Ints(positions)
+	if len(positions) != 5 {
+		t.Fatalf("reported %d assertions, want 5 at %v", len(positions), positions)
+	}
+}

--- a/internal/plugins/rstest/rules/prefer_to_contain/prefer_to_contain_source_only_test.go
+++ b/internal/plugins/rstest/rules/prefer_to_contain/prefer_to_contain_source_only_test.go
@@ -30,7 +30,7 @@ rstestTest('context', ({ expect: localExpect }) => { localExpect(contextList.inc
 import { expect as vitestExpect } from 'vitest';
 vitestExpect(foreignList.includes(item)).toBe(true);
 function local() { const expect = createExpect(); expect(localList.includes(item)).toBe(true); }
-const NaN = 1; expect([1].includes(NaN)).toBe(true);
+function shadowNaN(NaN: any) { expect([1].includes(NaN)).toBe(true); }
 function shadowNumber(Number: any) { expect([1].includes(Number.NaN)).toBe(true); }
 function shadowGlobalThis(globalThis: any) { expect([1].includes(globalThis.NaN)).toBe(true); }
 Number = { NaN: 1 } as any; expect([1].includes(Number.NaN)).toBe(true);
@@ -70,7 +70,7 @@ interface Number {} expect([Number.NaN].includes(Number.NaN)).toBe(true);
 		t.Fatalf("RunLinter: %v", err)
 	}
 	sort.Ints(positions)
-	if len(positions) != 11 {
-		t.Fatalf("reported %d assertions, want 11 at %v", len(positions), positions)
+	if len(positions) != 8 {
+		t.Fatalf("reported %d assertions, want 8 at %v", len(positions), positions)
 	}
 }

--- a/internal/plugins/rstest/rules/prefer_to_contain/prefer_to_contain_upstream_test.go
+++ b/internal/plugins/rstest/rules/prefer_to_contain/prefer_to_contain_upstream_test.go
@@ -1,0 +1,89 @@
+// TestPreferToContainUpstream migrates every valid and invalid case from
+// @vitest/eslint-plugin@v1.6.27 tests/prefer-to-contain.test.ts. Rstest-only
+// semantic exclusions and tsgo edge shapes live in the sibling extras suite.
+package prefer_to_contain
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/rstest/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestPreferToContainUpstream(t *testing.T) {
+	invalid := func(code, output string, column int) rule_tester.InvalidTestCase {
+		return rule_tester.InvalidTestCase{
+			Code: code, Output: []string{output},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToContain", Line: 1, Column: column}},
+		}
+	}
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&PreferToContainRule,
+		[]rule_tester.ValidTestCase{
+			{Code: `expect.hasAssertions`},
+			{Code: `expect.hasAssertions()`},
+			{Code: `expect.assertions(1)`},
+			{Code: `expect().toBe(false);`},
+			{Code: `expect(a).toContain(b);`},
+			{Code: `expect(a.name).toBe('b');`},
+			{Code: `expect(a).toBe(true);`},
+			{Code: `expect(a).toEqual(b)`},
+			{Code: `expect(a.test(c)).toEqual(b)`},
+			{Code: `expect(a.includes(b)).toEqual()`},
+			{Code: `expect(a.includes(b)).toEqual("test")`},
+			{Code: `expect(a.includes(b)).toBe("test")`},
+			{Code: `expect(a.includes()).toEqual()`},
+			{Code: `expect(a.includes()).toEqual(true)`},
+			{Code: `expect(a.includes(b,c)).toBe(true)`},
+			{Code: `expect([{a:1}]).toContain({a:1})`},
+			{Code: `expect([1].includes(1)).toEqual`},
+			{Code: `expect([1].includes).toEqual`},
+			{Code: `expect([1].includes).not`},
+			{Code: `expect(a.test(b)).resolves.toEqual(true)`},
+			{Code: `expect(a.test(b)).resolves.not.toEqual(true)`},
+			{Code: `expect(a).not.toContain(b)`},
+			{Code: `expect(a.includes(...[])).toBe(true)`},
+			{Code: `expect(a.includes(b)).toBe(...true)`},
+			{Code: `expect(a);`},
+			{Code: `expect(a).to.be.a("string");`},
+		},
+		[]rule_tester.InvalidTestCase{
+			invalid(`expect(a.includes(b)).toEqual(true);`, `expect(a).toContain(b);`, 23),
+			invalid(`expect(a.includes(b,),).toEqual(true,);`, `expect(a,).toContain(b,);`, 25),
+			invalid(`expect(a['includes'](b)).toEqual(true);`, `expect(a).toContain(b);`, 26),
+			invalid(`expect(a['includes'](b))['toEqual'](true);`, `expect(a)['toContain'](b);`, 26),
+			invalid(`expect(a['includes'](b)).toEqual(false);`, `expect(a).not.toContain(b);`, 26),
+			invalid(`expect(a['includes'](b)).not.toEqual(false);`, `expect(a).toContain(b);`, 30),
+			invalid(`expect(a['includes'](b))['not'].toEqual(false);`, `expect(a).toContain(b);`, 33),
+			invalid(`expect(a['includes'](b))['not']['toEqual'](false);`, `expect(a)['toContain'](b);`, 33),
+			invalid(`expect(a.includes(b)).toEqual(false);`, `expect(a).not.toContain(b);`, 23),
+			invalid(`expect(a.includes(b)).not.toEqual(false);`, `expect(a).toContain(b);`, 27),
+			invalid(`expect(a.includes(b)).not.toEqual(true);`, `expect(a).not.toContain(b);`, 27),
+			invalid(`expect(a.includes(b)).toBe(true);`, `expect(a).toContain(b);`, 23),
+			invalid(`expect(a.includes(b)).toBe(false);`, `expect(a).not.toContain(b);`, 23),
+			invalid(`expect(a.includes(b)).not.toBe(false);`, `expect(a).toContain(b);`, 27),
+			invalid(`expect(a.includes(b)).not.toBe(true);`, `expect(a).not.toContain(b);`, 27),
+			invalid(`expect(a.includes(b)).toStrictEqual(true);`, `expect(a).toContain(b);`, 23),
+			invalid(`expect(a.includes(b)).toStrictEqual(false);`, `expect(a).not.toContain(b);`, 23),
+			invalid(`expect(a.includes(b)).not.toStrictEqual(false);`, `expect(a).toContain(b);`, 27),
+			invalid(`expect(a.includes(b)).not.toStrictEqual(true);`, `expect(a).not.toContain(b);`, 27),
+			// ADAPT: Rstest reports these upstream cases but withholds the fix;
+			// moving b.test(p) after expect(...) can reorder observable effects.
+			{Code: `expect(a.test(t).includes(b.test(p))).toEqual(true);`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToContain", Line: 1, Column: 39}}},
+			{Code: `expect(a.test(t).includes(b.test(p))).toEqual(false);`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToContain", Line: 1, Column: 39}}},
+			{Code: `expect(a.test(t).includes(b.test(p))).not.toEqual(true);`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToContain", Line: 1, Column: 43}}},
+			{Code: `expect(a.test(t).includes(b.test(p))).not.toEqual(false);`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useToContain", Line: 1, Column: 43}}},
+			invalid(`expect([{a:1}].includes({a:1})).toBe(true);`, `expect([{a:1}]).toContain({a:1});`, 33),
+			invalid(`expect([{a:1}].includes({a:1})).toBe(false);`, `expect([{a:1}]).not.toContain({a:1});`, 33),
+			invalid(`expect([{a:1}].includes({a:1})).not.toBe(true);`, `expect([{a:1}]).not.toContain({a:1});`, 37),
+			invalid(`expect([{a:1}].includes({a:1})).not.toBe(false);`, `expect([{a:1}]).toContain({a:1});`, 37),
+			invalid(`expect([{a:1}].includes({a:1})).toStrictEqual(true);`, `expect([{a:1}]).toContain({a:1});`, 33),
+			invalid(`expect([{a:1}].includes({a:1})).toStrictEqual(false);`, `expect([{a:1}]).not.toContain({a:1});`, 33),
+			invalid(`expect([{a:1}].includes({a:1})).not.toStrictEqual(true);`, `expect([{a:1}]).not.toContain({a:1});`, 37),
+			invalid(`expect([{a:1}].includes({a:1})).not.toStrictEqual(false);`, `expect([{a:1}]).toContain({a:1});`, 37),
+		},
+	)
+}

--- a/internal/utils/test_framework/rules/prefer_to_contain/prefer_to_contain.go
+++ b/internal/utils/test_framework/rules/prefer_to_contain/prefer_to_contain.go
@@ -1,0 +1,236 @@
+// Package prefer_to_contain implements the matcher-independent decision tree
+// shared by Jest- and Rstest-flavoured prefer-to-contain rules. Framework
+// adapters own expect-call parsing and framework-specific semantic exclusions.
+package prefer_to_contain
+
+import (
+	"github.com/microsoft/TypeScript/tsc/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+	testFramework "github.com/web-infra-dev/rslint/internal/utils/test_framework"
+)
+
+type ExpectCall struct {
+	HeadCall     *ast.Node
+	MatcherCall  *ast.Node
+	MatcherEntry testFramework.MemberEntry
+	Matcher      string
+	Modifiers    []testFramework.MemberEntry
+}
+
+type Runtime struct {
+	Parse func(*ast.Node) *ExpectCall
+}
+
+type Match struct {
+	Expect        *ExpectCall
+	IncludesCall  *ast.Node
+	Receiver      *ast.Node
+	Item          *ast.Node
+	MatcherValue  *ast.Node
+	ShouldHaveNot bool
+	NotEntry      *testFramework.MemberEntry
+}
+
+type Config struct {
+	Name string
+
+	Prepare func(rule.RuleContext) Runtime
+	// IgnoreMatch applies framework-specific semantic exclusions after the
+	// syntax has been recognized.
+	IgnoreMatch func(rule.RuleContext, Match) bool
+	// BuildFixes lets an adapter preserve an established framework-specific
+	// edit contract. A nil callback uses the shared safe edit builder.
+	BuildFixes func(rule.RuleContext, Match) []rule.RuleFix
+}
+
+var equalityMatchers = map[string]bool{
+	"toBe":          true,
+	"toEqual":       true,
+	"toStrictEqual": true,
+}
+
+func message() rule.RuleMessage {
+	return rule.RuleMessage{Id: "useToContain", Description: "Use toContain() instead"}
+}
+
+func findNot(modifiers []testFramework.MemberEntry) *testFramework.MemberEntry {
+	for index := range modifiers {
+		if modifiers[index].Name == "not" {
+			return &modifiers[index]
+		}
+	}
+	return nil
+}
+
+func staticAccessor(node *ast.Node, name string) (*ast.Node, bool) {
+	node = ast.SkipParentheses(node)
+	if node == nil {
+		return nil, false
+	}
+	switch node.Kind {
+	case ast.KindPropertyAccessExpression:
+		property := node.AsPropertyAccessExpression()
+		member := property.Name()
+		return property.Expression, member != nil && member.Kind == ast.KindIdentifier && member.AsIdentifier().Text == name
+	case ast.KindElementAccessExpression:
+		element := node.AsElementAccessExpression()
+		member := ast.SkipParentheses(element.ArgumentExpression)
+		if member == nil {
+			return nil, false
+		}
+		switch member.Kind {
+		case ast.KindStringLiteral:
+			return element.Expression, member.AsStringLiteral().Text == name
+		case ast.KindNoSubstitutionTemplateLiteral:
+			return element.Expression, member.AsNoSubstitutionTemplateLiteral().Text == name
+		default:
+			return nil, false
+		}
+	default:
+		return nil, false
+	}
+}
+
+func match(call *ExpectCall) (Match, bool) {
+	if call == nil || call.HeadCall == nil || call.MatcherCall == nil ||
+		call.MatcherEntry.Node == nil || !equalityMatchers[call.Matcher] {
+		return Match{}, false
+	}
+
+	headArguments := call.HeadCall.Arguments()
+	matcherArguments := call.MatcherCall.Arguments()
+	if len(headArguments) == 0 || len(matcherArguments) != 1 {
+		return Match{}, false
+	}
+
+	includesCall := ast.SkipParentheses(headArguments[0])
+	if includesCall == nil || includesCall.Kind != ast.KindCallExpression || ast.IsOptionalChain(includesCall) {
+		return Match{}, false
+	}
+	includesExpression := includesCall.AsCallExpression()
+	receiver, ok := staticAccessor(includesExpression.Expression, "includes")
+	if !ok || ast.IsOptionalChain(ast.SkipParentheses(includesExpression.Expression)) {
+		return Match{}, false
+	}
+	includesArguments := includesCall.Arguments()
+	if len(includesArguments) != 1 || includesArguments[0].Kind == ast.KindSpreadElement {
+		return Match{}, false
+	}
+
+	matcherValue := testFramework.FollowTypeAssertionChain(matcherArguments[0])
+	if matcherValue == nil || matcherArguments[0].Kind == ast.KindSpreadElement {
+		return Match{}, false
+	}
+	value := false
+	switch matcherValue.Kind {
+	case ast.KindTrueKeyword:
+		value = true
+	case ast.KindFalseKeyword:
+	default:
+		return Match{}, false
+	}
+
+	notEntry := findNot(call.Modifiers)
+	return Match{
+		Expect: call, IncludesCall: includesCall, Receiver: receiver,
+		Item: includesArguments[0], MatcherValue: matcherArguments[0],
+		ShouldHaveNot: value == (notEntry != nil), NotEntry: notEntry,
+	}, true
+}
+
+func hasComment(ctx rule.RuleContext, node *ast.Node) bool {
+	if ctx.Comments == nil || node == nil {
+		return false
+	}
+	span := utils.TrimNodeTextRange(ctx.SourceFile, node)
+	return utils.HasCommentInSpan(ctx.Comments.All(), span.Pos(), span.End())
+}
+
+func callArgumentsHaveComment(ctx rule.RuleContext, call *ast.Node) bool {
+	if ctx.Comments == nil {
+		return false
+	}
+	span, ok := testFramework.CallArgumentListRange(ctx.SourceFile, call)
+	return ok && utils.HasCommentInSpan(ctx.Comments.All(), span.Pos(), span.End())
+}
+
+func BuildFixes(ctx rule.RuleContext, matched Match) []rule.RuleFix {
+	// Moving the item from inside expect(...) to the matcher call changes its
+	// position relative to a custom message expression. Report the style issue
+	// but do not reorder potentially observable evaluations.
+	if len(matched.Expect.HeadCall.Arguments()) != 1 ||
+		hasComment(ctx, matched.IncludesCall) ||
+		callArgumentsHaveComment(ctx, matched.IncludesCall) ||
+		callArgumentsHaveComment(ctx, matched.Expect.MatcherCall) {
+		return nil
+	}
+
+	matcherRange, matcherText, ok := testFramework.AccessorReplacement(
+		ctx.SourceFile,
+		matched.Expect.MatcherEntry.Node,
+		"toContain",
+	)
+	if !ok {
+		return nil
+	}
+
+	fixes := []rule.RuleFix{
+		rule.RuleFixReplace(ctx.SourceFile, matched.IncludesCall, utils.TrimmedNodeText(ctx.SourceFile, matched.Receiver)),
+		rule.RuleFixReplaceRange(matcherRange, matcherText),
+		rule.RuleFixReplace(ctx.SourceFile, matched.MatcherValue, utils.TrimmedNodeText(ctx.SourceFile, matched.Item)),
+	}
+
+	switch {
+	case matched.ShouldHaveNot && matched.NotEntry == nil:
+		span, text, ok := testFramework.InsertMemberBeforeAccessor(&matched.Expect.MatcherEntry, "not")
+		if !ok {
+			return nil
+		}
+		fixes = append(fixes, rule.RuleFixReplaceRange(span, text))
+	case !matched.ShouldHaveNot && matched.NotEntry != nil:
+		ranges, ok := testFramework.RemoveAccessorEntryRanges(ctx.SourceFile, ctx.Comments.All(), matched.NotEntry)
+		if !ok {
+			return nil
+		}
+		for _, span := range ranges {
+			fixes = append(fixes, rule.RuleFixRemoveRange(span))
+		}
+	}
+	return fixes
+}
+
+func NewRule(config Config) rule.Rule {
+	return rule.Rule{
+		Name:   config.Name,
+		Schema: rule.EmptyArraySchema,
+		Run: func(ctx rule.RuleContext, _ []any) rule.RuleListeners {
+			runtime := config.Prepare(ctx)
+			fixBuilder := config.BuildFixes
+			if fixBuilder == nil {
+				fixBuilder = BuildFixes
+			}
+			reported := map[*ast.Node]struct{}{}
+			return rule.RuleListeners{
+				ast.KindCallExpression: func(node *ast.Node) {
+					if runtime.Parse == nil {
+						return
+					}
+					matched, ok := match(runtime.Parse(node))
+					if !ok || (config.IgnoreMatch != nil && config.IgnoreMatch(ctx, matched)) {
+						return
+					}
+					if _, seen := reported[matched.Expect.MatcherCall]; seen {
+						return
+					}
+					reported[matched.Expect.MatcherCall] = struct{}{}
+					ctx.ReportNodeWithDeferredFixes(
+						matched.Expect.MatcherEntry.Node,
+						message(),
+						func() []rule.RuleFix { return fixBuilder(ctx, matched) },
+					)
+				},
+			}
+		},
+	}
+}

--- a/packages/rslint-test-tools/rstack.config.mts
+++ b/packages/rslint-test-tools/rstack.config.mts
@@ -686,6 +686,7 @@ define.test({
     './tests/rstest/rules/prefer-to-be.test.ts',
     './tests/rstest/rules/prefer-to-be-falsy.test.ts',
     './tests/rstest/rules/prefer-to-be-truthy.test.ts',
+    './tests/rstest/rules/prefer-to-contain.test.ts',
     './tests/rstest/rules/prefer-todo.test.ts',
     './tests/rstest/rules/require-awaited-expect-poll.test.ts',
     './tests/rstest/rules/require-to-throw-message.test.ts',

--- a/packages/rslint-test-tools/tests/rstest/rules/prefer-to-contain.test.ts
+++ b/packages/rslint-test-tools/tests/rstest/rules/prefer-to-contain.test.ts
@@ -1,0 +1,144 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('prefer-to-contain', {} as never, {
+  valid: [
+    { code: 'expect.hasAssertions' },
+    { code: 'expect.hasAssertions()' },
+    { code: 'expect.assertions(1)' },
+    { code: 'expect().toBe(false);' },
+    { code: 'expect(a).toContain(b);' },
+    { code: "expect(a.name).toBe('b');" },
+    { code: 'expect(a).toBe(true);' },
+    { code: 'expect(a).toEqual(b)' },
+    { code: 'expect(a.test(c)).toEqual(b)' },
+    { code: 'expect(a.includes(b)).toEqual()' },
+    { code: 'expect(a.includes(b)).toEqual("test")' },
+    { code: 'expect(a.includes(b)).toBe("test")' },
+    { code: 'expect(a.includes()).toEqual()' },
+    { code: 'expect(a.includes()).toEqual(true)' },
+    { code: 'expect(a.includes(b,c)).toBe(true)' },
+    { code: 'expect([{a:1}]).toContain({a:1})' },
+    { code: 'expect([1].includes(1)).toEqual' },
+    { code: 'expect([1].includes).toEqual' },
+    { code: 'expect([1].includes).not' },
+    { code: 'expect(a.test(b)).resolves.toEqual(true)' },
+    { code: 'expect(a.test(b)).resolves.not.toEqual(true)' },
+    { code: 'expect(a).not.toContain(b)' },
+    { code: 'expect(a.includes(...[])).toBe(true)' },
+    { code: 'expect(a.includes(b)).toBe(...true)' },
+    { code: 'expect(a);' },
+    { code: 'expect(a).to.be.a("string");' },
+  ],
+  invalid: [
+    {
+      code: 'expect(a.includes(b)).toEqual(true);',
+      output: 'expect(a).toContain(b);',
+      errors: [{ messageId: 'useToContain', column: 23, line: 1 }],
+    },
+    {
+      code: 'expect(a.includes(b,),).toEqual(true,);',
+      output: 'expect(a,).toContain(b,);',
+      errors: [{ messageId: 'useToContain', column: 25, line: 1 }],
+    },
+    {
+      code: "expect(a['includes'](b)).toEqual(true);",
+      output: 'expect(a).toContain(b);',
+      errors: [{ messageId: 'useToContain', column: 26, line: 1 }],
+    },
+    {
+      code: "expect(a['includes'](b))['toEqual'](true);",
+      output: "expect(a)['toContain'](b);",
+      errors: [{ messageId: 'useToContain', column: 26, line: 1 }],
+    },
+    {
+      code: "expect(a['includes'](b)).toEqual(false);",
+      output: 'expect(a).not.toContain(b);',
+      errors: [{ messageId: 'useToContain', column: 26, line: 1 }],
+    },
+    {
+      code: "expect(a['includes'](b)).not.toEqual(false);",
+      output: 'expect(a).toContain(b);',
+      errors: [{ messageId: 'useToContain', column: 30, line: 1 }],
+    },
+    {
+      code: "expect(a['includes'](b))['not']['toEqual'](false);",
+      output: "expect(a)['toContain'](b);",
+      errors: [{ messageId: 'useToContain', column: 33, line: 1 }],
+    },
+    {
+      code: 'expect(a.includes(b)).toEqual(false);',
+      output: 'expect(a).not.toContain(b);',
+      errors: [{ messageId: 'useToContain', column: 23, line: 1 }],
+    },
+    {
+      code: 'expect(a.includes(b)).not.toEqual(false);',
+      output: 'expect(a).toContain(b);',
+      errors: [{ messageId: 'useToContain', column: 27, line: 1 }],
+    },
+    {
+      code: 'expect(a.includes(b)).not.toEqual(true);',
+      output: 'expect(a).not.toContain(b);',
+      errors: [{ messageId: 'useToContain', column: 27, line: 1 }],
+    },
+    {
+      code: 'expect(a.includes(b)).toBe(true);',
+      output: 'expect(a).toContain(b);',
+      errors: [{ messageId: 'useToContain', column: 23, line: 1 }],
+    },
+    {
+      code: 'expect(a.includes(b)).toBe(false);',
+      output: 'expect(a).not.toContain(b);',
+      errors: [{ messageId: 'useToContain', column: 23, line: 1 }],
+    },
+    {
+      code: 'expect(a.includes(b)).not.toBe(false);',
+      output: 'expect(a).toContain(b);',
+      errors: [{ messageId: 'useToContain', column: 27, line: 1 }],
+    },
+    {
+      code: 'expect(a.includes(b)).not.toBe(true);',
+      output: 'expect(a).not.toContain(b);',
+      errors: [{ messageId: 'useToContain', column: 27, line: 1 }],
+    },
+    {
+      code: 'expect(a.includes(b)).toStrictEqual(true);',
+      output: 'expect(a).toContain(b);',
+      errors: [{ messageId: 'useToContain', column: 23, line: 1 }],
+    },
+    {
+      code: 'expect(a.includes(b)).toStrictEqual(false);',
+      output: 'expect(a).not.toContain(b);',
+      errors: [{ messageId: 'useToContain', column: 23, line: 1 }],
+    },
+    {
+      code: 'expect(a.includes(b)).not.toStrictEqual(false);',
+      output: 'expect(a).toContain(b);',
+      errors: [{ messageId: 'useToContain', column: 27, line: 1 }],
+    },
+    {
+      code: 'expect(a.includes(b)).not.toStrictEqual(true);',
+      output: 'expect(a).not.toContain(b);',
+      errors: [{ messageId: 'useToContain', column: 27, line: 1 }],
+    },
+    {
+      code: 'expect(a.test(t).includes(b.test(p))).toEqual(true);',
+      errors: [{ messageId: 'useToContain', column: 39, line: 1 }],
+    },
+    {
+      code: 'expect(a.test(t).includes(b.test(p))).not.toEqual(false);',
+      errors: [{ messageId: 'useToContain', column: 43, line: 1 }],
+    },
+    {
+      code: 'expect([{a:1}].includes({a:1})).toBe(true);',
+      output: 'expect([{a:1}]).toContain({a:1});',
+      errors: [{ messageId: 'useToContain', column: 33, line: 1 }],
+    },
+    {
+      code: 'expect([{a:1}].includes({a:1})).not.toStrictEqual(false);',
+      output: 'expect([{a:1}]).toContain({a:1});',
+      errors: [{ messageId: 'useToContain', column: 37, line: 1 }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Add `rstest/prefer-to-contain` to replace equality assertions over `includes()` boolean results with clearer containment assertions.

## Credits

- Port from [`@vitest/eslint-plugin@1.6.27`'s `prefer-to-contain` documentation](https://github.com/vitest-dev/eslint-plugin-vitest/blob/v1.6.27/docs/rules/prefer-to-contain.md), [source](https://github.com/vitest-dev/eslint-plugin-vitest/blob/v1.6.27/src/rules/prefer-to-contain.ts), and tests.

## Intentional differences from upstream

- **Explicit `NaN` items are excluded.** `Array.prototype.includes()` uses SameValueZero and matches `NaN`, while Rstest's current `toContain()` array path does not. Rewriting would reverse a passing assertion.

- **String literal receivers with regexp items are excluded.** Native `String.prototype.includes()` rejects regular expressions, while matcher behavior is not the same assertion shape.

- **Autofixes are withheld when moving the item may change evaluation order.** For example, function calls, property reads, custom `expect()` message arguments, and comments inside edited ranges still report but do not fix.

- **Assertion-factory and matcher type arguments are removed for Rstest autofixes.** These type arguments describe the original boolean assertion and may become invalid after the received value and matcher argument are replaced.

- **Accessor spelling is preserved.** Quoted and template-literal matcher accessors retain their delimiters instead of being normalized.

- **Type arguments containing comments are not fixed.** The rule still reports, but avoids deleting comments from either the assertion factory or matcher type arguments.

- **Chai `.deep` chains are excluded.** The flag changes `toContain()` to use deep equality, which does not match the identity comparison performed by `includes()`.

- **Assertion chains that continue after the equality matcher are excluded.** Replacing the received boolean would change the value observed by later matchers or chained members.

## Related Links

Related #935

## Checklist

- [x] Tests updated.
- [x] Documentation updated.
