### PR TITLE
chore(ci): skip tests for docs and skill changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,9 @@ jobs:
       - name: Setup Node.js
         uses: ./.github/actions/setup-node
 
+      - name: Format
+        run: pnpm format:check
+
       - name: Setup Go
         if: needs.changes.outputs.changed == 'true'
         uses: ./.github/actions/setup-go
@@ -223,9 +226,6 @@ jobs:
         uses: ./.github/actions/setup-rust
       - name: Build napi parser (native)
         run: pnpm --filter @rslint/native run build
-
-      - name: Format
-        run: pnpm format:check
 
       # Rule options JSON Schema dump for the generate-rule-option-types
       # rslib plugin (see packages/rslint/plugins/generate-rule-option-types.ts).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,7 @@ jobs:
         run: go test -count=1 ./cmd/... ./internal/...
 
   lint:
-    name: Lint&Check
+    name: Lint
     needs: changes
     runs-on: rspack-ubuntu-22.04-large
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,40 @@ concurrency:
   cancel-in-progress: ${{ github.ref_name != 'main' }}
 
 jobs:
+  changes:
+    name: Detect changes
+    runs-on: rspack-ubuntu-22.04-mini
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      changed: ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.changed == 'true' }}
+    steps:
+      - name: Checkout code
+        if: github.event_name != 'workflow_dispatch'
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          fetch-depth: 1
+
+      - name: Filter changes
+        if: github.event_name != 'workflow_dispatch'
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
+        id: filter
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            changed:
+              - '!**/*.md'
+              - '!**/*.mdx'
+              - '!**/_meta.json'
+              - '!**/dictionary.txt'
+              - '!.agents/skills/**'
+              - '!skills-lock.json'
+
   test-go:
     name: Test Go
+    needs: changes
+    if: needs.changes.outputs.changed == 'true'
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
     strategy:
@@ -98,7 +130,8 @@ jobs:
 
   test-go-darwin:
     name: Test Go (Darwin)
-    if: ${{ github.ref == 'refs/heads/main' || startsWith(github.head_ref || github.ref_name, 'chore/release-') }}
+    needs: changes
+    if: ${{ needs.changes.outputs.changed == 'true' && (github.ref == 'refs/heads/main' || startsWith(github.head_ref || github.ref_name, 'chore/release-')) }}
     runs-on: rspack-darwin-15.6.1-medium
     timeout-minutes: 60
     steps:
@@ -127,6 +160,7 @@ jobs:
 
   lint:
     name: Lint&Check
+    needs: changes
     runs-on: rspack-ubuntu-22.04-large
     steps:
       - name: Checkout code
@@ -138,18 +172,21 @@ jobs:
         uses: ./.github/actions/setup-node
 
       - name: Setup Go
+        if: needs.changes.outputs.changed == 'true'
         uses: ./.github/actions/setup-go
         with:
           go-version: 1.26.0
           cache-name: ci-go-lint
 
       - name: golangci-lint
+        if: needs.changes.outputs.changed == 'true'
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8
         with:
           version: v2.12.2
           args: --timeout=15m ./cmd/... ./internal/...
 
       - name: go fmt
+        if: needs.changes.outputs.changed == 'true'
         run: npm run format:go
 
       - name: Check Spell
@@ -157,6 +194,8 @@ jobs:
 
   test-node:
     name: Test npm packages
+    needs: changes
+    if: needs.changes.outputs.changed == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -226,6 +265,8 @@ jobs:
 
   test-node-windows:
     name: Test npm packages (rspack-windows-2022-large)
+    needs: changes
+    if: needs.changes.outputs.changed == 'true'
     runs-on: rspack-windows-2022-large
     steps:
       - name: Checkout code
@@ -350,6 +391,8 @@ jobs:
 
   test-wasm:
     name: Test WASM
+    needs: changes
+    if: needs.changes.outputs.changed == 'true'
     runs-on: rspack-ubuntu-22.04-large
     steps:
       - name: Checkout code
@@ -375,6 +418,8 @@ jobs:
           pnpm --filter '@rslint/wasm' build
   test-rust:
     name: Test Rust
+    needs: changes
+    if: needs.changes.outputs.changed == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -416,14 +461,16 @@ jobs:
         run: cargo test --verbose
 
   benchmark-go:
-    if: ${{ startsWith(github.ref_name, 'chore/release-') || startsWith(github.head_ref, 'chore/release-') }}
+    needs: changes
+    if: ${{ needs.changes.outputs.changed == 'true' && (startsWith(github.ref_name, 'chore/release-') || startsWith(github.head_ref, 'chore/release-')) }}
     permissions:
       contents: read
       id-token: write
     uses: ./.github/workflows/benchmark-go.yml
 
   benchmark-cli:
-    if: ${{ startsWith(github.ref_name, 'chore/release-') || startsWith(github.head_ref, 'chore/release-') }}
+    needs: changes
+    if: ${{ needs.changes.outputs.changed == 'true' && (startsWith(github.ref_name, 'chore/release-') || startsWith(github.head_ref, 'chore/release-')) }}
     permissions:
       contents: read
       id-token: write
@@ -431,6 +478,7 @@ jobs:
 
   done:
     needs:
+      - changes
       - test-go
       - test-go-darwin
       - test-node
@@ -444,16 +492,19 @@ jobs:
     name: CI Done
     steps:
       - run: exit 1
-        # Darwin may be skipped; all other required jobs must succeed.
+        # Lint must always succeed. Docs and skills may skip tests; otherwise, only Darwin may be skipped.
         if: >-
           ${{ always() && (
             contains(needs.*.result, 'failure') ||
             contains(needs.*.result, 'cancelled') ||
-            needs.test-go.result != 'success' ||
-            needs.test-node.result != 'success' ||
-            needs.test-node-windows.result != 'success' ||
-            needs.test-vscode-windows.result != 'success' ||
+            needs.changes.result != 'success' ||
             needs.lint.result != 'success' ||
-            needs.test-wasm.result != 'success' ||
-            needs.test-rust.result != 'success'
+            (needs.changes.outputs.changed != 'false' && (
+              needs.test-go.result != 'success' ||
+              needs.test-node.result != 'success' ||
+              needs.test-node-windows.result != 'success' ||
+              needs.test-vscode-windows.result != 'success' ||
+              needs.test-wasm.result != 'success' ||
+              needs.test-rust.result != 'success'
+            ))
           ) }}

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -153,6 +153,7 @@ Dmts
 dobedo
 Dogfooding
 dont
+dorny
 dotless
 doublestar
 DPUB


### PR DESCRIPTION
## Motivation

Documentation and skill changes currently run CI tests and Go checks that are unnecessary for these changes.

## Changes

Use path filtering, following Rsbuild's CI approach, to skip test and benchmark jobs for changes limited to Markdown, documentation metadata, dictionaries, and skill files. Rename `Lint&Check` to `Lint`, move format validation there, and keep format and spell checks enabled while skipping its Go setup, lint, and formatting steps. Preserve manual CI execution and require `Lint` to succeed in `CI Done` even when tests are skipped.