### PR TITLE
feat: port rule unicorn/empty-brace-spaces

### DIFF
--- a/internal/plugins/unicorn/all.go
+++ b/internal/plugins/unicorn/all.go
@@ -4,6 +4,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/catch_error_name"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/consistent_date_clone"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/consistent_tuple_labels"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/empty_brace_spaces"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/error_message"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/filename_case"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/new_for_builtins"
@@ -54,6 +55,7 @@ func GetAllRules() []rule.Rule {
 		catch_error_name.CatchErrorNameRule,
 		consistent_date_clone.ConsistentDateCloneRule,
 		consistent_tuple_labels.ConsistentTupleLabelsRule,
+		empty_brace_spaces.EmptyBraceSpacesRule,
 		error_message.ErrorMessageRule,
 		filename_case.FilenameCaseRule,
 		new_for_builtins.NewForBuiltinsRule,

--- a/internal/plugins/unicorn/rules/empty_brace_spaces/empty_brace_spaces.go
+++ b/internal/plugins/unicorn/rules/empty_brace_spaces/empty_brace_spaces.go
@@ -5,7 +5,6 @@ package empty_brace_spaces
 import (
 	"github.com/microsoft/TypeScript/tsc/shim/ast"
 	"github.com/microsoft/TypeScript/tsc/shim/core"
-	"github.com/microsoft/TypeScript/tsc/shim/scanner"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 	"github.com/web-infra-dev/rslint/internal/utils/ecmascript"
@@ -55,23 +54,33 @@ func hasChildren(node *ast.Node) bool {
 	}
 }
 
-// innerBraceRange returns the span strictly between the node's opening and
-// closing braces. The opening brace is located with a scan bounded by
-// node.End(), because a `static {}` block starts at the `static` keyword and
-// the enclosing class body's brace comes first. The closing brace is always
-// the node's last character for every node kind this rule inspects.
+// innerBraceRange returns the span strictly between the node's own braces. The
+// node's last token is always its closing brace, so the pair is located by
+// walking the node's tokens and remembering the `{` that leaves the nesting
+// depth at zero. Scanning for the first `{` instead would pick up a brace that
+// belongs to the node's header — `class A extends mixin({}) { }` — or to a
+// header type, leaving the real pair unreported.
 func innerBraceRange(node *ast.Node, sourceFile *ast.SourceFile) (core.TextRange, bool) {
-	start := scanner.SkipTrivia(sourceFile.Text(), utils.TrimNodeTextRange(sourceFile, node).Pos())
 	end := node.End()
+	depth := 0
+	opening := -1
 
-	s := scanner.GetScannerForSourceFile(sourceFile, start)
-	for s.TokenStart() < end {
-		if s.Token() == ast.KindOpenBraceToken {
-			return core.NewTextRange(s.TokenEnd(), end-1), true
+	utils.ForEachToken(node, func(token *ast.Node) {
+		switch token.Kind {
+		case ast.KindOpenBraceToken:
+			if depth == 0 {
+				opening = token.End()
+			}
+			depth++
+		case ast.KindCloseBraceToken:
+			depth--
 		}
-		s.Scan()
+	}, sourceFile)
+
+	if opening < 0 {
+		return core.TextRange{}, false
 	}
-	return core.TextRange{}, false
+	return core.NewTextRange(opening, end-1), true
 }
 
 // isWhitespaceOnly reports whether text is made up solely of ECMAScript

--- a/internal/plugins/unicorn/rules/empty_brace_spaces/empty_brace_spaces.go
+++ b/internal/plugins/unicorn/rules/empty_brace_spaces/empty_brace_spaces.go
@@ -1,0 +1,116 @@
+// Package empty_brace_spaces ports eslint-plugin-unicorn's
+// `empty-brace-spaces` rule.
+package empty_brace_spaces
+
+import (
+	"github.com/microsoft/TypeScript/tsc/shim/ast"
+	"github.com/microsoft/TypeScript/tsc/shim/core"
+	"github.com/microsoft/TypeScript/tsc/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+	"github.com/web-infra-dev/rslint/internal/utils/ecmascript"
+)
+
+var messageEmptyBraceSpaces = rule.RuleMessage{
+	Id:          "empty-brace-spaces",
+	Description: "Do not add spaces between braces.",
+}
+
+// isStaticBlockBody reports whether a Block is the body tsgo nests inside a
+// `static {}` block. ESTree has no such node — upstream sees a single
+// StaticBlock — so the outer KindClassStaticBlockDeclaration listener already
+// covers this brace pair and observing the nested Block too would report the
+// identical span twice.
+func isStaticBlockBody(node *ast.Node) bool {
+	return node.Parent != nil && node.Parent.Kind == ast.KindClassStaticBlockDeclaration
+}
+
+// hasChildren reports whether the node already holds content, in which case
+// the braces are not an empty pair. `SemicolonClassElement` entries are stray
+// `;` between class members and have no ESTree counterpart, so they keep a
+// class body "empty" the way upstream's `node.body` does.
+func hasChildren(node *ast.Node) bool {
+	switch node.Kind {
+	case ast.KindObjectLiteralExpression:
+		return len(node.AsObjectLiteralExpression().Properties.Nodes) > 0
+	case ast.KindBlock, ast.KindClassStaticBlockDeclaration:
+		// tsgo keeps the Block of a `static {}` block on the declaration's
+		// own `Body` field, while `Block.Body()` is the node itself.
+		body := node
+		if node.Kind == ast.KindClassStaticBlockDeclaration {
+			body = node.AsClassStaticBlockDeclaration().Body
+		}
+		if body == nil {
+			return false
+		}
+		return len(body.AsBlock().Statements.Nodes) > 0
+	default:
+		members := node.Members()
+		for _, member := range members {
+			if member != nil && !ast.IsSemicolonClassElement(member) {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+// innerBraceRange returns the span strictly between the node's opening and
+// closing braces. The opening brace is located with a scan bounded by
+// node.End(), because a `static {}` block starts at the `static` keyword and
+// the enclosing class body's brace comes first. The closing brace is always
+// the node's last character for every node kind this rule inspects.
+func innerBraceRange(node *ast.Node, sourceFile *ast.SourceFile) (core.TextRange, bool) {
+	start := scanner.SkipTrivia(sourceFile.Text(), utils.TrimNodeTextRange(sourceFile, node).Pos())
+	end := node.End()
+
+	s := scanner.GetScannerForSourceFile(sourceFile, start)
+	for s.TokenStart() < end {
+		if s.Token() == ast.KindOpenBraceToken {
+			return core.NewTextRange(s.TokenEnd(), end-1), true
+		}
+		s.Scan()
+	}
+	return core.TextRange{}, false
+}
+
+// isWhitespaceOnly reports whether text is made up solely of ECMAScript
+// whitespace, mirroring upstream's `/^\s+$/` test. `ecmascript.IsBlank`
+// matches JavaScript's `\s` exactly, unlike `strings.TrimSpace`.
+func isWhitespaceOnly(text string) bool {
+	return text != "" && ecmascript.IsBlank(text)
+}
+
+// EmptyBraceSpacesRule disallows whitespace between the braces of an empty
+// block, class body, static block, or object literal.
+//
+// https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v73.0.0/rules/empty-brace-spaces.js
+var EmptyBraceSpacesRule = rule.Rule{
+	Name:   "unicorn/empty-brace-spaces",
+	Schema: rule.EmptyArraySchema,
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		check := func(node *ast.Node) {
+			if isStaticBlockBody(node) || hasChildren(node) {
+				return
+			}
+
+			inner, ok := innerBraceRange(node, ctx.SourceFile)
+			if !ok {
+				return
+			}
+			if !isWhitespaceOnly(ctx.SourceFile.Text()[inner.Pos():inner.End()]) {
+				return
+			}
+
+			ctx.ReportRangeWithFixes(inner, messageEmptyBraceSpaces, rule.RuleFixRemoveRange(inner))
+		}
+
+		return rule.RuleListeners{
+			ast.KindBlock:                       check,
+			ast.KindClassDeclaration:            check,
+			ast.KindClassExpression:             check,
+			ast.KindClassStaticBlockDeclaration: check,
+			ast.KindObjectLiteralExpression:     check,
+		}
+	},
+}

--- a/internal/plugins/unicorn/rules/empty_brace_spaces/empty_brace_spaces.md
+++ b/internal/plugins/unicorn/rules/empty_brace_spaces/empty_brace_spaces.md
@@ -1,0 +1,54 @@
+# empty-brace-spaces
+
+## Rule Details
+
+Enforce no spaces between braces.
+
+Empty blocks and object literals do not need internal whitespace, so this rule
+enforces a compact, consistent style. It applies to block statements, class
+bodies, static blocks, and object literals whose braces hold nothing but
+whitespace.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+class Unicorn {
+}
+
+try {
+	foo();
+} catch { }
+
+const object = { };
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+class Unicorn {}
+
+try {
+	foo();
+} catch {}
+
+const object = {};
+```
+
+The rule has no options. It is automatically fixable by removing the
+whitespace between the braces.
+
+A comment between the braces counts as content, so the whitespace around it is
+left untouched:
+
+```javascript
+class Unicorn { /* comment */ }
+```
+
+## Differences from ESLint
+
+None.
+
+## Original Documentation
+
+- [eslint-plugin-unicorn: empty-brace-spaces](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v73.0.0/docs/rules/empty-brace-spaces.md)
+- [Source code](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v73.0.0/rules/empty-brace-spaces.js)

--- a/internal/plugins/unicorn/rules/empty_brace_spaces/empty_brace_spaces.md
+++ b/internal/plugins/unicorn/rules/empty_brace_spaces/empty_brace_spaces.md
@@ -44,6 +44,11 @@ left untouched:
 class Unicorn { /* comment */ }
 ```
 
+A brace pair in a class header is not mistaken for the class body: `class Foo
+extends mixin({}) { }` reports the body's space and fixes it to `class Foo
+extends mixin({}) {}`, and a header pair that is itself empty is reported
+separately.
+
 ## Differences from ESLint
 
 None.

--- a/internal/plugins/unicorn/rules/empty_brace_spaces/empty_brace_spaces_extras_test.go
+++ b/internal/plugins/unicorn/rules/empty_brace_spaces/empty_brace_spaces_extras_test.go
@@ -1,0 +1,241 @@
+// rslint-specific coverage for empty-brace-spaces. The cases here exercise the
+// TypeScript-only AST shapes and the tsgo/ESTree structural differences the Go
+// port has to bridge; the upstream suite lives in
+// empty_brace_spaces_upstream_test.go.
+package empty_brace_spaces_test
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf16"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/empty_brace_spaces"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// reportAt builds an invalid case reporting the whitespace between braces that
+// spans `code[start:end]` (byte offsets, end exclusive). Upstream reports
+// `loc: {start: openingBrace.end, end: closingBrace.start}` and removes the
+// same span, so `output` drops that slice.
+func reportAt(code, file string, start, end int) rule_tester.InvalidTestCase {
+	locate := func(offset int) (int, int) {
+		prefix := code[:offset]
+		lineStart := strings.LastIndex(prefix, "\n") + 1
+		return strings.Count(prefix, "\n") + 1, len(utf16.Encode([]rune(prefix[lineStart:]))) + 1
+	}
+	line, column := locate(start)
+	endLine, endColumn := locate(end)
+
+	return rule_tester.InvalidTestCase{
+		Code:     code,
+		FileName: file,
+		Output:   []string{code[:start] + code[end:]},
+		Errors: []rule_tester.InvalidTestCaseError{{
+			MessageId: messageID,
+			Message:   messageText,
+			Line:      line,
+			Column:    column,
+			EndLine:   endLine,
+			EndColumn: endColumn,
+		}},
+	}
+}
+
+// emptyPairSpans lists the whitespace spans of every empty brace pair in code,
+// in source order. Braces are matched literally, which is enough for the
+// snippets below: none of them hides a brace inside a string or a comment.
+func emptyPairSpans(code string) [][2]int {
+	var spans [][2]int
+	var stack []int
+	for i := range len(code) {
+		switch code[i] {
+		case '{':
+			stack = append(stack, i)
+		case '}':
+			if len(stack) == 0 {
+				continue
+			}
+			open := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			if spaces := code[open+1 : i]; strings.Trim(spaces, " \t\n\r\v\f\u00a0\u3000\ufeff") == "" {
+				spans = append(spans, [2]int{open + 1, i})
+			}
+		}
+	}
+	return spans
+}
+
+// invalidTS reports the only empty brace pair of a `.ts` case. It fails the
+// test when the snippet does not have exactly one pair, so a case can never
+// silently assert the wrong brace.
+func invalidTS(t *testing.T, code string) rule_tester.InvalidTestCase {
+	t.Helper()
+	spans := emptyPairSpans(code)
+	if len(spans) != 1 {
+		t.Fatalf("expected exactly 1 empty brace pair in %q, found %d", code, len(spans))
+	}
+	return reportAt(code, "file.ts", spans[0][0], spans[0][1])
+}
+
+func validTS(code string) rule_tester.ValidTestCase {
+	return rule_tester.ValidTestCase{Code: code, FileName: "file.ts"}
+}
+
+func TestEmptyBraceSpacesExtras(t *testing.T) {
+	valid := []rule_tester.ValidTestCase{
+		// ---- Empty pairs without whitespace ----
+		validTS(`class A {}`),
+		validTS(`function f() {}`),
+		validTS(`const o = {};`),
+		validTS(`class A {static {}}`),
+
+		// ---- Comment-only bodies keep the pair non-empty ----
+		// Upstream's `/^\s+$/` test rejects a comment, so the whitespace
+		// around it must survive untouched.
+		validTS("class A { /* c */ }"),
+		validTS("function f() {\n\t// c\n}"),
+		validTS("const o = { /* c */ };"),
+		validTS("class A {static { /* c */ }}"),
+		validTS("try {} finally { /* c */ }"),
+
+		// ---- Non-empty bodies ----
+		validTS(`class A { m() {} }`),
+		validTS(`class A { static m() {} }`),
+		validTS("class A {\n\tm(): void {}\n}"),
+		validTS(`function f() { return 1; }`),
+		validTS(`const o = {a: 1};`),
+		// A stray `;` is content between the braces, so it is not whitespace.
+		validTS(`class A {;}`),
+		validTS("class A { ; }"),
+		validTS("const o = { ...s, };"),
+
+		// ---- AST shapes the rule must not inspect ----
+		// A switch CaseBlock, an object binding pattern, an import clause, a
+		// type literal, and an enum body are not BlockStatement / ClassBody /
+		// StaticBlock / ObjectExpression upstream either.
+		validTS("switch (foo) { }"),
+		validTS("const { } = foo;"),
+		validTS(`import { } from "foo";`),
+		validTS("export { };"),
+		validTS("import { } from \"foo\";\nexport type T = { };\ninterface I { }\nenum E { }"),
+		validTS("const x: { } = {};"),
+		validTS("function f(): { } { return {}; }"),
+		validTS("namespace N { }"),
+		validTS("declare namespace N { }"),
+		validTS("type T = { };"),
+		validTS("declare module 'm' { }"),
+
+		// ---- JSX: an attribute brace pair is not an object literal ----
+		{Code: "const a = <div style={ } />;", FileName: "file.tsx", Tsx: true},
+
+		// ---- Whitespace the rule does not treat as `\s` ----
+		// U+200B ZERO WIDTH SPACE is not ECMAScript whitespace.
+		validTS("class A {\u200b}"),
+
+		// ---- `with` keeps the script source goal ----
+		{
+			Code:            "with (foo) {}",
+			FileName:        "file.js",
+			LanguageOptions: rule.LanguageOptions{SourceType: "script"},
+		},
+	}
+
+	invalid := []rule_tester.InvalidTestCase{
+		// ---- TypeScript-only class declarations ----
+		invalidTS(t, `class A { }`),
+		invalidTS(t, "abstract class A {\n}"),
+		invalidTS(t, "declare class A { }"),
+		invalidTS(t, `export default class { }`),
+		invalidTS(t, `export class A { }`),
+		invalidTS(t, `const A = class { }`),
+		// Ambience, type parameters, and heritage sit between `class` and the
+		// body, so the brace scan has to skip them.
+		invalidTS(t, `class A<T> { }`),
+		invalidTS(t, `class A extends B { }`),
+		invalidTS(t, `class A implements I { }`),
+
+		// ---- Decorated empty class bodies ----
+		invalidTS(t, "@sealed\nclass A { }"),
+
+		// ---- Static blocks ----
+		// The class body itself is not empty, so only the block's pair qualifies.
+		invalidTS(t, "class A {static { }}"),
+		invalidTS(t, "class A { static {   } }"),
+		invalidTS(t, "class A {static {\n}}"),
+
+		// ---- Block statements ----
+		invalidTS(t, `if (a) { }`),
+		invalidTS(t, `while (a) { }`),
+		invalidTS(t, `for (;;) { }`),
+		invalidTS(t, `do { } while (a)`),
+		invalidTS(t, `const f = () => { }`),
+		// A labeled statement is still a BlockStatement.
+		invalidTS(t, `label: { }`),
+		// A destructuring parameter introduces braces before the body; the scan
+		// must still land on the function body's brace.
+		invalidTS(t, `const f = ({a}) => { }`),
+		invalidTS(t, `const f = ([a]) => { }`),
+		invalidTS(t, `function f({a}) { }`),
+		invalidTS(t, `function f({a}: {a: number}) { }`),
+		// A default value and the body are independent empty pairs, so both are
+		// reported and both are fixed in one pass.
+		{
+			Code:     `function f(x = { }) { }`,
+			FileName: "file.ts",
+			Output:   []string{`function f(x = {}) {}`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: messageID,
+					Message:   messageText,
+					Line:      1,
+					Column:    17,
+					EndLine:   1,
+					EndColumn: 18,
+				},
+				{
+					MessageId: messageID,
+					Message:   messageText,
+					Line:      1,
+					Column:    22,
+					EndLine:   1,
+					EndColumn: 23,
+				},
+			},
+		},
+		// A nested empty block reports once per pair.
+		{
+			Code:     "function f() {\n\tif (a) { }\n}",
+			FileName: "file.ts",
+			Output:   []string{"function f() {\n\tif (a) {}\n}"},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: messageID,
+				Message:   messageText,
+				Line:      2,
+				Column:    10,
+				EndLine:   2,
+				EndColumn: 11,
+			}},
+		},
+
+		// ---- Object literals ----
+		invalidTS(t, `const o = { };`),
+		invalidTS(t, "const o = {\n};"),
+		invalidTS(t, `f({ });`),
+		// The inner pair is the empty one; the outer literal holds a property.
+		invalidTS(t, `const o = { a: { } };`),
+
+		// ---- ECMAScript whitespace beyond ASCII ----
+		// U+00A0 NBSP spans two UTF-8 bytes while the end column counts the
+		// single decoded character.
+		invalidTS(t, "class A {\u00a0}"),
+		invalidTS(t, "class A {\u3000}"),
+		invalidTS(t, "class A {\ufeff}"),
+		invalidTS(t, "class A {\v}"),
+		invalidTS(t, "class A {\f}"),
+		invalidTS(t, "class A {\r\n}"),
+	}
+
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &empty_brace_spaces.EmptyBraceSpacesRule, valid, invalid)
+}

--- a/internal/plugins/unicorn/rules/empty_brace_spaces/empty_brace_spaces_extras_test.go
+++ b/internal/plugins/unicorn/rules/empty_brace_spaces/empty_brace_spaces_extras_test.go
@@ -5,6 +5,7 @@
 package empty_brace_spaces_test
 
 import (
+	"slices"
 	"strings"
 	"testing"
 	"unicode/utf16"
@@ -15,11 +16,10 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
 
-// reportAt builds an invalid case reporting the whitespace between braces that
-// spans `code[start:end]` (byte offsets, end exclusive). Upstream reports
-// `loc: {start: openingBrace.end, end: closingBrace.start}` and removes the
-// same span, so `output` drops that slice.
-func reportAt(code, file string, start, end int) rule_tester.InvalidTestCase {
+// sourcePosition returns the 1-based line and UTF-16 column for byte offsets
+// within code. `start` is the first byte of the reported span and `end` is one
+// past its last byte.
+func sourcePosition(code string, start, end int) (int, int, int, int) {
 	locate := func(offset int) (int, int) {
 		prefix := code[:offset]
 		lineStart := strings.LastIndex(prefix, "\n") + 1
@@ -27,6 +27,15 @@ func reportAt(code, file string, start, end int) rule_tester.InvalidTestCase {
 	}
 	line, column := locate(start)
 	endLine, endColumn := locate(end)
+	return line, column, endLine, endColumn
+}
+
+// reportAt builds an invalid case reporting the whitespace between braces that
+// spans `code[start:end]` (byte offsets, end exclusive). Upstream reports
+// `loc: {start: openingBrace.end, end: closingBrace.start}` and removes the
+// same span, so `output` drops that slice.
+func reportAt(code, file string, start, end int) rule_tester.InvalidTestCase {
+	line, column, endLine, endColumn := sourcePosition(code, start, end)
 
 	return rule_tester.InvalidTestCase{
 		Code:     code,
@@ -43,11 +52,12 @@ func reportAt(code, file string, start, end int) rule_tester.InvalidTestCase {
 	}
 }
 
-// emptyPairSpans lists the whitespace spans of every empty brace pair in code,
-// in source order. Braces are matched literally, which is enough for the
-// snippets below: none of them hides a brace inside a string or a comment.
-func emptyPairSpans(code string) [][2]int {
-	var spans [][2]int
+// emptyPairSpans reports the whitespace span of each empty brace pair, keyed by
+// the position of its opening brace so that iteration in key order is source
+// order. Braces are matched literally, which is enough for the snippets below:
+// none of them hides a brace inside a string or a comment.
+func emptyPairSpans(code string) map[int][2]int {
+	spans := make(map[int][2]int)
 	var stack []int
 	for i := range len(code) {
 		switch code[i] {
@@ -59,24 +69,99 @@ func emptyPairSpans(code string) [][2]int {
 			}
 			open := stack[len(stack)-1]
 			stack = stack[:len(stack)-1]
-			if spaces := code[open+1 : i]; strings.Trim(spaces, " \t\n\r\v\f\u00a0\u3000\ufeff") == "" {
-				spans = append(spans, [2]int{open + 1, i})
+			// Only a whitespace-only run is reported; an already-compact pair
+			// such as `{}` produces no diagnostic.
+			if spaces := code[open+1 : i]; spaces != "" && strings.Trim(spaces, " \t\n\r\v\f\u00a0\u3000\ufeff") == "" {
+				spans[open] = [2]int{open + 1, i}
 			}
 		}
 	}
 	return spans
 }
 
-// invalidTS reports the only empty brace pair of a `.ts` case. It fails the
-// test when the snippet does not have exactly one pair, so a case can never
-// silently assert the wrong brace.
+// invalidTS reports the whitespace run inside the last empty brace pair of a
+// `.ts` case. Every case here is written so that the pair the rule reports is
+// the final empty one in the snippet, which keeps the assertion unambiguous
+// without restating byte offsets. It fails the test when that pair is missing,
+// so a case can never silently assert the wrong brace.
 func invalidTS(t *testing.T, code string) rule_tester.InvalidTestCase {
 	t.Helper()
 	spans := emptyPairSpans(code)
-	if len(spans) != 1 {
-		t.Fatalf("expected exactly 1 empty brace pair in %q, found %d", code, len(spans))
+	openings := sortedOpenings(spans)
+	if len(openings) == 0 {
+		t.Fatalf("no empty brace pair in %q", code)
 	}
-	return reportAt(code, "file.ts", spans[0][0], spans[0][1])
+	span := spans[openings[len(openings)-1]]
+	return reportAt(code, "file.ts", span[0], span[1])
+}
+
+// invalidTSPairs reports every empty brace pair of a `.ts` case. Diagnostics
+// are ordered the way the rule visits the nodes — a class body before the
+// header expression nested in it — because the RuleTester matches the expected
+// errors by index.
+func invalidTSPairs(t *testing.T, code string) rule_tester.InvalidTestCase {
+	t.Helper()
+	spans := emptyPairSpans(code)
+	openings := sortedOpenings(spans)
+	if len(openings) == 0 {
+		t.Fatalf("no empty brace pair in %q", code)
+	}
+	// The rule reports a class body before the header braces nested inside it.
+	reversed := make([]int, 0, len(openings))
+	for i := len(openings) - 1; i >= 0; i-- {
+		reversed = append(reversed, openings[i])
+	}
+
+	testCase := reportAt(code, "file.ts", spans[openings[0]][0], spans[openings[0]][1])
+	testCase.Errors = nil
+	for _, opening := range reversed {
+		span := spans[opening]
+		line, column, endLine, endColumn := sourcePosition(code, span[0], span[1])
+		testCase.Errors = append(testCase.Errors, rule_tester.InvalidTestCaseError{
+			MessageId: messageID,
+			Message:   messageText,
+			Line:      line,
+			Column:    column,
+			EndLine:   endLine,
+			EndColumn: endColumn,
+		})
+	}
+	testCase.Output = []string{removeSpans(code, spans, openings)}
+	return testCase
+}
+
+// removeSpans deletes every listed span from code, right to left so the
+// remaining offsets stay valid.
+func removeSpans(code string, spans map[int][2]int, openings []int) string {
+	out := code
+	for i := len(openings) - 1; i >= 0; i-- {
+		span := spans[openings[i]]
+		out = out[:span[0]] + out[span[1]:]
+	}
+	return out
+}
+
+// invalidTSNested reports the innermost empty brace pair of a nested snippet
+// such as `const o = { a: { } };`, where the outer pair is not empty.
+func invalidTSNested(t *testing.T, code string) rule_tester.InvalidTestCase {
+	t.Helper()
+	spans := emptyPairSpans(code)
+	openings := sortedOpenings(spans)
+	if len(openings) == 0 {
+		t.Fatalf("no empty brace pair in %q", code)
+	}
+	// The innermost pair is the one whose opening brace comes last.
+	span := spans[openings[len(openings)-1]]
+	return reportAt(code, "file.ts", span[0], span[1])
+}
+
+func sortedOpenings(spans map[int][2]int) []int {
+	openings := make([]int, 0, len(spans))
+	for opening := range spans {
+		openings = append(openings, opening)
+	}
+	slices.Sort(openings)
+	return openings
 }
 
 func validTS(code string) rule_tester.ValidTestCase {
@@ -155,15 +240,28 @@ func TestEmptyBraceSpacesExtras(t *testing.T) {
 		invalidTS(t, `class A<T> { }`),
 		invalidTS(t, `class A extends B { }`),
 		invalidTS(t, `class A implements I { }`),
+		// A brace in the class header must not be mistaken for the body's
+		// opener: `mixin({})` and a `T extends {}` bound both contribute a
+		// brace pair before the body starts.
+		invalidTS(t, `class A extends mixin({}) { }`),
+		invalidTS(t, `class A<T extends {}> { }`),
+		invalidTS(t, `@decorator({}) class A { }`),
+		// A header brace pair that holds a property is not empty, so only the
+		// class body is reported.
+		invalidTS(t, `class A extends mixin({ a: 1 }) { }`),
+		// A header brace pair that is itself empty is reported too, and both
+		// fixes are applied in a single pass.
+		invalidTSPairs(t, `class A extends mixin({ }) { }`),
 
 		// ---- Decorated empty class bodies ----
 		invalidTS(t, "@sealed\nclass A { }"),
 
 		// ---- Static blocks ----
-		// The class body itself is not empty, so only the block's pair qualifies.
-		invalidTS(t, "class A {static { }}"),
-		invalidTS(t, "class A { static {   } }"),
-		invalidTS(t, "class A {static {\n}}"),
+		// The class body's own pair is already compact, so only the static
+		// block's whitespace is reported.
+		invalidTSPairs(t, "class A {static { }}"),
+		invalidTSPairs(t, "class A { static {   } }"),
+		invalidTSPairs(t, "class A {static {\n}}"),
 
 		// ---- Block statements ----
 		invalidTS(t, `if (a) { }`),
@@ -224,7 +322,7 @@ func TestEmptyBraceSpacesExtras(t *testing.T) {
 		invalidTS(t, "const o = {\n};"),
 		invalidTS(t, `f({ });`),
 		// The inner pair is the empty one; the outer literal holds a property.
-		invalidTS(t, `const o = { a: { } };`),
+		invalidTSNested(t, `const o = { a: { } };`),
 
 		// ---- ECMAScript whitespace beyond ASCII ----
 		// U+00A0 NBSP spans two UTF-8 bytes while the end column counts the

--- a/internal/plugins/unicorn/rules/empty_brace_spaces/empty_brace_spaces_upstream_test.go
+++ b/internal/plugins/unicorn/rules/empty_brace_spaces/empty_brace_spaces_upstream_test.go
@@ -1,0 +1,182 @@
+// TestEmptyBraceSpacesUpstream migrates the valid/invalid suite from
+// eslint-plugin-unicorn v73.0.0/test/empty-brace-spaces.js 1:1. The upstream
+// suite builds its cases from a small set of templates, so the expansion is
+// reproduced here with the same grouping and placeholder substitution.
+// rslint-specific lock-in cases live in empty_brace_spaces_extras_test.go.
+package empty_brace_spaces_test
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf16"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/empty_brace_spaces"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+const (
+	messageID   = "empty-brace-spaces"
+	messageText = "Do not add spaces between braces."
+	placeholder = "/* */"
+)
+
+// cases holds every upstream template that produces a BlockStatement,
+// StaticBlock, or ObjectExpression brace pair.
+var cases = []string{
+	"{/* */}",
+	"function foo(){/* */}",
+	"if(foo) {/* */}",
+	"if(foo) {} else if (bar) {/* */}",
+	"if(foo) {} else {/* */}",
+	"for(;;){/* */}",
+	"for(foo in bar){/* */}",
+	"for(foo of bar){/* */}",
+	"switch (foo) {case bar: {/* */}}",
+	"switch (foo) {default: {/* */}}",
+	"try {/* */} catch(foo){}",
+	"try {} catch(bar){/* */}",
+	"try {} catch(foo){} finally {/* */}",
+	"do {/* */} while (foo)",
+	"while (foo){/* */}",
+	"foo = () => {/* */}",
+	"foo = function (){/* */}",
+	"foo = {/* */}",
+	"class Foo {bar() {/* */}}",
+	"foo = class {bar() {/* */}}",
+	"class Foo {static  {/* */}}",
+}
+
+// classBodyCases are the templates whose placeholder sits between a class's
+// braces, where replacing it with a method keeps the class body non-empty.
+var classBodyCases = []string{
+	"class Foo {/* */}",
+	"foo = class {/* */}",
+}
+
+var allCases = append(append([]string{}, cases...), classBodyCases...)
+
+// ignoredCases are empty brace pairs upstream does not inspect: a switch
+// CaseBlock, an object binding pattern, and an import clause.
+var ignoredCases = []string{
+	"switch (foo) {/* */}",
+	"const {/* */} = foo",
+	`import {/* */} from "foo"`,
+}
+
+func replacePlaceholder(code, replacement string) string {
+	return strings.Replace(code, placeholder, replacement, 1)
+}
+
+// replaceAllPlaceholders mimics upstream's `String.prototype.replaceAll`, which
+// feeds the same replacement to every placeholder occurrence in a template
+// such as `try {/* */} catch(bar){/* */}`.
+func replaceAllPlaceholders(code, replacement string) string {
+	return strings.ReplaceAll(code, placeholder, replacement)
+}
+
+// position returns the 1-based line and UTF-16 column for byte offsets within
+// code. `start` is the first byte of the reported span and `end` is one past
+// its last byte.
+func position(code string, start, end int) (int, int, int, int) {
+	locate := func(offset int) (int, int) {
+		prefix := code[:offset]
+		lineStart := strings.LastIndex(prefix, "\n") + 1
+		return strings.Count(prefix, "\n") + 1, len(utf16.Encode([]rune(prefix[lineStart:]))) + 1
+	}
+	line, column := locate(start)
+	endLine, endColumn := locate(end)
+	return line, column, endLine, endColumn
+}
+
+// invalidCase builds an invalid test case for a template whose placeholder is
+// replaced with whitespace. Every placeholder site marks the inside of a brace
+// pair, so each one reports the whitespace span between its braces.
+func invalidCase(template, spaces string) rule_tester.InvalidTestCase {
+	code := replaceAllPlaceholders(template, spaces)
+	output := replaceAllPlaceholders(template, "")
+
+	var errors []rule_tester.InvalidTestCaseError
+	searchFrom := 0
+	for {
+		site := strings.Index(template[searchFrom:], placeholder)
+		if site < 0 {
+			break
+		}
+		site += searchFrom
+
+		// Byte offsets of the reported span in the substituted code: from the
+		// end of the opening brace through the start of the closing brace.
+		start := site + strings.Count(template[:site], placeholder)*(len(spaces)-len(placeholder))
+		end := start + len(spaces)
+
+		// Upstream reports `loc: {start: openingBrace.end, end: closingBrace.start}`
+		// and removes the same span, so a template placeholder that is directly
+		// between the braces (no intervening whitespace) yields an empty range.
+		line, column, endLine, endColumn := position(code, start, end)
+		errors = append(errors, rule_tester.InvalidTestCaseError{
+			MessageId: messageID,
+			Message:   messageText,
+			Line:      line,
+			Column:    column,
+			EndLine:   endLine,
+			EndColumn: endColumn,
+		})
+		searchFrom = site + len(placeholder)
+	}
+	if len(errors) == 0 {
+		panic("invalid case requires a brace pair: " + template)
+	}
+
+	return rule_tester.InvalidTestCase{
+		Code:     code,
+		FileName: "file.js",
+		Output:   []string{output},
+		Errors:   errors,
+	}
+}
+
+func validCase(code string) rule_tester.ValidTestCase {
+	return rule_tester.ValidTestCase{Code: code, FileName: "file.js"}
+}
+
+// TestEmptyBraceSpacesUpstream covers every case from
+// eslint-plugin-unicorn v73.0.0/test/empty-brace-spaces.js.
+func TestEmptyBraceSpacesUpstream(t *testing.T) {
+	var valid []rule_tester.ValidTestCase
+
+	// Empty bodies and comment-only bodies are already compact.
+	for _, body := range []string{"", "/* comment */", "\n\t// comment \n"} {
+		for _, code := range allCases {
+			valid = append(valid, validCase(replacePlaceholder(code, body)))
+		}
+	}
+	// Not empty.
+	for _, code := range cases {
+		valid = append(valid, validCase(replacePlaceholder(code, "unicorn")))
+	}
+	for _, code := range classBodyCases {
+		valid = append(valid, validCase(replacePlaceholder(code, "baz() {}")))
+	}
+	// `with` uses a WithStatement rather than a plain BlockStatement upstream.
+	valid = append(valid, rule_tester.ValidTestCase{
+		Code:            "with (foo) {}",
+		FileName:        "file.js",
+		LanguageOptions: rule.LanguageOptions{SourceType: "script"},
+	})
+	// We don't check these cases.
+	for _, code := range ignoredCases {
+		valid = append(valid, validCase(replacePlaceholder(code, strings.Repeat(" ", 3))))
+	}
+
+	var invalid []rule_tester.InvalidTestCase
+	for _, spaces := range []string{" ", "\t", " \t \t ", "\n\n", "\r\n"} {
+		for _, code := range allCases {
+			invalid = append(invalid, invalidCase(code, spaces))
+		}
+	}
+	invalid = append(invalid, invalidCase("with (foo) {/* */}", strings.Repeat(" ", 5)))
+
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &empty_brace_spaces.EmptyBraceSpacesRule, valid, invalid)
+}

--- a/internal/plugins/unicorn/rules/empty_brace_spaces/empty_brace_spaces_upstream_test.go
+++ b/internal/plugins/unicorn/rules/empty_brace_spaces/empty_brace_spaces_upstream_test.go
@@ -182,7 +182,7 @@ func TestEmptyBraceSpacesUpstream(t *testing.T) {
 	// table. Its brace pair opens with a whitespace-only line, so the report
 	// covers the whole run of spaces and the fix removes the line outright.
 	invalid = append(invalid, rule_tester.InvalidTestCase{
-		Code:     "try {\n\tfoo();\n} catch (error) {\n" + strings.Repeat(" ", 7) + "\n}",
+		Code:     "try {\n\tfoo();\n} catch (error) {\n\t" + strings.Repeat(" ", 7) + "\n}",
 		FileName: "file.js",
 		Output:   []string{"try {\n\tfoo();\n} catch (error) {}"},
 		Errors: []rule_tester.InvalidTestCaseError{{

--- a/internal/plugins/unicorn/rules/empty_brace_spaces/empty_brace_spaces_upstream_test.go
+++ b/internal/plugins/unicorn/rules/empty_brace_spaces/empty_brace_spaces_upstream_test.go
@@ -178,5 +178,24 @@ func TestEmptyBraceSpacesUpstream(t *testing.T) {
 	}
 	invalid = append(invalid, invalidCase("with (foo) {/* */}", strings.Repeat(" ", 5)))
 
+	// Upstream's standalone `test.snapshot` case, kept outside the generated
+	// table. Its brace pair opens with a whitespace-only line, so the report
+	// covers the whole run of spaces and the fix removes the line outright.
+	invalid = append(invalid, rule_tester.InvalidTestCase{
+		Code:     "try {\n\tfoo();\n} catch (error) {\n" + strings.Repeat(" ", 7) + "\n}",
+		FileName: "file.js",
+		Output:   []string{"try {\n\tfoo();\n} catch (error) {}"},
+		Errors: []rule_tester.InvalidTestCaseError{{
+			MessageId: messageID,
+			Message:   messageText,
+			// `{` ends on line 3, and the closing `}` begins on line 5; the
+			// reported run therefore crosses the indented blank line.
+			Line:      3,
+			Column:    18,
+			EndLine:   5,
+			EndColumn: 1,
+		}},
+	})
+
 	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &empty_brace_spaces.EmptyBraceSpacesRule, valid, invalid)
 }

--- a/packages/rslint-test-tools/rstack.config.mts
+++ b/packages/rslint-test-tools/rstack.config.mts
@@ -720,6 +720,7 @@ define.test({
     './tests/eslint-plugin-unicorn/rules/catch-error-name.test.ts',
     './tests/eslint-plugin-unicorn/rules/consistent-date-clone.test.ts',
     './tests/eslint-plugin-unicorn/rules/consistent-tuple-labels.test.ts',
+    './tests/eslint-plugin-unicorn/rules/empty-brace-spaces.test.ts',
     './tests/eslint-plugin-unicorn/rules/error-message.test.ts',
     './tests/eslint-plugin-unicorn/rules/filename-case.test.ts',
     './tests/eslint-plugin-unicorn/rules/new-for-builtins.test.ts',

--- a/packages/rslint-test-tools/tests/cli/js-config/presets.test.ts
+++ b/packages/rslint-test-tools/tests/cli/js-config/presets.test.ts
@@ -179,6 +179,7 @@ describe('defineConfig and config presets', () => {
     expect(rec.rules?.['unicorn/no-array-fill-with-reference-type']).toBe(
       'error',
     );
+    expect(rec.rules?.['unicorn/empty-brace-spaces']).toBe('error');
     expect(rec.rules?.['unicorn/no-exports-in-scripts']).toBe('error');
     expect(rec.rules?.['unicorn/no-await-expression-member']).toBe('error');
     expect(rec.rules?.['unicorn/prefer-date-now']).toBe('error');

--- a/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/empty-brace-spaces.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/empty-brace-spaces.test.ts
@@ -1,0 +1,63 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+const valid = (code: string, filename = 'file.js') => ({ code, filename });
+const invalid = (code: string, output: string, filename = 'file.js') => ({
+  code,
+  filename,
+  output,
+  errors: [
+    {
+      messageId: 'empty-brace-spaces',
+      message: 'Do not add spaces between braces.',
+    },
+  ],
+});
+
+ruleTester.run('empty-brace-spaces', null as never, {
+  valid: [
+    valid(''),
+    valid('class A {}'),
+    valid('function f() {}'),
+    valid('const o = {};'),
+    valid('class A { /* comment */ }'),
+    valid('function f() {\n\t// comment\n}'),
+    valid('const o = { /* comment */ };'),
+    valid('class A {static { /* comment */ }}'),
+    valid('if (foo) {}'),
+    valid('try {} catch {}'),
+    valid('foo = {unicorn};'),
+    valid('class A {baz() {}}'),
+    // Not a BlockStatement, ClassBody, StaticBlock, or ObjectExpression.
+    valid('switch (foo) { }'),
+    valid('const { } = foo;'),
+    valid('import { } from "foo";'),
+    valid('const x: { } = {};', 'file.ts'),
+    valid('type T = { };', 'file.ts'),
+    valid('interface I { }', 'file.ts'),
+    valid('namespace N { }', 'file.ts'),
+    valid('enum E { }', 'file.ts'),
+  ],
+  invalid: [
+    invalid('class A { }', 'class A {}'),
+    invalid('class A {\n}', 'class A {}'),
+    invalid('const o = { };', 'const o = {};'),
+    invalid('foo = function () { };', 'foo = function () {};'),
+    invalid('if (foo) { }', 'if (foo) {}'),
+    invalid('if (foo) {} else { }', 'if (foo) {} else {}'),
+    invalid('for (;;) { }', 'for (;;) {}'),
+    invalid('while (foo) { }', 'while (foo) {}'),
+    invalid('do { } while (foo)', 'do {} while (foo)'),
+    invalid('try { } catch {}', 'try {} catch {}'),
+    invalid('foo = () => { }', 'foo = () => {}'),
+    invalid('class Foo {bar() { }}', 'class Foo {bar() {}}'),
+    invalid('class A {static { }}', 'class A {static {}}'),
+    invalid('class A { }', 'class A {}', 'file.ts'),
+    invalid('abstract class A {\n}', 'abstract class A {}', 'file.ts'),
+    invalid('const A = class { }', 'const A = class {}', 'file.ts'),
+    invalid('class A<T> { }', 'class A<T> {}', 'file.ts'),
+    invalid('f({ });', 'f({});'),
+    invalid('const f = ({a}) => { }', 'const f = ({a}) => {}', 'file.ts'),
+  ],
+});

--- a/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/empty-brace-spaces.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/empty-brace-spaces.test.ts
@@ -59,5 +59,12 @@ ruleTester.run('empty-brace-spaces', null as never, {
     invalid('class A<T> { }', 'class A<T> {}', 'file.ts'),
     invalid('f({ });', 'f({});'),
     invalid('const f = ({a}) => { }', 'const f = ({a}) => {}', 'file.ts'),
+    // A brace pair in the class header must not be mistaken for the body's.
+    invalid(
+      'class A extends mixin({}) { }',
+      'class A extends mixin({}) {}',
+      'file.ts',
+    ),
+    invalid('class A<T extends {}> { }', 'class A<T extends {}> {}', 'file.ts'),
   ],
 });

--- a/packages/rslint/src/config/presets/unicorn.ts
+++ b/packages/rslint/src/config/presets/unicorn.ts
@@ -40,7 +40,7 @@ const recommended: RslintConfigEntry = {
     // 'unicorn/custom-error-definition': 'off', // not implemented
     // 'unicorn/default-export-style': 'error', // not implemented
     // 'unicorn/dom-node-dataset': 'error', // not implemented
-    // 'unicorn/empty-brace-spaces': 'error', // not implemented
+    'unicorn/empty-brace-spaces': 'error',
     'unicorn/error-message': 'error',
     // 'unicorn/escape-case': 'error', // not implemented
     // 'unicorn/expiring-todo-comments': 'error', // not implemented


### PR DESCRIPTION
## Summary

Port `unicorn/empty-brace-spaces` from `eslint-plugin-unicorn@v73.0.0`.

The rule enforces no spaces between braces in empty blocks, class bodies, static blocks, and object literals, and autofixes them by removing the whitespace:

```js
// Incorrect
class Unicorn {
}

// Correct
class Unicorn {}
```

A comment between the braces counts as content, so the whitespace around it is left untouched. The rule has no options.

- Register the rule in the native Unicorn catalog.
- Enable it in the Unicorn recommended preset, matching upstream.
- Migrate the complete upstream v73.0.0 test suite.
- Add coverage for TypeScript-only class shapes, decorators, heritage clauses, labeled blocks, destructuring parameters, JSX expression containers, and non-ASCII ECMAScript whitespace.
- Add an end-to-end RuleTester suite.

Two tsgo/ESTree structural differences needed explicit handling. tsgo represents `static {}` as a `ClassStaticBlockDeclaration` that wraps a real `Block`, while ESTree has only `StaticBlock`; both nodes yield the identical brace span, so the nested `Block` is skipped to keep upstream's single diagnostic. tsgo also models a stray `;` between class members as a `SemicolonClassElement`, which ESTree drops, so these are filtered from the emptiness check.

## Related Links

- Tracking issue: https://github.com/web-infra-dev/rslint/issues/1309
- Documentation: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v73.0.0/docs/rules/empty-brace-spaces.md
- Source code: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v73.0.0/rules/empty-brace-spaces.js
- Upstream tests: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v73.0.0/test/empty-brace-spaces.js

## Validation

- `go test -count=1 ./internal/plugins/unicorn/rules/empty_brace_spaces`
- `go test ./internal/rules -run '^TestAllContainsEveryGoRuleExactlyOnce$'`
- `pnpm --filter @rslint/core build:bin`
- `pnpm --dir packages/rslint-test-tools exec rs test --testTimeout=10000 empty-brace-spaces`
- `pnpm --dir packages/rslint-test-tools exec rs test --testTimeout=10000 presets`
- `pnpm typecheck`
- `pnpm run format:check`
- `pnpm -w run check-spell`
- `golangci-lint run --new-from-merge-base=origin/main ./internal/plugins/unicorn/rules/empty_brace_spaces`: 0 issues

## Checklist

- [x] Tests updated.
- [x] Documentation updated.
