### PR TITLE
feat(playground): support JS, JSX, and TSX source files

### DIFF
--- a/internal/api/server/ast_info.go
+++ b/internal/api/server/ast_info.go
@@ -11,6 +11,7 @@ import (
 	"github.com/microsoft/TypeScript/tsc/shim/ast"
 	"github.com/microsoft/TypeScript/tsc/shim/bundled"
 	"github.com/microsoft/TypeScript/tsc/shim/compiler"
+	"github.com/microsoft/TypeScript/tsc/shim/tspath"
 	"github.com/microsoft/TypeScript/tsc/shim/vfs/cachedvfs"
 	"github.com/microsoft/TypeScript/tsc/shim/vfs/osvfs"
 	api "github.com/web-infra-dev/rslint/internal/api"
@@ -36,8 +37,8 @@ func (h *Handler) HandleGetAstInfo(req api.GetAstInfoRequest) (*api.GetAstInfoRe
 	userFileName := req.SourceFileName
 	if userFileName == "" {
 		userFileName = "/index.ts"
-	} else if userFileName[0] != '/' {
-		userFileName = "/" + userFileName
+	} else {
+		userFileName = tspath.ResolvePath("/", userFileName)
 	}
 
 	// Serialize compiler options for comparison

--- a/internal/api/server/ast_info.go
+++ b/internal/api/server/ast_info.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/microsoft/TypeScript/tsc/shim/ast"
@@ -21,6 +22,7 @@ import (
 type programCache struct {
 	mu              sync.RWMutex
 	fileContent     string
+	sourceFileName  string
 	compilerOptions string // JSON serialized for comparison
 	program         *compiler.Program
 	sourceFile      *ast.SourceFile
@@ -31,8 +33,12 @@ var astInfoProgramCache = &programCache{}
 
 // HandleGetAstInfo handles get AST info requests in IPC mode
 func (h *Handler) HandleGetAstInfo(req api.GetAstInfoRequest) (*api.GetAstInfoResponse, error) {
-	// Fixed user file name for program creation
-	const userFileName = "/index.ts"
+	userFileName := req.SourceFileName
+	if userFileName == "" {
+		userFileName = "/index.ts"
+	} else if userFileName[0] != '/' {
+		userFileName = "/" + userFileName
+	}
 
 	// Serialize compiler options for comparison
 	compilerOptionsJSON := "{}"
@@ -45,7 +51,7 @@ func (h *Handler) HandleGetAstInfo(req api.GetAstInfoRequest) (*api.GetAstInfoRe
 	}
 
 	// Check if we can use cached program
-	program, userSourceFile := getCachedProgram(req.FileContent, compilerOptionsJSON)
+	program, userSourceFile := getCachedProgram(userFileName, req.FileContent, compilerOptionsJSON)
 	if program == nil || userSourceFile == nil {
 		// Cache miss - create new program
 		var err error
@@ -131,7 +137,7 @@ func (h *Handler) HandleGetAstInfo(req api.GetAstInfoRequest) (*api.GetAstInfoRe
 }
 
 // getCachedProgram returns the cached program if it matches the current request
-func getCachedProgram(fileContent, compilerOptionsJSON string) (*compiler.Program, *ast.SourceFile) {
+func getCachedProgram(sourceFileName, fileContent, compilerOptionsJSON string) (*compiler.Program, *ast.SourceFile) {
 	astInfoProgramCache.mu.RLock()
 	defer astInfoProgramCache.mu.RUnlock()
 
@@ -139,8 +145,8 @@ func getCachedProgram(fileContent, compilerOptionsJSON string) (*compiler.Progra
 		return nil, nil
 	}
 
-	// Check if cache is valid (only fileContent and compilerOptions matter)
-	if astInfoProgramCache.fileContent == fileContent &&
+	if astInfoProgramCache.sourceFileName == sourceFileName &&
+		astInfoProgramCache.fileContent == fileContent &&
 		astInfoProgramCache.compilerOptions == compilerOptionsJSON {
 		return astInfoProgramCache.program, astInfoProgramCache.sourceFile
 	}
@@ -180,6 +186,7 @@ func createAndCacheProgram(fileName, fileContent, compilerOptionsJSON string, co
 
 	// Update cache
 	astInfoProgramCache.mu.Lock()
+	astInfoProgramCache.sourceFileName = fileName
 	astInfoProgramCache.fileContent = fileContent
 	astInfoProgramCache.compilerOptions = compilerOptionsJSON
 	astInfoProgramCache.program = program
@@ -198,6 +205,10 @@ func buildTsConfigContent(fileName string, compilerOptions map[string]any) strin
 		"strict":           true,
 		"strictNullChecks": true,
 	}
+	if strings.HasSuffix(fileName, ".js") || strings.HasSuffix(fileName, ".jsx") {
+		opts["allowJs"] = true
+		opts["checkJs"] = true
+	}
 
 	// Merge with provided options (provided options override defaults)
 	for k, v := range compilerOptions {
@@ -210,6 +221,10 @@ func buildTsConfigContent(fileName string, compilerOptions map[string]any) strin
 		// Fallback to minimal config on error
 		return fmt.Sprintf(`{"compilerOptions":{"target":"ESNext","module":"ESNext","strict":true},"files":["%s"]}`, fileName)
 	}
+	fileNameJSON, err := json.Marshal(fileName)
+	if err != nil {
+		return fmt.Sprintf(`{"compilerOptions":%s,"files":["/index.ts"]}`, string(optsJSON))
+	}
 
-	return fmt.Sprintf(`{"compilerOptions":%s,"files":["%s"]}`, string(optsJSON), fileName)
+	return fmt.Sprintf(`{"compilerOptions":%s,"files":[%s]}`, string(optsJSON), string(fileNameJSON))
 }

--- a/internal/api/server/ast_info_test.go
+++ b/internal/api/server/ast_info_test.go
@@ -13,10 +13,12 @@ func TestHandleGetAstInfoProgramCacheInvalidation(t *testing.T) {
 	cache := astInfoProgramCache
 	cache.mu.Lock()
 	originalFileContent := cache.fileContent
+	originalSourceFileName := cache.sourceFileName
 	originalCompilerOptions := cache.compilerOptions
 	originalProgram := cache.program
 	originalSourceFile := cache.sourceFile
 	cache.fileContent = ""
+	cache.sourceFileName = ""
 	cache.compilerOptions = ""
 	cache.program = nil
 	cache.sourceFile = nil
@@ -24,6 +26,7 @@ func TestHandleGetAstInfoProgramCacheInvalidation(t *testing.T) {
 	t.Cleanup(func() {
 		cache.mu.Lock()
 		cache.fileContent = originalFileContent
+		cache.sourceFileName = originalSourceFileName
 		cache.compilerOptions = originalCompilerOptions
 		cache.program = originalProgram
 		cache.sourceFile = originalSourceFile
@@ -31,10 +34,11 @@ func TestHandleGetAstInfoProgramCacheInvalidation(t *testing.T) {
 	})
 
 	handler := &Handler{}
-	loadProgram := func(content string, compilerOptions map[string]any) *compiler.Program {
+	loadProgram := func(fileName, content string, compilerOptions map[string]any) *compiler.Program {
 		t.Helper()
 		response, err := handler.HandleGetAstInfo(api.GetAstInfoRequest{
 			FileContent:     content,
+			SourceFileName:  fileName,
 			Kind:            int(ast.KindSourceFile),
 			CompilerOptions: compilerOptions,
 		})
@@ -53,7 +57,7 @@ func TestHandleGetAstInfoProgramCacheInvalidation(t *testing.T) {
 			}
 			optionsJSON = string(encoded)
 		}
-		program, sourceFile := getCachedProgram(content, optionsJSON)
+		program, sourceFile := getCachedProgram(fileName, content, optionsJSON)
 		if program == nil || sourceFile == nil {
 			t.Fatal("HandleGetAstInfo() did not publish its Program cache entry")
 		}
@@ -61,17 +65,21 @@ func TestHandleGetAstInfoProgramCacheInvalidation(t *testing.T) {
 	}
 
 	const initialContent = "const value = 1\n"
-	initialProgram := loadProgram(initialContent, nil)
-	if cachedProgram := loadProgram(initialContent, nil); cachedProgram != initialProgram {
+	initialProgram := loadProgram("/index.ts", initialContent, nil)
+	if cachedProgram := loadProgram("/index.ts", initialContent, nil); cachedProgram != initialProgram {
 		t.Fatal("identical content and compiler options did not reuse the cached Program")
+	}
+	jsxProgram := loadProgram("/index.tsx", initialContent, nil)
+	if jsxProgram == initialProgram {
+		t.Fatal("changed source filename reused the previous Program")
 	}
 
 	const changedContent = "const value = 2\n"
-	if cachedProgram, _ := getCachedProgram(changedContent, "{}"); cachedProgram != nil {
+	if cachedProgram, _ := getCachedProgram("/index.tsx", changedContent, "{}"); cachedProgram != nil {
 		t.Fatal("changed content unexpectedly matched the cached Program")
 	}
-	changedContentProgram := loadProgram(changedContent, nil)
-	if changedContentProgram == initialProgram {
+	changedContentProgram := loadProgram("/index.tsx", changedContent, nil)
+	if changedContentProgram == jsxProgram {
 		t.Fatal("changed content reused the previous Program")
 	}
 
@@ -80,10 +88,46 @@ func TestHandleGetAstInfoProgramCacheInvalidation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal changed compiler options: %v", err)
 	}
-	if cachedProgram, _ := getCachedProgram(changedContent, string(changedOptionsJSON)); cachedProgram != nil {
+	if cachedProgram, _ := getCachedProgram("/index.tsx", changedContent, string(changedOptionsJSON)); cachedProgram != nil {
 		t.Fatal("changed compiler options unexpectedly matched the cached Program")
 	}
-	if changedOptionsProgram := loadProgram(changedContent, changedOptions); changedOptionsProgram == changedContentProgram {
+	if changedOptionsProgram := loadProgram("/index.tsx", changedContent, changedOptions); changedOptionsProgram == changedContentProgram {
 		t.Fatal("changed compiler options reused the previous Program")
+	}
+}
+
+func TestHandleGetAstInfoUsesRequestedSourceFileName(t *testing.T) {
+	handler := &Handler{}
+	for _, testCase := range []struct {
+		name     string
+		fileName string
+		content  string
+	}{
+		{name: "default", content: "const value = 1\n"},
+		{name: "JavaScript", fileName: "index.js", content: "const value = 1\n"},
+		{name: "TypeScript JSX", fileName: "index.tsx", content: "const value = <div />\n"},
+		{name: "JavaScript JSX", fileName: "index.jsx", content: "const value = <div />\n"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			response, err := handler.HandleGetAstInfo(api.GetAstInfoRequest{
+				FileContent:    testCase.content,
+				SourceFileName: testCase.fileName,
+				Kind:           int(ast.KindSourceFile),
+			})
+			if err != nil {
+				t.Fatalf("HandleGetAstInfo() error = %v", err)
+			}
+			if response.Node == nil || response.Node.Kind != int(ast.KindSourceFile) {
+				t.Fatalf("HandleGetAstInfo() node = %#v, want SourceFile", response.Node)
+			}
+
+			wantFileName := testCase.fileName
+			if wantFileName == "" {
+				wantFileName = "index.ts"
+			}
+			if astInfoProgramCache.sourceFile == nil || astInfoProgramCache.sourceFile.FileName() != "/"+wantFileName {
+				t.Fatalf("source file = %v, want /%s", astInfoProgramCache.sourceFile, wantFileName)
+			}
+		})
 	}
 }

--- a/internal/api/server/ast_info_test.go
+++ b/internal/api/server/ast_info_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/microsoft/TypeScript/tsc/shim/ast"
 	"github.com/microsoft/TypeScript/tsc/shim/compiler"
+	"github.com/microsoft/TypeScript/tsc/shim/tspath"
 	api "github.com/web-infra-dev/rslint/internal/api"
 )
 
@@ -107,6 +108,9 @@ func TestHandleGetAstInfoUsesRequestedSourceFileName(t *testing.T) {
 		{name: "JavaScript", fileName: "index.js", content: "const value = 1\n"},
 		{name: "TypeScript JSX", fileName: "index.tsx", content: "const value = <div />\n"},
 		{name: "JavaScript JSX", fileName: "index.jsx", content: "const value = <div />\n"},
+		{name: "dot segment", fileName: "./index.ts", content: "const value = 1\n"},
+		{name: "parent segment", fileName: "src/../index.ts", content: "const value = 1\n"},
+		{name: "absolute", fileName: "/index.ts", content: "const value = 1\n"},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
 			response, err := handler.HandleGetAstInfo(api.GetAstInfoRequest{
@@ -125,8 +129,9 @@ func TestHandleGetAstInfoUsesRequestedSourceFileName(t *testing.T) {
 			if wantFileName == "" {
 				wantFileName = "index.ts"
 			}
-			if astInfoProgramCache.sourceFile == nil || astInfoProgramCache.sourceFile.FileName() != "/"+wantFileName {
-				t.Fatalf("source file = %v, want /%s", astInfoProgramCache.sourceFile, wantFileName)
+			wantFileName = tspath.ResolvePath("/", wantFileName)
+			if astInfoProgramCache.sourceFile == nil || astInfoProgramCache.sourceFile.FileName() != wantFileName {
+				t.Fatalf("source file = %v, want %s", astInfoProgramCache.sourceFile, wantFileName)
 			}
 		})
 	}

--- a/internal/inspector/types.go
+++ b/internal/inspector/types.go
@@ -8,6 +8,7 @@ package inspector
 // GetAstInfoRequest represents a request for AST info at a specific position
 type GetAstInfoRequest struct {
 	FileContent     string         `json:"fileContent"`               // Source code content
+	SourceFileName  string         `json:"sourceFileName,omitempty"`  // User source filename (defaults to /index.ts)
 	Position        int            `json:"position"`                  // Start position (pos)
 	End             int            `json:"end,omitempty"`             // End position (optional, for exact node matching)
 	Kind            int            `json:"kind,omitempty"`            // Optional: filter by node kind (when multiple nodes at same position)

--- a/packages/rslint/src/service/service.ts
+++ b/packages/rslint/src/service/service.ts
@@ -130,6 +130,7 @@ export class RSLintService {
   ): Promise<GetAstInfoResponse> {
     const {
       fileContent,
+      sourceFileName,
       position,
       end,
       kind,
@@ -143,6 +144,7 @@ export class RSLintService {
     // Send getAstInfo request
     return this.service.sendMessage('getAstInfo', {
       fileContent,
+      sourceFileName,
       position,
       end,
       kind,

--- a/packages/rslint/src/types.ts
+++ b/packages/rslint/src/types.ts
@@ -159,6 +159,7 @@ export interface RslintServiceInterface {
  */
 export interface GetAstInfoRequest {
   fileContent: string;
+  sourceFileName?: string; // User source filename (defaults to /index.ts)
   position: number;
   end?: number; // End position (optional, for exact node matching)
   kind?: number; // Optional: filter by node kind (when multiple nodes at same position)

--- a/website/theme/components/Playground/Client.tsx
+++ b/website/theme/components/Playground/Client.tsx
@@ -15,6 +15,7 @@ import {
 } from '@/theme/components/ui/select';
 import { ensureWasmService, fetchWasmVersions } from './wasm';
 import { readShareState } from './share-url';
+import type { SourceFileName } from './source-file';
 
 const Playground: React.FC = () => {
   const editorRef = useRef<EditorTabsRef | null>(null);
@@ -83,13 +84,15 @@ const Playground: React.FC = () => {
       const service = await ensureWasmService(version);
       if (!isCurrentLintRun(runId, version)) return;
       const code = editorRef.current?.getValue() ?? '';
+      const sourceFileName =
+        editorRef.current?.getSourceFileName() ?? 'index.ts';
       const rslintConfig = await editorRef.current?.getRslintConfig(version);
       if (!isCurrentLintRun(runId, version)) return;
       const tsConfig = editorRef.current?.getTsConfig();
 
       // Build fileContents with code and config files
       const fileContents: Record<string, string> = {
-        '/index.ts': code,
+        [`/${sourceFileName}`]: code,
       };
 
       // Add tsconfig.json if we have a valid config
@@ -141,7 +144,7 @@ const Playground: React.FC = () => {
       // Generate AST (tsgo)
       let sourceTextForTs: string | undefined;
       try {
-        const astBuffer = result.encodedSourceFiles!['index.ts'];
+        const astBuffer = result.encodedSourceFiles![sourceFileName];
         const buffer = Uint8Array.from(atob(astBuffer), (c) => c.charCodeAt(0));
         const source = new RemoteSourceFile(buffer, new TextDecoder());
         // capture the exact source text from encoded source file
@@ -254,6 +257,7 @@ const Playground: React.FC = () => {
 
         const result = await service.getAstInfo({
           fileContent: code,
+          sourceFileName: editorRef.current?.getSourceFileName(),
           position,
           end,
           kind,
@@ -291,6 +295,7 @@ const Playground: React.FC = () => {
 
         const result = await service.getAstInfo({
           fileContent: code,
+          sourceFileName: editorRef.current?.getSourceFileName(),
           position,
           end,
           kind,
@@ -307,15 +312,32 @@ const Playground: React.FC = () => {
     [initialized, selectedVersion],
   );
 
+  function scriptKindForFile(
+    ts: typeof import('typescript'),
+    fileName: SourceFileName,
+  ) {
+    switch (fileName) {
+      case 'index.js':
+        return ts.ScriptKind.JS;
+      case 'index.jsx':
+        return ts.ScriptKind.JSX;
+      case 'index.tsx':
+        return ts.ScriptKind.TSX;
+      default:
+        return ts.ScriptKind.TS;
+    }
+  }
+
   async function buildTypeScriptAst(text: string) {
     const ts = tsModuleRef.current!;
+    const sourceFileName = editorRef.current?.getSourceFileName() ?? 'index.ts';
     try {
       const sf = ts.createSourceFile(
-        'index.ts',
+        sourceFileName,
         text,
         ts.ScriptTarget.Latest,
         /*setParentNodes*/ true,
-        ts.ScriptKind.TS,
+        scriptKindForFile(ts, sourceFileName),
       );
 
       interface TSAstNode {

--- a/website/theme/components/Playground/Client.tsx
+++ b/website/theme/components/Playground/Client.tsx
@@ -13,7 +13,11 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/theme/components/ui/select';
-import { ensureWasmService, fetchWasmVersions } from './wasm';
+import {
+  ensureWasmService,
+  fetchWasmVersions,
+  supportsAstInspector,
+} from './wasm';
 import { readShareState } from './share-url';
 import type { SourceFileName } from './source-file';
 
@@ -38,9 +42,16 @@ const Playground: React.FC = () => {
   const [astInfoLoading, setAstInfoLoading] = useState(false);
   const [wasmVersions, setWasmVersions] = useState<string[]>([]);
   const [selectedVersion, setSelectedVersion] = useState<string>();
+  const [sourceFileName, setSourceFileName] = useState<SourceFileName>(
+    () => readShareState().sourceFileName,
+  );
   // Captured before the editors get a chance to rewrite the URL.
   const [pinnedVersion] = useState(() => readShareState().wasmVersion);
   const selectedVersionRef = useRef<string | undefined>(undefined);
+  const astInspectorEnabled = supportsAstInspector(
+    selectedVersion,
+    sourceFileName,
+  );
 
   useEffect(() => {
     const controller = new AbortController();
@@ -247,7 +258,7 @@ const Playground: React.FC = () => {
       kind?: number,
       fileName?: string,
     ): Promise<GetAstInfoResponse | null> => {
-      if (!initialized) return null;
+      if (!initialized || !astInspectorEnabled) return null;
 
       try {
         setAstInfoLoading(true);
@@ -275,7 +286,7 @@ const Playground: React.FC = () => {
         setAstInfoLoading(false);
       }
     },
-    [initialized, selectedVersion],
+    [astInspectorEnabled, initialized, selectedVersion],
   );
 
   // Fetch AST info for lazy loading - does NOT update global state
@@ -286,7 +297,7 @@ const Playground: React.FC = () => {
       kind?: number,
       fileName?: string,
     ): Promise<GetAstInfoResponse | null> => {
-      if (!initialized) return null;
+      if (!initialized || !astInspectorEnabled) return null;
 
       try {
         const service = await ensureWasmService(selectedVersion!);
@@ -309,7 +320,7 @@ const Playground: React.FC = () => {
         return null;
       }
     },
-    [initialized, selectedVersion],
+    [astInspectorEnabled, initialized, selectedVersion],
   );
 
   function scriptKindForFile(
@@ -382,6 +393,7 @@ const Playground: React.FC = () => {
             <EditorTabs
               ref={editorRef}
               onChange={() => scheduleRunLint()}
+              onSourceFileNameChange={setSourceFileName}
               onSelectionChange={(start: number, end: number) =>
                 setSelectedAstRange((prev) => {
                   // Preserve kind if position is the same (e.g., from revealRangeByOffset)
@@ -463,6 +475,7 @@ const Playground: React.FC = () => {
             }}
             astInfo={astInfo}
             astInfoLoading={astInfoLoading}
+            astInfoEnabled={astInspectorEnabled}
             onRequestAstInfo={handleRequestAstInfo}
             onFetchAstInfoForLazy={fetchAstInfoForLazy}
             onHighlightRange={(pos, end) =>

--- a/website/theme/components/Playground/EditorTabs.tsx
+++ b/website/theme/components/Playground/EditorTabs.tsx
@@ -18,6 +18,14 @@ import {
 import { type Diagnostic } from '@rslint/core/service';
 import { useDark } from '@rspress/core/runtime';
 import { Button } from '@components/ui/button';
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@components/ui/select';
 import { evaluateConfig, type PlaygroundConfig } from './config';
 import {
   DEFAULT_RSLINT_CONFIG,
@@ -25,6 +33,12 @@ import {
   writeShareState,
 } from './share-url';
 import { installRslintCoreTypes } from './config-types';
+import {
+  isSourceFileName,
+  sourceFileLanguage,
+  SOURCE_FILE_NAMES,
+  type SourceFileName,
+} from './source-file';
 // Monaco-specific styles only (ast-node-highlight)
 import './EditorTabs.css';
 
@@ -51,6 +65,7 @@ export type EditorTabType = 'code' | 'rslint' | 'tsconfig';
 export interface EditorTabsRef {
   getValue: () => string | undefined;
   getCodeValue: () => string | undefined;
+  getSourceFileName: () => SourceFileName;
   getRslintConfig: (wasmVersion: string) => Promise<PlaygroundConfig>;
   getTsConfig: () => any | null;
   attachDiag: (diags: Diagnostic[]) => void;
@@ -100,6 +115,9 @@ export const EditorTabs = ({
 }: EditorTabsProps) => {
   const [activeTab, setActiveTab] = useState<EditorTabType>('code');
   const [initialState] = useState(readShareState);
+  const [sourceFileName, setSourceFileName] = useState(
+    initialState.sourceFileName,
+  );
   const isDark = useDark();
   const editorTheme = isDark ? 'vs-dark' : 'vs';
 
@@ -126,6 +144,7 @@ export const EditorTabs = ({
   const onSelectionChangeRef = useRef(onSelectionChange);
   const onConfigChangeRef = useRef(onConfigChange);
   const wasmVersionRef = useRef(wasmVersion);
+  const sourceFileNameRef = useRef(initialState.sourceFileName);
 
   const lastValidTsConfig = useRef<any>(null);
 
@@ -140,6 +159,7 @@ export const EditorTabs = ({
   function serializeToUrl() {
     writeShareState({
       code: codeEditorRef.current?.getValue() ?? initialState.code,
+      sourceFileName: sourceFileNameRef.current,
       rslintConfig:
         rslintEditorRef.current?.getValue() ?? initialState.rslintConfig,
       tsconfig: tsconfigEditorRef.current?.getValue() ?? initialState.tsconfig,
@@ -178,6 +198,7 @@ export const EditorTabs = ({
     },
     getValue: () => codeEditorRef.current?.getValue(),
     getCodeValue: () => codeEditorRef.current?.getValue(),
+    getSourceFileName: () => sourceFileNameRef.current,
     getRslintConfig: async (wasmVersion) => {
       await installRslintCoreTypes(wasmVersion);
       return evaluateConfig(
@@ -310,9 +331,13 @@ export const EditorTabs = ({
   useEffect(() => {
     if (!codeContainerRef.current) return;
 
+    const model = monaco.editor.createModel(
+      initialState.code,
+      sourceFileLanguage(initialState.sourceFileName),
+      monaco.Uri.parse(`file:///${initialState.sourceFileName}`),
+    );
     const editor = monaco.editor.create(codeContainerRef.current, {
-      value: initialState.code,
-      language: 'typescript',
+      model,
       theme: editorTheme,
       automaticLayout: true,
       scrollBeyondLastLine: false,
@@ -374,12 +399,35 @@ export const EditorTabs = ({
 
     return () => {
       selDisposable.dispose();
+      editor.getModel()?.dispose();
       editor.dispose();
       if (editingTimer.current) {
         window.clearTimeout(editingTimer.current);
       }
     };
   }, []);
+
+  function selectSourceFile(value: string) {
+    if (!isSourceFileName(value) || value === sourceFileNameRef.current) return;
+    setActiveTab('code');
+
+    const editor = codeEditorRef.current;
+    const previousModel = editor?.getModel();
+    if (!editor || !previousModel) return;
+
+    const nextModel = monaco.editor.createModel(
+      previousModel.getValue(),
+      sourceFileLanguage(value),
+      monaco.Uri.parse(`file:///${value}`),
+    );
+    editor.setModel(nextModel);
+    previousModel.dispose();
+
+    sourceFileNameRef.current = value;
+    setSourceFileName(value);
+    onChangeRef.current(nextModel.getValue());
+    scheduleSerializeToUrl();
+  }
 
   // Configure Monaco JSON to allow comments and trailing commas (JSONC)
   useEffect(() => {
@@ -459,8 +507,7 @@ export const EditorTabs = ({
     monaco.editor.setTheme(editorTheme);
   }, [editorTheme]);
 
-  const tabs: { key: EditorTabType; label: string }[] = [
-    { key: 'code', label: 'Code' },
+  const tabs: { key: Exclude<EditorTabType, 'code'>; label: string }[] = [
     { key: 'rslint', label: 'rslint.config.js' },
     { key: 'tsconfig', label: 'tsconfig.json' },
   ];
@@ -469,6 +516,34 @@ export const EditorTabs = ({
     <div className="flex flex-col h-full w-full">
       <div className="flex items-center justify-between gap-2 bg-[var(--rp-c-bg-soft)] p-2 flex-shrink-0">
         <div className="flex items-center gap-2">
+          <Select
+            value={sourceFileName}
+            onValueChange={selectSourceFile}
+            onOpenChange={(open) => {
+              if (open) setActiveTab('code');
+            }}
+          >
+            <SelectTrigger
+              size="sm"
+              aria-label="Select source file type"
+              className={
+                activeTab === 'code'
+                  ? 'border-primary bg-primary text-primary-foreground hover:bg-primary/90 [&_svg]:text-primary-foreground'
+                  : undefined
+              }
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectGroup>
+                {SOURCE_FILE_NAMES.map((fileName) => (
+                  <SelectItem key={fileName} value={fileName}>
+                    {fileName}
+                  </SelectItem>
+                ))}
+              </SelectGroup>
+            </SelectContent>
+          </Select>
           {tabs.map((tab) => (
             <Button
               key={tab.key}

--- a/website/theme/components/Playground/EditorTabs.tsx
+++ b/website/theme/components/Playground/EditorTabs.tsx
@@ -84,6 +84,7 @@ export interface EditorTabsRef {
 interface EditorTabsProps {
   ref: Ref<EditorTabsRef>;
   onChange: (value: string) => void;
+  onSourceFileNameChange?: (fileName: SourceFileName) => void;
   onSelectionChange?: (start: number, end: number) => void;
   onConfigChange?: () => void;
   /** The `@rslint/wasm` version to pin in the link, once one is selected. */
@@ -108,6 +109,7 @@ function parseJsonc(content: string): any | null {
 export const EditorTabs = ({
   ref,
   onChange,
+  onSourceFileNameChange,
   onSelectionChange,
   onConfigChange,
   wasmVersion,
@@ -141,6 +143,7 @@ export const EditorTabs = ({
   const isEditingRef = useRef<boolean>(false);
   const editingTimer = useRef<number | null>(null);
   const onChangeRef = useRef(onChange);
+  const onSourceFileNameChangeRef = useRef(onSourceFileNameChange);
   const onSelectionChangeRef = useRef(onSelectionChange);
   const onConfigChangeRef = useRef(onConfigChange);
   const wasmVersionRef = useRef(wasmVersion);
@@ -152,9 +155,10 @@ export const EditorTabs = ({
   // through refs instead of retaining callbacks from the initial render.
   useLayoutEffect(() => {
     onChangeRef.current = onChange;
+    onSourceFileNameChangeRef.current = onSourceFileNameChange;
     onSelectionChangeRef.current = onSelectionChange;
     onConfigChangeRef.current = onConfigChange;
-  }, [onChange, onSelectionChange, onConfigChange]);
+  }, [onChange, onSourceFileNameChange, onSelectionChange, onConfigChange]);
 
   function serializeToUrl() {
     writeShareState({
@@ -425,6 +429,7 @@ export const EditorTabs = ({
 
     sourceFileNameRef.current = value;
     setSourceFileName(value);
+    onSourceFileNameChangeRef.current?.(value);
     onChangeRef.current(nextModel.getValue());
     scheduleSerializeToUrl();
   }

--- a/website/theme/components/Playground/ResultPanel.tsx
+++ b/website/theme/components/Playground/ResultPanel.tsx
@@ -37,6 +37,7 @@ interface ResultPanelProps {
   onRequestTsAst?: () => void;
   astInfo?: GetAstInfoResponse | null;
   astInfoLoading?: boolean;
+  astInfoEnabled?: boolean;
   onRequestAstInfo?: (
     position: number,
     end?: number,
@@ -89,6 +90,7 @@ export const ResultPanel: React.FC<ResultPanelProps> = (props) => {
     onRequestTsAst,
     astInfo,
     astInfoLoading,
+    astInfoEnabled,
     onRequestAstInfo,
     onFetchAstInfoForLazy,
     onHighlightRange,
@@ -535,6 +537,7 @@ export const ResultPanel: React.FC<ResultPanelProps> = (props) => {
                   <AstInfoPanel
                     info={astInfo ?? undefined}
                     loading={astInfoLoading}
+                    enabled={astInfoEnabled}
                     onRequestAstInfo={onRequestAstInfo}
                     onFetchAstInfoForLazy={onFetchAstInfoForLazy}
                     onHighlightRange={onHighlightRange}

--- a/website/theme/components/Playground/ast/AstInfoPanel.tsx
+++ b/website/theme/components/Playground/ast/AstInfoPanel.tsx
@@ -24,6 +24,7 @@ import { CollapsibleItem } from './CollapsibleItem';
 interface AstInfoPanelProps {
   info?: GetAstInfoResponse;
   loading?: boolean;
+  enabled?: boolean;
   onRequestAstInfo?: (
     position: number,
     end?: number,
@@ -62,11 +63,20 @@ const Section: React.FC<SectionProps> = ({ title, children }) => (
 export const AstInfoPanel: React.FC<AstInfoPanelProps> = ({
   info,
   loading,
+  enabled = true,
   onRequestAstInfo,
   onFetchAstInfoForLazy,
   onHighlightRange,
   onClearHighlight,
 }) => {
+  if (!enabled) {
+    return (
+      <div className="flex h-full items-center justify-center px-4 text-center text-sm text-gray-400">
+        AST details for this file type require Rslint v0.9.3 or newer
+      </div>
+    );
+  }
+
   if (loading) {
     return (
       <div className="flex h-full items-center justify-center text-center text-sm text-gray-400">

--- a/website/theme/components/Playground/ast/types.ts
+++ b/website/theme/components/Playground/ast/types.ts
@@ -233,6 +233,7 @@ export interface GetAstInfoResponse {
 
 export interface GetAstInfoRequest {
   fileContent: string;
+  sourceFileName?: string; // User source filename (defaults to /index.ts)
   position: number;
   end?: number; // Optional: end position for exact node matching
   kind?: number; // Optional: filter by node kind (when multiple nodes at same position)

--- a/website/theme/components/Playground/share-url.ts
+++ b/website/theme/components/Playground/share-url.ts
@@ -1,5 +1,10 @@
 import { deflateSync, inflateSync } from 'fflate';
 import { SHARE_DICT_V1 } from './share-dict';
+import {
+  DEFAULT_SOURCE_FILE_NAME,
+  isSourceFileName,
+  type SourceFileName,
+} from './source-file';
 
 export const DEFAULT_CODE = ['let a: any;', 'a.b = 10;'].join('\n');
 
@@ -31,6 +36,7 @@ export const DEFAULT_TSCONFIG = `{
 
 export interface ShareState {
   code: string;
+  sourceFileName: SourceFileName;
   rslintConfig: string;
   tsconfig: string;
   /**
@@ -80,8 +86,13 @@ const FLAG_CODE = 1;
 const FLAG_RSLINT_CONFIG = 2;
 const FLAG_TSCONFIG = 4;
 const FLAG_WASM_VERSION = 8;
+const FLAG_SOURCE_FILE_NAME = 16;
 const ALL_FLAGS =
-  FLAG_CODE | FLAG_RSLINT_CONFIG | FLAG_TSCONFIG | FLAG_WASM_VERSION;
+  FLAG_CODE |
+  FLAG_RSLINT_CONFIG |
+  FLAG_TSCONFIG |
+  FLAG_WASM_VERSION |
+  FLAG_SOURCE_FILE_NAME;
 
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
@@ -158,11 +169,12 @@ function encodeFrame(
 function decodeFrame(frame: Uint8Array): ShareState | null {
   if (frame.length === 0) return null;
   const flags = frame[0];
-  if (flags === 0 || flags > ALL_FLAGS) return null;
+  if (flags === 0 || (flags & ~ALL_FLAGS) !== 0) return null;
   const cursor = { offset: 1 };
 
   const state: ShareState = {
     code: DEFAULT_CODE,
+    sourceFileName: DEFAULT_SOURCE_FILE_NAME,
     rslintConfig: DEFAULT_RSLINT_CONFIG,
     tsconfig: DEFAULT_TSCONFIG,
   };
@@ -180,20 +192,29 @@ function decodeFrame(frame: Uint8Array): ShareState | null {
       [FLAG_CODE, 'code'],
       [FLAG_RSLINT_CONFIG, 'rslintConfig'],
       [FLAG_TSCONFIG, 'tsconfig'],
+      [FLAG_SOURCE_FILE_NAME, 'sourceFileName'],
     ] as const
   ).filter(([flag]) => flags & flag);
   keys.forEach(([, key], index) => {
+    let value: string;
     if (index === keys.length - 1) {
-      state[key] = decoder.decode(frame.subarray(cursor.offset));
+      value = decoder.decode(frame.subarray(cursor.offset));
       cursor.offset = frame.length;
-      return;
+    } else {
+      const length = readVarint(frame, cursor);
+      if (cursor.offset + length > frame.length) throw new RangeError();
+      value = decoder.decode(
+        frame.subarray(cursor.offset, cursor.offset + length),
+      );
+      cursor.offset += length;
     }
-    const length = readVarint(frame, cursor);
-    if (cursor.offset + length > frame.length) throw new RangeError();
-    state[key] = decoder.decode(
-      frame.subarray(cursor.offset, cursor.offset + length),
-    );
-    cursor.offset += length;
+
+    if (key === 'sourceFileName') {
+      if (!isSourceFileName(value)) throw new RangeError();
+      state.sourceFileName = value;
+    } else {
+      state[key] = value;
+    }
   });
   return state;
 }
@@ -218,12 +239,16 @@ export function encodeShareState(state: ShareState): string | null {
     flags |= FLAG_TSCONFIG;
     sections.push(encoder.encode(state.tsconfig));
   }
-  const version =
+  if (state.sourceFileName !== DEFAULT_SOURCE_FILE_NAME) {
+    flags |= FLAG_SOURCE_FILE_NAME;
+    sections.push(encoder.encode(state.sourceFileName));
+  }
+  const parsedVersion =
     state.wasmVersion === undefined ? null : parseVersion(state.wasmVersion);
-  if (version !== null) flags |= FLAG_WASM_VERSION;
+  if (parsedVersion !== null) flags |= FLAG_WASM_VERSION;
   if (flags === 0) return null;
 
-  const compressed = deflateSync(encodeFrame(flags, version, sections), {
+  const compressed = deflateSync(encodeFrame(flags, parsedVersion, sections), {
     level: 9,
     mem: 12,
     dictionary: getDictionary(),
@@ -270,6 +295,7 @@ export function decodeShareState(payload: string): ShareState | null {
 export function readShareState(): ShareState {
   const defaults: ShareState = {
     code: DEFAULT_CODE,
+    sourceFileName: DEFAULT_SOURCE_FILE_NAME,
     rslintConfig: DEFAULT_RSLINT_CONFIG,
     tsconfig: DEFAULT_TSCONFIG,
   };

--- a/website/theme/components/Playground/source-file.ts
+++ b/website/theme/components/Playground/source-file.ts
@@ -1,0 +1,20 @@
+export const SOURCE_FILE_NAMES = [
+  'index.ts',
+  'index.js',
+  'index.tsx',
+  'index.jsx',
+] as const;
+
+export type SourceFileName = (typeof SOURCE_FILE_NAMES)[number];
+
+export const DEFAULT_SOURCE_FILE_NAME: SourceFileName = 'index.ts';
+
+export function isSourceFileName(value: unknown): value is SourceFileName {
+  return SOURCE_FILE_NAMES.some((fileName) => fileName === value);
+}
+
+export function sourceFileLanguage(fileName: SourceFileName) {
+  return fileName.endsWith('.js') || fileName.endsWith('.jsx')
+    ? 'javascript'
+    : 'typescript';
+}

--- a/website/theme/components/Playground/wasm.ts
+++ b/website/theme/components/Playground/wasm.ts
@@ -1,6 +1,8 @@
 import type { RSLintService } from '@rslint/core/service';
+import { DEFAULT_SOURCE_FILE_NAME, type SourceFileName } from './source-file';
 
 const MINIMUM_WASM_VERSION = '0.8.0';
+const MINIMUM_FILENAME_AWARE_AST_INSPECTOR_VERSION = '0.9.2';
 
 const NPM_REGISTRY_URL = 'https://registry.npmjs.org/@rslint%2Fwasm';
 const UNPKG_BASE_URL = 'https://unpkg.com/@rslint/wasm';
@@ -30,6 +32,18 @@ function compareVersions(left: string, right: string): number {
     if (difference !== 0) return difference;
   }
   return 0;
+}
+
+export function supportsAstInspector(
+  version: string | undefined,
+  sourceFileName: SourceFileName,
+): boolean {
+  return (
+    sourceFileName === DEFAULT_SOURCE_FILE_NAME ||
+    (version !== undefined &&
+      compareVersions(version, MINIMUM_FILENAME_AWARE_AST_INSPECTOR_VERSION) >
+        0)
+  );
 }
 
 export async function fetchWasmVersions(


### PR DESCRIPTION
## Motivation

The Playground currently treats all source code as `index.ts`. As a result, JavaScript and JSX examples are parsed with the wrong source type, and rules from plugins such as React and JSX a11y cannot be demonstrated correctly.

<img width="972" height="671" alt="image" src="https://github.com/user-attachments/assets/193f026e-1f24-4ca1-afff-46309d9814c1" />


## Changes

The Playground source tab is now a filename selector with four supported options:

- `index.ts` (default)
- `index.js`
- `index.tsx`
- `index.jsx`

The selected filename is used consistently for the Monaco model, wasm lint input, encoded AST lookup, TypeScript AST parsing, and AST inspector requests. Opening the selector or choosing a filename also activates the source editor tab.

The AST inspector API now accepts an optional source filename and includes it in its program cache identity. JavaScript and JSX requests enable `allowJs` and `checkJs` in the inspector's temporary TypeScript project.

Older published WASM versions do not support filename-aware AST detail requests. AST details therefore remain available for `index.ts` with every selectable version, while `index.js`, `index.tsx`, and `index.jsx` require a version newer than `0.9.2`. Lint results and both AST trees remain available on older versions.

The selected filename is preserved in Playground share links. `index.ts` remains the implicit default and is not serialized, so existing links remain compatible. The existing share format version is unchanged.
