### PR TITLE
fix(tsgo): symbol data collect for anonymous type

### DIFF
--- a/cmd/tsgo/semantic.go
+++ b/cmd/tsgo/semantic.go
@@ -253,20 +253,44 @@ func CollectSemanticInFile(tc *checker.Checker, file *ast.SourceFile, semantic *
 		}
 	}
 
+	// Type symbols such as anonymous type literals are not necessarily returned by
+	// GetSymbolAtLocation while walking the AST. Record them when they are reached
+	// through a type so every non-zero TypeInfo.Symbol has a Symtab entry.
+	recordSymbolInfo := func(symbol *ast.Symbol) ast.SymbolId {
+		if symbol == nil {
+			return 0
+		}
+
+		symbolID := ast.GetSymbolId(symbol)
+		if _, exists := semantic.Symtab[symbolID]; !exists {
+			semantic.Symtab[symbolID] = SymbolInfo{
+				Id:         symbolID,
+				Name:       sanitizeSymbolName(symbol.Name),
+				Flags:      int(symbol.Flags),
+				CheckFlags: int(symbol.CheckFlags),
+				Decl:       nodeReference(symbol.ValueDeclaration),
+			}
+		}
+		return symbolID
+	}
+
 	recordType := func(ty *checker.Type) checker.TypeId {
 		if ty == nil {
 			return 0
 		}
 
 		typeID := ty.Id()
+		var symbolID ast.SymbolId
+		if symbol := ty.Symbol(); symbol != nil {
+			symbolID = recordSymbolInfo(symbol)
+		}
+
 		if _, exists := semantic.Typetab[typeID]; !exists {
 			typeInfo := TypeInfo{
 				Id:          typeID,
 				Flags:       int(ty.Flags()),
 				ObjectFlags: int(ty.ObjectFlags()),
-			}
-			if symbol := ty.Symbol(); symbol != nil {
-				typeInfo.Symbol = ast.GetSymbolId(symbol)
+				Symbol:      symbolID,
 			}
 			semantic.Typetab[typeID] = typeInfo
 			semantic.TypeExtra.Name[int(typeID)] = []byte(tc.TypeToString(ty))
@@ -284,28 +308,15 @@ func CollectSemanticInFile(tc *checker.Checker, file *ast.SourceFile, semantic *
 					Signatures: signatures,
 				}
 			}
+		} else if symbolID != 0 {
+			typeInfo := semantic.Typetab[typeID]
+			if typeInfo.Symbol == 0 {
+				typeInfo.Symbol = symbolID
+				semantic.Typetab[typeID] = typeInfo
+			}
 		}
 
 		return typeID
-	}
-	// A symbol can be reached from multiple AST nodes and alias edges. Record each
-	// Symtab entry once, then reuse it on subsequent visits.
-	recordSymbolInfo := func(symbol *ast.Symbol) ast.SymbolId {
-		if symbol == nil {
-			return 0
-		}
-
-		symbolID := ast.GetSymbolId(symbol)
-		if _, exists := semantic.Symtab[symbolID]; !exists {
-			semantic.Symtab[symbolID] = SymbolInfo{
-				Id:         symbolID,
-				Name:       sanitizeSymbolName(symbol.Name),
-				Flags:      int(symbol.Flags),
-				CheckFlags: int(symbol.CheckFlags),
-				Decl:       nodeReference(symbol.ValueDeclaration),
-			}
-		}
-		return symbolID
 	}
 	recordSymbol := func(symbol *ast.Symbol) (ast.SymbolId, checker.TypeId, bool) {
 		if symbol == nil {

--- a/crates/tsgo-client/tests/fixtures/simple-project/src/index.ts
+++ b/crates/tsgo-client/tests/fixtures/simple-project/src/index.ts
@@ -39,3 +39,7 @@ export class ParameterPropertyExample {
 
 const message = greet('World');
 console.log(message);
+
+export function f(o: { x: number }) {
+  o.x = 1;
+}

--- a/crates/tsgo-client/tests/integration_test.rs
+++ b/crates/tsgo-client/tests/integration_test.rs
@@ -158,6 +158,70 @@ fn test_tsgo_integration_simple_project() {
 }
 
 #[test]
+fn test_type_literal_symbol_has_symbol_data() {
+    let tsgo_path = get_tsgo_path().expect("Could not find tsgo executable");
+    let fixture_dir = get_fixtures_dir().join("simple-project");
+    let config_file = fixture_dir.join("tsconfig.json");
+    let options = Options {
+        cwd: Some(fixture_dir),
+        log_file: None,
+        config_file: config_file.to_string_lossy().to_string(),
+    };
+    let client = Client::builder(OsStr::new(&tsgo_path), options)
+        .build()
+        .expect("Failed to build client");
+    let api = Api::with_uninitialized_client(client).expect("Failed to initialize API");
+    let mut buffer = Vec::new();
+    let project = api
+        .load_project(&mut buffer)
+        .expect("Failed to load project");
+    let semantic = &project.semantic;
+
+    let index_sourcefile_id = project
+        .module_list
+        .iter()
+        .position(|path| path.ends_with("/src/index.ts"))
+        .expect("Expected index.ts module") as u32;
+    let parameter_symbol_id = semantic
+        .symtab
+        .iter()
+        .find(|(_, data)| {
+            data.name == b"o"
+                && data
+                    .decl
+                    .as_ref()
+                    .is_some_and(|decl| decl.sourcefile_id == index_sourcefile_id)
+        })
+        .map(|(id, _)| *id)
+        .expect("Expected symbol data for parameter o");
+    let type_id = semantic
+        .sym2type
+        .iter()
+        .find(|(symbol_id, _)| *symbol_id == parameter_symbol_id)
+        .map(|(_, type_id)| *type_id)
+        .expect("Expected type for parameter o");
+    let type_symbol_id = semantic
+        .typetab
+        .iter()
+        .find(|(id, _)| *id == type_id)
+        .and_then(|(_, data)| data.symbol)
+        .expect("Expected the type literal to have a symbol");
+    let type_symbol_data = semantic
+        .symtab
+        .iter()
+        .find(|(id, _)| *id == type_symbol_id)
+        .map(|(_, data)| data)
+        .expect("Expected type literal symbol data in symtab");
+
+    assert_eq!(type_symbol_data.name, b"__type");
+    assert!(
+        SymbolFlags::from_bits_truncate(type_symbol_data.flags).contains(SymbolFlags::TYPE_LITERAL),
+        "Expected a type literal symbol, got flags {}",
+        type_symbol_data.flags
+    );
+}
+
+#[test]
 fn test_runtime_module_exports() {
     let tsgo_path = get_tsgo_path().expect("Could not find tsgo executable");
     let fixture_dir = get_fixtures_dir().join("module-exports");


### PR DESCRIPTION
## Motivation

<!-- Explain the problem or motivation and why it matters. Include relevant context and links to issues or discussions. -->

Type data for anonymous type literals could reference a symbol missing from Symtab, leaving a dangling symbol reference for consumers.

## Changes

<!-- Describe how this PR addresses the motivation and what behavior changes. Focus on the key approach rather than a file-by-file summary. -->

Record symbols reached through Type.Symbol() before storing their IDs in type data. Add a tsgo-client integration test to verify that type-literal symbols have corresponding symbol data.