### PR TITLE
docs: remove rule prefixes from document titles

### DIFF
--- a/.agents/skills/port-rule/references/PORT_RULE.md
+++ b/.agents/skills/port-rule/references/PORT_RULE.md
@@ -105,6 +105,7 @@ Use the exact locations in [QUICK_REFERENCE](QUICK_REFERENCE.md#rule-files-and-r
 - Inspect the selected wrapper's types and assertions before copying cases. The core wrapper uses object-shaped options for object rules; other wrappers can accept positional arrays. Prefixing, skip support and snapshot support differ. In particular, the jsx-a11y wrapper does not provide the core wrapper's snapshots, message-ID or position assertions.
 - Unsupported cases cannot be silently discarded. Use a supported skip mechanism or retain an explained case/comment and report the coverage gap when the JS wrapper cannot express it.
 - Keep documentation focused on the rule's behavior, options and correct/incorrect examples. Include official docs when available and a source link pinned to the exact tag. Record requested/established public differences there; reusable AST/API discoveries belong in their reference, not product-facing rule explanations.
+- Use the bare rule name in the documentation H1; do not include a plugin namespace.
 - If the plugin is already enabled in repo-root `rslint.config.ts`, add the new rule at `warn` before verification. Otherwise do not enable a plugin or change the preset as a side effect of porting.
 
 Build prerequisites are listed once in the command reference. A fresh binary does not imply fresh core JS, generated option types or wrapper output.

--- a/internal/plugins/node/rules/no_extraneous_import/no_extraneous_import.md
+++ b/internal/plugins/node/rules/no_extraneous_import/no_extraneous_import.md
@@ -1,4 +1,4 @@
-# node/no-extraneous-import
+# no-extraneous-import
 
 Disallow imports of installed packages that are not declared in `package.json`.
 

--- a/internal/plugins/react/rules/function_component_definition/function_component_definition.md
+++ b/internal/plugins/react/rules/function_component_definition/function_component_definition.md
@@ -1,4 +1,4 @@
-# react/function-component-definition
+# function-component-definition
 
 ## Rule Details
 

--- a/internal/plugins/rstest/rules/no_async_mock_factory/no_async_mock_factory.md
+++ b/internal/plugins/rstest/rules/no_async_mock_factory/no_async_mock_factory.md
@@ -1,4 +1,4 @@
-# rstest/no-async-mock-factory
+# no-async-mock-factory
 
 ## Rule Details
 

--- a/internal/plugins/rstest/rules/prefer_called_with/prefer_called_with.md
+++ b/internal/plugins/rstest/rules/prefer_called_with/prefer_called_with.md
@@ -1,4 +1,4 @@
-# rstest/prefer-called-with
+# prefer-called-with
 
 ## Rule Details
 


### PR DESCRIPTION
## Motivation

Some rule documentation titles include the plugin namespace, unlike the rest of the rule documentation.

## Changes

- Remove plugin prefixes from four rule document titles.
