### PR TITLE
fix(react): align jsx-curly-brace-presence with upstream

### DIFF
--- a/internal/plugins/react/rules/jsx_curly_brace_presence/jsx_curly_brace_presence.go
+++ b/internal/plugins/react/rules/jsx_curly_brace_presence/jsx_curly_brace_presence.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/microsoft/TypeScript/tsc/shim/ast"
 	"github.com/microsoft/TypeScript/tsc/shim/core"
+	"github.com/microsoft/TypeScript/tsc/shim/scanner"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
@@ -65,7 +66,6 @@ func parseOptions(options []any) curlyBraceOptions {
 
 var (
 	htmlEntityRegex     = regexp.MustCompile(`&[A-Za-z\d#]+;`)
-	leadingTrailingWS   = regexp.MustCompile(`^\s|\s$`)
 	disallowedJSXChars  = regexp.MustCompile(`[{<>}]`)
 	quoteCharsRegex     = regexp.MustCompile(`['"]`)
 	multilineCommentSeq = regexp.MustCompile(`/\*`)
@@ -104,7 +104,7 @@ func isAllWhitespace(s string) bool {
 }
 
 func isStringWithTrailingWhitespaces(s string) bool {
-	return leadingTrailingWS.MatchString(s)
+	return s != ecmascript.StringTrim(s)
 }
 
 // jsStringify mirrors `JSON.stringify(s)` for the limited subset of strings
@@ -314,7 +314,7 @@ func jsxExpressionHasComments(text string, je *ast.Node) bool {
 }
 
 func stringLiteralRawText(text string, node *ast.Node) string {
-	return text[node.Pos():node.End()]
+	return text[scanner.SkipTrivia(text, node.Pos()):node.End()]
 }
 
 func jsxTextRawText(text string, node *ast.Node) string {
@@ -449,70 +449,72 @@ func makeRun() func(rule.RuleContext, []any) rule.RuleListeners {
 			if je == nil {
 				return
 			}
-			// Skip ParenthesizedExpression so `{('foo')}` and `{(<Foo />)}`
-			// classify (and emit replacement text) based on their inner
-			// content, matching upstream's ESTree-flattened view.
-			expr := ast.SkipParentheses(je.Expression)
-			parent := jsxExpr.Parent
-			parentIsAttribute := parent != nil && parent.Kind == ast.KindJsxAttribute
+			ctx.ReportNodeWithDeferredFixes(jsxExpr, unnecessaryMsg, func() []rule.RuleFix {
+				// Skip ParenthesizedExpression so `{('foo')}` and `{(<Foo />)}`
+				// classify (and emit replacement text) based on their inner
+				// content, matching upstream's ESTree-flattened view.
+				expr := ast.SkipParentheses(je.Expression)
+				parent := jsxExpr.Parent
+				parentIsAttribute := parent != nil && parent.Kind == ast.KindJsxAttribute
 
-			var replacement string
-			switch {
-			case isJSXLike(expr):
-				replacement = utils.TrimmedNodeText(ctx.SourceFile, expr)
-			case parentIsAttribute:
-				switch expr.Kind {
-				case ast.KindNoSubstitutionTemplateLiteral:
-					ntl := expr.AsNoSubstitutionTemplateLiteral()
-					rawText := ntl.RawText
-					if rawText == "" {
-						// tsgo may not populate RawText for substitution-free
-						// templates; fall back to source-text slicing.
-						src := utils.TrimmedNodeText(ctx.SourceFile, expr)
-						if len(src) >= 2 && src[0] == '`' && src[len(src)-1] == '`' {
-							rawText = src[1 : len(src)-1]
-						} else {
-							rawText = ntl.Text
+				var replacement string
+				switch {
+				case isJSXLike(expr):
+					replacement = utils.TrimmedNodeText(ctx.SourceFile, expr)
+				case parentIsAttribute:
+					switch expr.Kind {
+					case ast.KindNoSubstitutionTemplateLiteral:
+						ntl := expr.AsNoSubstitutionTemplateLiteral()
+						rawText := ntl.RawText
+						if rawText == "" {
+							// tsgo may not populate RawText for substitution-free
+							// templates; fall back to source-text slicing.
+							src := utils.TrimmedNodeText(ctx.SourceFile, expr)
+							if len(src) >= 2 && src[0] == '`' && src[len(src)-1] == '`' {
+								rawText = src[1 : len(src)-1]
+							} else {
+								rawText = ntl.Text
+							}
 						}
-					}
-					replacement = `"` + rawText + `"`
-				case ast.KindStringLiteral:
-					rawWithQuotes := stringLiteralRawText(text, expr)
-					inner := trimQuotes(rawWithQuotes)
-					// Preserve the original quoting when the inner text holds a
-					// double quote; otherwise re-wrap in double quotes.
-					if strings.Contains(inner, `"`) {
-						replacement = rawWithQuotes
-					} else {
-						replacement = `"` + inner + `"`
+						replacement = `"` + rawText + `"`
+					case ast.KindStringLiteral:
+						rawWithQuotes := stringLiteralRawText(text, expr)
+						inner := trimQuotes(rawWithQuotes)
+						// Preserve the original quoting when the inner text holds a
+						// double quote; otherwise re-wrap in double quotes.
+						if strings.Contains(inner, `"`) {
+							replacement = rawWithQuotes
+						} else {
+							replacement = `"` + inner + `"`
+						}
+					default:
+						replacement = utils.TrimmedNodeText(ctx.SourceFile, expr)
 					}
 				default:
-					replacement = utils.TrimmedNodeText(ctx.SourceFile, expr)
+					switch expr.Kind {
+					case ast.KindNoSubstitutionTemplateLiteral:
+						// Use cooked text (matches upstream's
+						// `quasis[0].value.cooked`).
+						replacement = expr.AsNoSubstitutionTemplateLiteral().Text
+					case ast.KindStringLiteral:
+						replacement = expr.AsStringLiteral().Text
+					default:
+						replacement = utils.TrimmedNodeText(ctx.SourceFile, expr)
+					}
 				}
-			default:
-				switch expr.Kind {
-				case ast.KindNoSubstitutionTemplateLiteral:
-					// Use cooked text (matches upstream's
-					// `quasis[0].value.cooked`).
-					replacement = expr.AsNoSubstitutionTemplateLiteral().Text
-				case ast.KindStringLiteral:
-					replacement = expr.AsStringLiteral().Text
-				default:
-					replacement = utils.TrimmedNodeText(ctx.SourceFile, expr)
-				}
-			}
 
-			ctx.ReportNodeWithFixes(jsxExpr, unnecessaryMsg,
-				rule.RuleFixReplace(ctx.SourceFile, jsxExpr, replacement))
+				return []rule.RuleFix{rule.RuleFixReplace(ctx.SourceFile, jsxExpr, replacement)}
+			})
 		}
 
 		// reportMissingCurlyOnLiteral — wraps the literal in `{"…"}` for
 		// attribute initializers and uses line-aware wrapping for JsxText.
 		reportMissingCurlyOnLiteral := func(literal *ast.Node) {
 			if isJSXLike(literal) {
-				inner := utils.TrimmedNodeText(ctx.SourceFile, literal)
-				ctx.ReportNodeWithFixes(literal, missingMsg,
-					rule.RuleFixReplace(ctx.SourceFile, literal, "{"+inner+"}"))
+				ctx.ReportNodeWithDeferredFixes(literal, missingMsg, func() []rule.RuleFix {
+					inner := utils.TrimmedNodeText(ctx.SourceFile, literal)
+					return []rule.RuleFix{rule.RuleFixReplace(ctx.SourceFile, literal, "{"+inner+"}")}
+				})
 				return
 			}
 
@@ -540,24 +542,25 @@ func makeRun() func(rule.RuleContext, []any) rule.RuleListeners {
 				return
 			}
 
-			var replacement string
 			if parentIsAttribute {
-				inner := trimQuotes(rawWithDelimiters)
-				escaped := escapeDoubleQuotes(escapeBackslashes(inner))
-				replacement = `{"` + escaped + `"}`
-				ctx.ReportNodeWithFixes(literal, missingMsg,
-					rule.RuleFixReplace(ctx.SourceFile, literal, replacement))
+				ctx.ReportNodeWithDeferredFixes(literal, missingMsg, func() []rule.RuleFix {
+					inner := trimQuotes(rawWithDelimiters)
+					escaped := escapeDoubleQuotes(escapeBackslashes(inner))
+					replacement := `{"` + escaped + `"}`
+					return []rule.RuleFix{rule.RuleFixReplace(ctx.SourceFile, literal, replacement)}
+				})
 				return
 			}
-			replacement = wrapJsxTextWithCurlyBraces(rawWithDelimiters)
 			// JsxText leading whitespace/newlines are trivia for the TS
 			// scanner, so the default `TrimNodeTextRange` skips them — both
 			// the report range and the fix range need to span the raw
 			// `[Pos, End)` to match upstream (which uses the JSXText node's
 			// own range, not a trivia-skipped one).
 			rawRange := core.NewTextRange(literal.Pos(), literal.End())
-			ctx.ReportRangeWithFixes(rawRange, missingMsg,
-				rule.RuleFixReplaceRange(rawRange, replacement))
+			ctx.ReportRangeWithDeferredFixes(rawRange, missingMsg, func() []rule.RuleFix {
+				replacement := wrapJsxTextWithCurlyBraces(rawWithDelimiters)
+				return []rule.RuleFix{rule.RuleFixReplaceRange(rawRange, replacement)}
+			})
 		}
 
 		areRuleConditionsSatisfied := func(parent *ast.Node, condition string) bool {

--- a/internal/plugins/react/rules/jsx_curly_brace_presence/jsx_curly_brace_presence_extras_test.go
+++ b/internal/plugins/react/rules/jsx_curly_brace_presence/jsx_curly_brace_presence_extras_test.go
@@ -1,0 +1,162 @@
+// This file contains rslint-specific regressions and edge cases. Migrated
+// upstream coverage remains in jsx_curly_brace_presence_test.go.
+package jsx_curly_brace_presence
+
+import (
+	"testing"
+
+	"github.com/microsoft/TypeScript/tsc/shim/ast"
+	"github.com/microsoft/TypeScript/tsc/shim/core"
+	"github.com/microsoft/TypeScript/tsc/shim/parser"
+	"github.com/web-infra-dev/rslint/internal/linter"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+func TestJsxCurlyBracePresenceSourceTextEdges(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &JsxCurlyBracePresenceRule, []rule_tester.ValidTestCase{
+		// JavaScript /^\s|\s$/ protects whitespace whose removal from a
+		// multiline JSX expression would change the rendered child text.
+		{Code: "<div>\n{\"\u00a0hello\"}\n</div>", Tsx: true},
+		{Code: "<div>\n{\"hello\u00a0\"}\n</div>", Tsx: true},
+		{Code: "<div>\n{\"" + "\ufeff" + "hello\"}\n</div>", Tsx: true},
+		{Code: "<div>\n{\"hello" + "\ufeff" + "\"}\n</div>", Tsx: true},
+		{Code: "<div>\n{\"\vhello\"}\n</div>", Tsx: true},
+		{Code: "<div>\n{\"hello\v\"}\n</div>", Tsx: true},
+	}, []rule_tester.InvalidTestCase{
+		// A tsgo StringLiteral Pos includes leading trivia. Fixes must slice
+		// from the token start so trivia never becomes attribute content.
+		{
+			Code:   `<X title={ 'hello' }/>`,
+			Tsx:    true,
+			Output: []string{`<X title="hello"/>`},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unnecessaryCurly"}},
+		},
+		{
+			Code:   `<X title={	"hello" }/>`,
+			Tsx:    true,
+			Output: []string{`<X title="hello"/>`},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unnecessaryCurly"}},
+		},
+		{
+			Code:   "<X title={\n  'hello'\n}/>",
+			Tsx:    true,
+			Output: []string{`<X title="hello"/>`},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unnecessaryCurly"}},
+		},
+		{
+			Code:    `<X title= "hello"/>`,
+			Tsx:     true,
+			Options: "always",
+			Output:  []string{`<X title= {"hello"}/>`},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingCurly"}},
+		},
+		{
+			Code:    `<X title=	'hello'/>`,
+			Tsx:     true,
+			Options: "always",
+			Output:  []string{`<X title=	{"hello"}/>`},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingCurly"}},
+		},
+		{
+			Code:    "<X title=\n  \"hello\"/>",
+			Tsx:     true,
+			Options: "always",
+			Output:  []string{"<X title=\n  {\"hello\"}/>"},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingCurly"}},
+		},
+	})
+}
+
+func TestJsxCurlyBracePresenceEditDemand(t *testing.T) {
+	t.Parallel()
+
+	for _, testCase := range []struct {
+		name       string
+		code       string
+		options    any
+		wantOutput string
+	}{
+		{
+			name:       "remove braces after leading trivia",
+			code:       `<X title={ 'hello' }/>`,
+			wantOutput: `<X title="hello"/>`,
+		},
+		{
+			name:       "add braces after leading trivia",
+			code:       `<X title= "hello"/>`,
+			options:    "always",
+			wantOutput: `<X title= {"hello"}/>`,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+				FileName: "/edit-demand.tsx",
+				Path:     "/edit-demand.tsx",
+			}, testCase.code, core.ScriptKindTSX)
+
+			run := func(demand rule.EditDemand) rule.RuleDiagnostic {
+				t.Helper()
+
+				comments := rule.NewCommentStore(sourceFile)
+				var diagnostics []rule.RuleDiagnostic
+				ctx := rule.RuleContext{
+					SourceFile:     sourceFile,
+					Comments:       comments,
+					DisableManager: rule.NewDisableManager(sourceFile, comments),
+				}.WithDiagnosticConsumer(JsxCurlyBracePresenceRule.Name, rule.SeverityError, rule.DiagnosticConsumer{
+					Demand: demand,
+					Report: func(diagnostic rule.RuleDiagnostic) {
+						diagnostics = append(diagnostics, diagnostic)
+					},
+				})
+				listeners := JsxCurlyBracePresenceRule.Run(ctx, rule_tester.ResolveTestCaseOptions(t, &JsxCurlyBracePresenceRule, testCase.options))
+				utils.VisitDescendants(sourceFile.AsNode(), func(node *ast.Node) bool {
+					if listener := listeners[node.Kind]; listener != nil {
+						listener(node)
+					}
+					return true
+				})
+				if len(diagnostics) != 1 {
+					t.Fatalf("demand %d: diagnostics = %d, want 1", demand, len(diagnostics))
+				}
+				return diagnostics[0]
+			}
+
+			diagnosticsOnly := run(rule.EditDemandNone)
+			autofixOnly := run(rule.EditDemandAutofix)
+			suggestionOnly := run(rule.EditDemandSuggestion)
+			allEdits := run(rule.EditDemandAll)
+
+			for demand, diagnostic := range map[rule.EditDemand]rule.RuleDiagnostic{
+				rule.EditDemandAutofix:    autofixOnly,
+				rule.EditDemandSuggestion: suggestionOnly,
+				rule.EditDemandAll:        allEdits,
+			} {
+				if diagnostic.Range != diagnosticsOnly.Range || diagnostic.Message.Id != diagnosticsOnly.Message.Id ||
+					diagnostic.Message.Description != diagnosticsOnly.Message.Description || diagnostic.RuleName != diagnosticsOnly.RuleName {
+					t.Errorf("demand %d changed diagnostic identity", demand)
+				}
+			}
+			if diagnosticsOnly.FixesPtr != nil || suggestionOnly.FixesPtr != nil {
+				t.Fatal("non-autofix demand materialized fixes")
+			}
+			if autofixOnly.FixesPtr == nil || allEdits.FixesPtr == nil {
+				t.Fatal("autofix demand did not materialize fixes")
+			}
+			for _, diagnostic := range []rule.RuleDiagnostic{diagnosticsOnly, autofixOnly, suggestionOnly, allEdits} {
+				if diagnostic.Suggestions != nil {
+					t.Fatal("autofix-only rule materialized suggestions")
+				}
+			}
+			output, _, fixed := linter.ApplyRuleFixes(testCase.code, []rule.RuleDiagnostic{allEdits})
+			if !fixed || output != testCase.wantOutput {
+				t.Errorf("fixed output = %q, %v; want %q, true", output, fixed, testCase.wantOutput)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- exclude leading trivia when reading raw JSX string literals so autofixes preserve attribute values
- use ECMAScript whitespace semantics when deciding whether JSX child braces can be safely removed
- defer autofix construction until fixes are requested
- add Go regression coverage for spaces, tabs, line breaks, NBSP, BOM, and vertical tabs

## Other differences not addressed

- Upstream cases that use JSX elements directly as attribute values remain skipped because the TypeScript parser rejects that legacy syntax.
