### PR TITLE
fix(react): align jsx-props-no-multi-spaces with upstream

### DIFF
--- a/internal/plugins/react/rules/jsx_props_no_multi_spaces/jsx_props_no_multi_spaces.go
+++ b/internal/plugins/react/rules/jsx_props_no_multi_spaces/jsx_props_no_multi_spaces.go
@@ -20,7 +20,6 @@ var JsxPropsNoMultiSpacesRule = rule.Rule{
 		lineStarts := ctx.SourceFile.ECMALineMap()
 
 		check := func(node *ast.Node) {
-			comments := ctx.Comments.All()
 			var props []*ast.Node
 			var tagNameEnd int
 			var tagName *ast.Node
@@ -51,13 +50,13 @@ var JsxPropsNoMultiSpacesRule = rule.Rule{
 			// Check between tag name and first attribute
 			firstTrimmed := utils.TrimNodeTextRange(ctx.SourceFile, props[0])
 			tagDisplayName := getTagDisplayName(ctx, tagName)
-			checkGap(ctx, text, lineStarts, comments, tagNameEnd, firstTrimmed.Pos(), firstTrimmed.End(), props[0], tagDisplayName, getDisplayName(ctx, props[0]))
+			checkGap(ctx, text, lineStarts, tagNameEnd, firstTrimmed.Pos(), firstTrimmed.End(), props[0], tagDisplayName, getDisplayName(ctx, props[0]))
 
 			// Check between consecutive attributes
 			for i := 1; i < len(props); i++ {
 				prevTrimmed := utils.TrimNodeTextRange(ctx.SourceFile, props[i-1])
 				currTrimmed := utils.TrimNodeTextRange(ctx.SourceFile, props[i])
-				checkGap(ctx, text, lineStarts, comments, prevTrimmed.End(), currTrimmed.Pos(), currTrimmed.End(), props[i], getDisplayName(ctx, props[i-1]), getDisplayName(ctx, props[i]))
+				checkGap(ctx, text, lineStarts, prevTrimmed.End(), currTrimmed.Pos(), currTrimmed.End(), props[i], getDisplayName(ctx, props[i-1]), getDisplayName(ctx, props[i]))
 			}
 		}
 
@@ -120,7 +119,7 @@ func hasEmptyLines(lineStarts []core.TextPos, comments []*ast.CommentRange, star
 	return scanner.ComputeLineOfPosition(lineStarts, endPos)-scanner.ComputeLineOfPosition(lineStarts, previousEnd) >= 2
 }
 
-func checkGap(ctx rule.RuleContext, text string, lineStarts []core.TextPos, comments []*ast.CommentRange, prevEnd, currStart, currEnd int, reportNode *ast.Node, prevName, currName string) {
+func checkGap(ctx rule.RuleContext, text string, lineStarts []core.TextPos, prevEnd, currStart, currEnd int, reportNode *ast.Node, prevName, currName string) {
 	prevEndLine := scanner.ComputeLineOfPosition(lineStarts, prevEnd)
 	currEndLine := scanner.ComputeLineOfPosition(lineStarts, currEnd)
 
@@ -138,7 +137,7 @@ func checkGap(ctx rule.RuleContext, text string, lineStarts []core.TextPos, comm
 		}
 	} else {
 		// Different lines - comments bridge gaps, but empty lines around them do not.
-		if hasEmptyLines(lineStarts, comments, prevEnd, currStart) {
+		if hasEmptyLines(lineStarts, ctx.Comments.All(), prevEnd, currStart) {
 			ctx.ReportNode(reportNode, rule.RuleMessage{
 				Id:          "noLineGap",
 				Description: fmt.Sprintf("Expected no line gap between \"%s\" and \"%s\"", prevName, currName),

--- a/internal/plugins/react/rules/jsx_props_no_multi_spaces/jsx_props_no_multi_spaces.go
+++ b/internal/plugins/react/rules/jsx_props_no_multi_spaces/jsx_props_no_multi_spaces.go
@@ -20,6 +20,7 @@ var JsxPropsNoMultiSpacesRule = rule.Rule{
 		lineStarts := ctx.SourceFile.ECMALineMap()
 
 		check := func(node *ast.Node) {
+			comments := ctx.Comments.All()
 			var props []*ast.Node
 			var tagNameEnd int
 			var tagName *ast.Node
@@ -50,13 +51,13 @@ var JsxPropsNoMultiSpacesRule = rule.Rule{
 			// Check between tag name and first attribute
 			firstTrimmed := utils.TrimNodeTextRange(ctx.SourceFile, props[0])
 			tagDisplayName := getTagDisplayName(ctx, tagName)
-			checkGap(ctx, text, lineStarts, tagNameEnd, firstTrimmed.Pos(), firstTrimmed.End(), props[0], tagDisplayName, getDisplayName(props[0]))
+			checkGap(ctx, text, lineStarts, comments, tagNameEnd, firstTrimmed.Pos(), firstTrimmed.End(), props[0], tagDisplayName, getDisplayName(ctx, props[0]))
 
 			// Check between consecutive attributes
 			for i := 1; i < len(props); i++ {
 				prevTrimmed := utils.TrimNodeTextRange(ctx.SourceFile, props[i-1])
 				currTrimmed := utils.TrimNodeTextRange(ctx.SourceFile, props[i])
-				checkGap(ctx, text, lineStarts, prevTrimmed.End(), currTrimmed.Pos(), currTrimmed.End(), props[i], getDisplayName(props[i-1]), getDisplayName(props[i]))
+				checkGap(ctx, text, lineStarts, comments, prevTrimmed.End(), currTrimmed.Pos(), currTrimmed.End(), props[i], getDisplayName(ctx, props[i-1]), getDisplayName(ctx, props[i]))
 			}
 		}
 
@@ -71,16 +72,13 @@ var JsxPropsNoMultiSpacesRule = rule.Rule{
 // including TypeArguments if present (e.g., `<App<T>` -> end of `>`).
 func getTagNameEnd(ctx rule.RuleContext, tagName *ast.Node, typeArgs *ast.NodeList) int {
 	if typeArgs != nil && len(typeArgs.Nodes) > 0 {
-		// Use the end of the type arguments list (includes the closing `>`)
-		trimmed := utils.TrimNodeTextRange(ctx.SourceFile, typeArgs.Nodes[len(typeArgs.Nodes)-1])
-		// The closing `>` of type arguments is after the last type arg node.
+		// NodeList.End points at the parsed closing angle token. Looking the
+		// token up from that parser-owned boundary avoids mistaking a `>` in
+		// trailing trivia (notably a block comment) for the delimiter.
+		closeAngle := scanner.GetRangeOfTokenAtPosition(ctx.SourceFile, typeArgs.End())
 		text := ctx.SourceFile.Text()
-		pos := trimmed.End()
-		for pos < len(text) && text[pos] != '>' {
-			pos++
-		}
-		if pos < len(text) {
-			return pos + 1 // past the `>`
+		if closeAngle.Pos() < len(text) && text[closeAngle.Pos()] == '>' {
+			return closeAngle.End()
 		}
 	}
 	trimmed := utils.TrimNodeTextRange(ctx.SourceFile, tagName)
@@ -95,41 +93,34 @@ func getTagDisplayName(ctx rule.RuleContext, tagName *ast.Node) string {
 	return ctx.SourceFile.Text()[trimmed.Pos():trimmed.End()]
 }
 
-func getDisplayName(node *ast.Node) string {
+func getDisplayName(ctx rule.RuleContext, node *ast.Node) string {
+	if ast.IsJsxSpreadAttribute(node) {
+		return utils.TrimmedNodeText(ctx.SourceFile, node.AsJsxSpreadAttribute().Expression)
+	}
 	if name := reactutil.GetJsxPropName(node); name != "" {
 		return name
 	}
 	return "element"
 }
 
-// hasBlankLineBetween checks if there is a truly blank line (only whitespace, no comments)
-// between two positions in the source text.
-func hasBlankLineBetween(text string, lineStarts []core.TextPos, startPos, endPos int) bool {
-	startLine := scanner.ComputeLineOfPosition(lineStarts, startPos)
-	endLine := scanner.ComputeLineOfPosition(lineStarts, endPos)
-
-	for line := startLine + 1; line < endLine; line++ {
-		lineStart := int(lineStarts[line])
-		lineEnd := len(text)
-		if line+1 < len(lineStarts) {
-			lineEnd = int(lineStarts[line+1])
-		}
-		isBlank := true
-		for i := lineStart; i < lineEnd; i++ {
-			ch := text[i]
-			if ch != ' ' && ch != '\t' && ch != '\r' && ch != '\n' {
-				isBlank = false
-				break
-			}
-		}
-		if isBlank {
+// hasEmptyLines mirrors upstream's comparison of the previous JSX node, every
+// comment before the current attribute, and the current attribute. A comment is
+// one item regardless of newlines inside it, while any ECMAScript whitespace on
+// an otherwise empty intervening line still contributes to the location gap.
+func hasEmptyLines(lineStarts []core.TextPos, comments []*ast.CommentRange, startPos, endPos int) bool {
+	previousEnd := startPos
+	for _, comment := range utils.CommentsInSpan(comments, startPos, endPos) {
+		if scanner.ComputeLineOfPosition(lineStarts, comment.Pos())-scanner.ComputeLineOfPosition(lineStarts, previousEnd) >= 2 {
 			return true
 		}
+		if comment.End() > previousEnd {
+			previousEnd = comment.End()
+		}
 	}
-	return false
+	return scanner.ComputeLineOfPosition(lineStarts, endPos)-scanner.ComputeLineOfPosition(lineStarts, previousEnd) >= 2
 }
 
-func checkGap(ctx rule.RuleContext, text string, lineStarts []core.TextPos, prevEnd, currStart, currEnd int, reportNode *ast.Node, prevName, currName string) {
+func checkGap(ctx rule.RuleContext, text string, lineStarts []core.TextPos, comments []*ast.CommentRange, prevEnd, currStart, currEnd int, reportNode *ast.Node, prevName, currName string) {
 	prevEndLine := scanner.ComputeLineOfPosition(lineStarts, prevEnd)
 	currEndLine := scanner.ComputeLineOfPosition(lineStarts, currEnd)
 
@@ -146,8 +137,8 @@ func checkGap(ctx rule.RuleContext, text string, lineStarts []core.TextPos, prev
 			})
 		}
 	} else {
-		// Different lines - check for truly blank lines between them (comments bridge gaps)
-		if hasBlankLineBetween(text, lineStarts, prevEnd, currStart) {
+		// Different lines - comments bridge gaps, but empty lines around them do not.
+		if hasEmptyLines(lineStarts, comments, prevEnd, currStart) {
 			ctx.ReportNode(reportNode, rule.RuleMessage{
 				Id:          "noLineGap",
 				Description: fmt.Sprintf("Expected no line gap between \"%s\" and \"%s\"", prevName, currName),

--- a/internal/plugins/react/rules/jsx_props_no_multi_spaces/jsx_props_no_multi_spaces_extras_test.go
+++ b/internal/plugins/react/rules/jsx_props_no_multi_spaces/jsx_props_no_multi_spaces_extras_test.go
@@ -1,0 +1,109 @@
+package jsx_props_no_multi_spaces
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestJsxPropsNoMultiSpacesRuleExtras(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &JsxPropsNoMultiSpacesRule, []rule_tester.ValidTestCase{
+		{
+			Code: `<X<T /* > */> a/>`,
+			Tsx:  true,
+		},
+		{
+			Code: `<X<Map<string, Array<number /* > */>>> a/>`,
+			Tsx:  true,
+		},
+		{
+			Code: `<X a /*
+
+*/
+ b/>`,
+			Tsx: true,
+		},
+	}, []rule_tester.InvalidTestCase{
+		{
+			Code:   `<X<T /* > */>  a/>`,
+			Tsx:    true,
+			Output: []string{`<X<T /* > */> a/>`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "onlyOneSpace",
+					Message:   `Expected only one space between "X" and "a"`,
+					Line:      1,
+					Column:    16,
+				},
+			},
+		},
+		{
+			Code:   `<X<T>  a/>`,
+			Tsx:    true,
+			Output: []string{`<X<T> a/>`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "onlyOneSpace",
+					Message:   `Expected only one space between "X" and "a"`,
+					Line:      1,
+					Column:    8,
+				},
+			},
+		},
+		{
+			Code: `<X a /*
+
+*/
+
+ b/>`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noLineGap",
+					Message:   `Expected no line gap between "a" and "b"`,
+					Line:      5,
+					Column:    2,
+				},
+			},
+		},
+		{
+			Code: "<X a\n\u00a0\n b/>",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noLineGap",
+					Message:   `Expected no line gap between "a" and "b"`,
+					Line:      3,
+					Column:    2,
+				},
+			},
+		},
+		{
+			Code:   `<X a  {...props}/>`,
+			Tsx:    true,
+			Output: []string{`<X a {...props}/>`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "onlyOneSpace",
+					Message:   `Expected only one space between "a" and "props"`,
+					Line:      1,
+					Column:    7,
+				},
+			},
+		},
+		{
+			Code:   `<X {...props}  a/>`,
+			Tsx:    true,
+			Output: []string{`<X {...props} a/>`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "onlyOneSpace",
+					Message:   `Expected only one space between "props" and "a"`,
+					Line:      1,
+					Column:    16,
+				},
+			},
+		},
+	})
+}

--- a/internal/plugins/react/rules/jsx_props_no_multi_spaces/jsx_props_no_multi_spaces_extras_test.go
+++ b/internal/plugins/react/rules/jsx_props_no_multi_spaces/jsx_props_no_multi_spaces_extras_test.go
@@ -3,9 +3,16 @@ package jsx_props_no_multi_spaces
 import (
 	"testing"
 
+	"github.com/microsoft/TypeScript/tsc/shim/core"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/rule_tester"
 )
+
+func TestCheckGapDoesNotCollectCommentsForSingleLine(t *testing.T) {
+	t.Helper()
+	checkGap(rule.RuleContext{}, " ", []core.TextPos{0}, 0, 1, 1, nil, "a", "b")
+}
 
 func TestJsxPropsNoMultiSpacesRuleExtras(t *testing.T) {
 	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &JsxPropsNoMultiSpacesRule, []rule_tester.ValidTestCase{


### PR DESCRIPTION
## Summary

- use the parsed type argument boundary when checking spacing after generic JSX tag names, avoiding unsafe fixes when comments contain `>`
- make line-gap detection comment-aware so blank lines inside block comments are not treated as gaps between props
- recognize Unicode whitespace-only lines when checking for gaps between JSX props
- report the actual spread argument text in diagnostics instead of the generic `spread` placeholder
- add Go regression coverage for generic comments, block comments, Unicode whitespace, spread diagnostics, and autofix output
