### PR TITLE
feat: port rule unicorn/require-post-message-target-origin

### DIFF
--- a/internal/plugins/unicorn/all.go
+++ b/internal/plugins/unicorn/all.go
@@ -46,6 +46,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_then_catch"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/require_array_join_separator"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/require_number_to_fixed_digits_argument"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/require_post_message_target_origin"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/throw_new_error"
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
@@ -97,6 +98,7 @@ func GetAllRules() []rule.Rule {
 		prefer_ternary.PreferTernaryRule,
 		require_array_join_separator.RequireArrayJoinSeparatorRule,
 		require_number_to_fixed_digits_argument.RequireNumberToFixedDigitsArgumentRule,
+		require_post_message_target_origin.RequirePostMessageTargetOriginRule,
 		throw_new_error.ThrowNewErrorRule,
 	}
 }

--- a/internal/plugins/unicorn/rules/require_post_message_target_origin/require_post_message_target_origin.go
+++ b/internal/plugins/unicorn/rules/require_post_message_target_origin/require_post_message_target_origin.go
@@ -1,0 +1,79 @@
+// Ported from eslint-plugin-unicorn v74.0.0 (MIT).
+package require_post_message_target_origin
+
+import (
+	"github.com/microsoft/TypeScript/tsc/shim/ast"
+	"github.com/microsoft/TypeScript/tsc/shim/core"
+	"github.com/microsoft/TypeScript/tsc/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/unicornutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/rules/require-post-message-target-origin.js
+var RequirePostMessageTargetOriginRule = rule.Rule{
+	Name:   "unicorn/require-post-message-target-origin",
+	Schema: rule.EmptyArraySchema,
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		oneArgument := 1
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				call, ok := unicornutil.MatchDotMethodCall(node, unicornutil.DotMethodCallOptions{
+					Method:              "postMessage",
+					ArgumentsLength:     &oneArgument,
+					RejectSpreadElement: true,
+					AllowOptionalMember: true,
+				})
+				if !ok {
+					return
+				}
+
+				// Scan only the suffix after the argument. This preserves comments
+				// and parentheses without re-scanning regex or template literals.
+				start := node.Arguments()[0].End()
+				s := scanner.GetScannerForSourceFile(ctx.SourceFile, start)
+				trailingComma := s.Token() == ast.KindCommaToken
+				if trailingComma {
+					start = s.TokenEnd()
+					s.Scan()
+				}
+				if s.Token() != ast.KindCloseParenToken || s.TokenEnd() != node.End() {
+					return
+				}
+				closing := s.TokenRange()
+				ctx.ReportRangeWithDeferredSuggestions(core.NewTextRange(start, closing.End()), rule.RuleMessage{
+					Id:          "error",
+					Description: "Missing the `targetOrigin` argument.",
+				}, func() []rule.RuleSuggestion {
+					replacements := []string{}
+					target := utils.ESTreeRuntimeExpression(call.Object)
+					if ast.IsIdentifier(target) {
+						name := target.AsIdentifier().Text
+						replacements = append(replacements, name+".location.origin")
+						if name != "self" && name != "window" && name != "globalThis" {
+							replacements = append(replacements, "self.location.origin")
+						}
+					} else {
+						replacements = append(replacements, "self.location.origin")
+					}
+					replacements = append(replacements, "'*'")
+
+					suggestions := make([]rule.RuleSuggestion, 0, len(replacements))
+					for _, replacement := range replacements {
+						text := ", " + replacement
+						if trailingComma {
+							text = " " + replacement + ","
+						}
+						suggestions = append(suggestions, rule.RuleSuggestion{
+							Message: rule.RuleMessage{Id: "suggestion", Description: "Use `" + replacement + "`."},
+							FixesArr: []rule.RuleFix{
+								rule.RuleFixReplaceRange(core.NewTextRange(closing.Pos(), closing.Pos()), text),
+							},
+						})
+					}
+					return suggestions
+				})
+			},
+		}
+	},
+}

--- a/internal/plugins/unicorn/rules/require_post_message_target_origin/require_post_message_target_origin.go
+++ b/internal/plugins/unicorn/rules/require_post_message_target_origin/require_post_message_target_origin.go
@@ -65,7 +65,11 @@ var RequirePostMessageTargetOriginRule = rule.Rule{
 							text = " " + replacement + ","
 						}
 						suggestions = append(suggestions, rule.RuleSuggestion{
-							Message: rule.RuleMessage{Id: "suggestion", Description: "Use `" + replacement + "`."},
+							Message: rule.RuleMessage{
+								Id:          "suggestion",
+								Description: "Use `" + replacement + "`.",
+								Data:        map[string]string{"code": replacement},
+							},
 							FixesArr: []rule.RuleFix{
 								rule.RuleFixReplaceRange(core.NewTextRange(closing.Pos(), closing.Pos()), text),
 							},

--- a/internal/plugins/unicorn/rules/require_post_message_target_origin/require_post_message_target_origin.md
+++ b/internal/plugins/unicorn/rules/require_post_message_target_origin/require_post_message_target_origin.md
@@ -38,7 +38,8 @@ This rule has no options.
 Like upstream, this rule cannot distinguish a window from a `Worker`,
 `MessagePort`, `Client`, or `BroadcastChannel`. Those APIs do not accept a
 `targetOrigin` argument, so enable this rule only where it is appropriate.
-The rule is not included in upstream's recommended configuration.
+The recommended preset explicitly disables this rule, matching upstream. If
+you want to enable it, place your rule configuration after the preset.
 
 Computed property access, spread arguments, and optional calls are ignored.
 Optional member access, such as `window?.postMessage(message)`, is checked.

--- a/internal/plugins/unicorn/rules/require_post_message_target_origin/require_post_message_target_origin.md
+++ b/internal/plugins/unicorn/rules/require_post_message_target_origin/require_post_message_target_origin.md
@@ -1,0 +1,49 @@
+# require-post-message-target-origin
+
+Require an explicit `targetOrigin` argument in `.postMessage()` calls so that
+messages can be restricted to an intended origin.
+
+## Examples
+
+Incorrect:
+
+```js
+window.postMessage(sensitiveData);
+window.postMessage({ token: authToken });
+iframe.contentWindow.postMessage(data);
+```
+
+Correct:
+
+```js
+window.postMessage(sensitiveData, 'https://trusted-domain.com');
+window.postMessage({ token: authToken }, 'https://api.example.com');
+iframe.contentWindow.postMessage(data, 'https://expected-iframe-origin.com');
+
+// Use a wildcard only for non-sensitive public data.
+window.postMessage({ publicData: 'hello' }, '*');
+```
+
+The rule provides editor suggestions, not automatic fixes. Depending on the
+receiver, suggestions use its `location.origin`, `self.location.origin`, or
+`'*'`. Choose the intended recipient's origin; a wildcard does not restrict
+which origin can receive the message.
+
+## Options
+
+This rule has no options.
+
+## Limitations
+
+Like upstream, this rule cannot distinguish a window from a `Worker`,
+`MessagePort`, `Client`, or `BroadcastChannel`. Those APIs do not accept a
+`targetOrigin` argument, so enable this rule only where it is appropriate.
+The rule is not included in upstream's recommended configuration.
+
+Computed property access, spread arguments, and optional calls are ignored.
+Optional member access, such as `window?.postMessage(message)`, is checked.
+
+## References
+
+- [Upstream documentation](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/docs/rules/require-post-message-target-origin.md)
+- [Upstream implementation](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/rules/require-post-message-target-origin.js)

--- a/internal/plugins/unicorn/rules/require_post_message_target_origin/require_post_message_target_origin_extras_test.go
+++ b/internal/plugins/unicorn/rules/require_post_message_target_origin/require_post_message_target_origin_extras_test.go
@@ -154,6 +154,9 @@ func TestRequirePostMessageTargetOriginEditDemand(t *testing.T) {
 		if suggestion.Message.Id != "suggestion" || suggestion.Message.Description != "Use `"+origin+"`." {
 			t.Errorf("suggestion %d: unexpected message %+v", i, suggestion.Message)
 		}
+		if !reflect.DeepEqual(suggestion.Message.Data, map[string]string{"code": origin}) {
+			t.Errorf("suggestion %d: unexpected data %#v", i, suggestion.Message.Data)
+		}
 		output, _, fixed := linter.ApplyRuleFixes(source, []rule.RuleSuggestion{suggestion})
 		if !fixed || output != "foo.postMessage(message, "+origin+")" {
 			t.Errorf("suggestion %d: unexpected output %q", i, output)

--- a/internal/plugins/unicorn/rules/require_post_message_target_origin/require_post_message_target_origin_extras_test.go
+++ b/internal/plugins/unicorn/rules/require_post_message_target_origin/require_post_message_target_origin_extras_test.go
@@ -1,0 +1,162 @@
+package require_post_message_target_origin_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/microsoft/TypeScript/tsc/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/linter"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/require_post_message_target_origin"
+	lintprogram "github.com/web-infra-dev/rslint/internal/program"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestRequirePostMessageTargetOriginExtras(t *testing.T) {
+	invalid := []rule_tester.InvalidTestCase{
+		invalidCase("(window).postMessage(message)", "file.js", 1, 29, 1, 30,
+			"(window).postMessage(message, window.location.origin)",
+			"(window).postMessage(message, '*')",
+		),
+		invalidCase("(window.postMessage)(message)", "file.js", 1, 29, 1, 30,
+			"(window.postMessage)(message, window.location.origin)",
+			"(window.postMessage)(message, '*')",
+		),
+		invalidCase("window?.child.postMessage(message)", "file.js", 1, 34, 1, 35,
+			"window?.child.postMessage(message, self.location.origin)",
+			"window?.child.postMessage(message, '*')",
+		),
+		invalidCase("(window?.child).postMessage(message)", "file.js", 1, 36, 1, 37,
+			"(window?.child).postMessage(message, self.location.origin)",
+			"(window?.child).postMessage(message, '*')",
+		),
+		invalidCase("window['child'].postMessage(message)", "file.js", 1, 36, 1, 37,
+			"window['child'].postMessage(message, self.location.origin)",
+			"window['child'].postMessage(message, '*')",
+		),
+		invalidCase("(window as Window).postMessage<string>(message)", "file.ts", 1, 47, 1, 48,
+			"(window as Window).postMessage<string>(message, self.location.origin)",
+			"(window as Window).postMessage<string>(message, '*')",
+		),
+		invalidCase("window.postMessage<string>(message)", "file.ts", 1, 35, 1, 36,
+			"window.postMessage<string>(message, window.location.origin)",
+			"window.postMessage<string>(message, '*')",
+		),
+		invalidCase("(/** @type {Window} */ (window)).postMessage(message)", "file.js", 1, 53, 1, 54,
+			"(/** @type {Window} */ (window)).postMessage(message, window.location.origin)",
+			"(/** @type {Window} */ (window)).postMessage(message, '*')",
+		),
+		invalidCase("wind\\u006fw.postMessage(message)", "file.js", 1, 32, 1, 33,
+			"wind\\u006fw.postMessage(message, window.location.origin)",
+			"wind\\u006fw.postMessage(message, '*')",
+		),
+		invalidCase("window.postMessage(\"😀\");", "file.js", 1, 24, 1, 25,
+			"window.postMessage(\"😀\", window.location.origin);",
+			"window.postMessage(\"😀\", '*');",
+		),
+		invalidCase("window.postMessage(\n  message, // keep\n)", "file.js", 2, 11, 3, 2,
+			"window.postMessage(\n  message, // keep\n window.location.origin,)",
+			"window.postMessage(\n  message, // keep\n '*',)",
+		),
+		invalidCase("window.postMessage((message) /* keep */ )", "file.js", 1, 29, 1, 42,
+			"window.postMessage((message) /* keep */ , window.location.origin)",
+			"window.postMessage((message) /* keep */ , '*')",
+		),
+		invalidCase("window.postMessage(/[,)]/)", "file.js", 1, 26, 1, 27,
+			"window.postMessage(/[,)]/, window.location.origin)",
+			"window.postMessage(/[,)]/, '*')",
+		),
+		invalidCase("window.postMessage(`value: ${value}`)", "file.js", 1, 37, 1, 38,
+			"window.postMessage(`value: ${value}`, window.location.origin)",
+			"window.postMessage(`value: ${value}`, '*')",
+		),
+		invalidCase("window.postMessage(<span>{message}</span>)", "file.jsx", 1, 42, 1, 43,
+			"window.postMessage(<span>{message}</span>, window.location.origin)",
+			"window.postMessage(<span>{message}</span>, '*')",
+		),
+		invalidCase("class Sender extends Base { send() { super.postMessage(message); } }", "file.js", 1, 63, 1, 64,
+			"class Sender extends Base { send() { super.postMessage(message, self.location.origin); } }",
+			"class Sender extends Base { send() { super.postMessage(message, '*'); } }",
+		),
+		invalidCase("class Child extends window.postMessage(message) {}", "file.ts", 1, 47, 1, 48,
+			"class Child extends window.postMessage(message, window.location.origin) {}",
+			"class Child extends window.postMessage(message, '*') {}",
+		),
+		invalidCase("new Worker('worker.js').postMessage(message)", "file.js", 1, 44, 1, 45,
+			"new Worker('worker.js').postMessage(message, self.location.origin)",
+			"new Worker('worker.js').postMessage(message, '*')",
+		),
+	}
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t,
+		&require_post_message_target_origin.RequirePostMessageTargetOriginRule,
+		[]rule_tester.ValidTestCase{
+			{Code: "window?.postMessage?.(message)", FileName: "file.js"},
+			{Code: "(window?.postMessage)(message)", FileName: "file.js"},
+			{Code: "window.postMessage(...[message])", FileName: "file.js"},
+			{Code: "new window.postMessage(message)", FileName: "file.js"},
+			{Code: "window['postMessage']?.(message)", FileName: "file.js"},
+			{Code: "class Sender { #postMessage() {} send() { this.#postMessage(message); } }", FileName: "file.js"},
+			{Code: "(window.postMessage as Function)(message)", FileName: "file.ts"},
+			{Code: "window.postMessage!(message)", FileName: "file.ts"},
+			{Code: "window.postMessage(message, undefined)", FileName: "file.js"},
+		}, invalid)
+}
+
+func TestRequirePostMessageTargetOriginEditDemand(t *testing.T) {
+	const source = "foo.postMessage(message)"
+	helper := rule_tester.NewProgramHelper(fixtures.GetRootDir())
+	program, sourceFile, err := helper.CreateTestProgram(source, "edit-demand.js", "tsconfig.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	diagnostics := make(map[rule.EditDemand]rule.RuleDiagnostic, 4)
+	for _, demand := range []rule.EditDemand{rule.EditDemandNone, rule.EditDemandAutofix, rule.EditDemandSuggestion, rule.EditDemandAll} {
+		var got []rule.RuleDiagnostic
+		linter.LintSingleFile(linter.LintSingleFileOptions{
+			Program: lintprogram.NewFromCompiler(program), File: sourceFile.FileName(),
+			GetRulesForFile: func(*ast.SourceFile) []rule.ConfiguredRule {
+				return []rule.ConfiguredRule{{Name: require_post_message_target_origin.RequirePostMessageTargetOriginRule.Name, Severity: rule.SeverityError,
+					Run: func(ctx rule.RuleContext) rule.RuleListeners {
+						return require_post_message_target_origin.RequirePostMessageTargetOriginRule.Run(ctx, nil)
+					},
+				}}
+			},
+			Consumer: rule.DiagnosticConsumer{Demand: demand, Report: func(d rule.RuleDiagnostic) { got = append(got, d) }},
+		})
+		if len(got) != 1 {
+			t.Fatalf("demand %d: got %d diagnostics", demand, len(got))
+		}
+		diagnostics[demand] = got[0]
+		output, _, fixed := linter.ApplyRuleFixes(source, got)
+		if fixed || output != source {
+			t.Fatalf("demand %d: unexpected autofix %q", demand, output)
+		}
+	}
+	base := diagnostics[rule.EditDemandNone]
+	for demand, d := range diagnostics {
+		if d.Range != base.Range || !reflect.DeepEqual(d.Message, base.Message) {
+			t.Errorf("demand %d changed diagnostic identity", demand)
+		}
+		if d.FixesPtr != nil {
+			t.Errorf("demand %d produced an autofix", demand)
+		}
+	}
+	if diagnostics[rule.EditDemandNone].Suggestions != nil || diagnostics[rule.EditDemandAutofix].Suggestions != nil {
+		t.Fatal("suggestions produced without demand")
+	}
+	suggestions := diagnostics[rule.EditDemandAll].Suggestions
+	if suggestions == nil || len(*suggestions) != 3 || !reflect.DeepEqual(suggestions, diagnostics[rule.EditDemandSuggestion].Suggestions) {
+		t.Fatal("inconsistent suggestion artifacts")
+	}
+	for i, origin := range []string{"foo.location.origin", "self.location.origin", "'*'"} {
+		suggestion := (*suggestions)[i]
+		if suggestion.Message.Id != "suggestion" || suggestion.Message.Description != "Use `"+origin+"`." {
+			t.Errorf("suggestion %d: unexpected message %+v", i, suggestion.Message)
+		}
+		output, _, fixed := linter.ApplyRuleFixes(source, []rule.RuleSuggestion{suggestion})
+		if !fixed || output != "foo.postMessage(message, "+origin+")" {
+			t.Errorf("suggestion %d: unexpected output %q", i, output)
+		}
+	}
+}

--- a/internal/plugins/unicorn/rules/require_post_message_target_origin/require_post_message_target_origin_upstream_test.go
+++ b/internal/plugins/unicorn/rules/require_post_message_target_origin/require_post_message_target_origin_upstream_test.go
@@ -1,0 +1,113 @@
+// Upstream tests and documentation from eslint-plugin-unicorn v74.0.0 (MIT).
+// https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/test/require-post-message-target-origin.js
+package require_post_message_target_origin_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/require_post_message_target_origin"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+const message = "Missing the `targetOrigin` argument."
+
+func invalidCase(code, filename string, line, column, endLine, endColumn int, outputs ...string) rule_tester.InvalidTestCase {
+	suggestions := make([]rule_tester.InvalidTestCaseSuggestion, 0, len(outputs))
+	for _, output := range outputs {
+		suggestions = append(suggestions, rule_tester.InvalidTestCaseSuggestion{MessageId: "suggestion", Output: output})
+	}
+	return rule_tester.InvalidTestCase{
+		Code: code, FileName: filename,
+		Errors: []rule_tester.InvalidTestCaseError{{
+			MessageId: "error", Message: message,
+			Line: line, Column: column, EndLine: endLine, EndColumn: endColumn,
+			Suggestions: suggestions,
+		}},
+	}
+}
+
+func TestRequirePostMessageTargetOriginUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t,
+		&require_post_message_target_origin.RequirePostMessageTargetOriginRule,
+		[]rule_tester.ValidTestCase{
+			{Code: "window.postMessage(message, targetOrigin)", FileName: "file.js"},
+			{Code: "postMessage(message)", FileName: "file.js"},
+			{Code: "window.postMessage", FileName: "file.js"},
+			{Code: "window.postMessage()", FileName: "file.js"},
+			{Code: "window.postMessage(message, targetOrigin, transfer)", FileName: "file.js"},
+			{Code: "window.postMessage(...message)", FileName: "file.js"},
+			{Code: "window[postMessage](message)", FileName: "file.js"},
+			{Code: "window[\"postMessage\"](message)", FileName: "file.js"},
+			{Code: "window.notPostMessage(message)", FileName: "file.js"},
+			{Code: "window.postMessage?.(message)", FileName: "file.js"},
+			// Upstream documentation examples.
+			{Code: "window.postMessage(sensitiveData, 'https://trusted-domain.com');", FileName: "file.js"},
+			{Code: "window.postMessage({token: authToken}, 'https://api.example.com');", FileName: "file.js"},
+			{Code: "window.postMessage({publicData: 'hello'}, '*');", FileName: "file.js"},
+			{Code: "iframe.contentWindow.postMessage(data, 'https://expected-iframe-origin.com');", FileName: "file.js"},
+		}, []rule_tester.InvalidTestCase{
+			invalidCase("window.postMessage(message)", "file.js", 1, 27, 1, 28,
+				"window.postMessage(message, window.location.origin)",
+				"window.postMessage(message, '*')",
+			),
+			invalidCase("self.postMessage(message)", "file.js", 1, 25, 1, 26,
+				"self.postMessage(message, self.location.origin)",
+				"self.postMessage(message, '*')",
+			),
+			invalidCase("globalThis.postMessage(message)", "file.js", 1, 31, 1, 32,
+				"globalThis.postMessage(message, globalThis.location.origin)",
+				"globalThis.postMessage(message, '*')",
+			),
+			invalidCase("foo.postMessage(message )", "file.js", 1, 24, 1, 26,
+				"foo.postMessage(message , foo.location.origin)",
+				"foo.postMessage(message , self.location.origin)",
+				"foo.postMessage(message , '*')",
+			),
+			invalidCase("foo?.postMessage(message )", "file.js", 1, 25, 1, 27,
+				"foo?.postMessage(message , foo.location.origin)",
+				"foo?.postMessage(message , self.location.origin)",
+				"foo?.postMessage(message , '*')",
+			),
+			invalidCase("foo.postMessage( ((message)) )", "file.js", 1, 29, 1, 31,
+				"foo.postMessage( ((message)) , foo.location.origin)",
+				"foo.postMessage( ((message)) , self.location.origin)",
+				"foo.postMessage( ((message)) , '*')",
+			),
+			invalidCase("foo.postMessage(message,)", "file.js", 1, 25, 1, 26,
+				"foo.postMessage(message, foo.location.origin,)",
+				"foo.postMessage(message, self.location.origin,)",
+				"foo.postMessage(message, '*',)",
+			),
+			invalidCase("foo.postMessage(message , )", "file.js", 1, 26, 1, 28,
+				"foo.postMessage(message ,  foo.location.origin,)",
+				"foo.postMessage(message ,  self.location.origin,)",
+				"foo.postMessage(message ,  '*',)",
+			),
+			invalidCase("foo.window.postMessage(message)", "file.js", 1, 31, 1, 32,
+				"foo.window.postMessage(message, self.location.origin)",
+				"foo.window.postMessage(message, '*')",
+			),
+			invalidCase("document.defaultView.postMessage(message)", "file.js", 1, 41, 1, 42,
+				"document.defaultView.postMessage(message, self.location.origin)",
+				"document.defaultView.postMessage(message, '*')",
+			),
+			invalidCase("getWindow().postMessage(message)", "file.js", 1, 32, 1, 33,
+				"getWindow().postMessage(message, self.location.origin)",
+				"getWindow().postMessage(message, '*')",
+			),
+			// Upstream documentation examples.
+			invalidCase("window.postMessage(sensitiveData);", "file.js", 1, 33, 1, 34,
+				"window.postMessage(sensitiveData, window.location.origin);",
+				"window.postMessage(sensitiveData, '*');",
+			),
+			invalidCase("window.postMessage({token: authToken});", "file.js", 1, 38, 1, 39,
+				"window.postMessage({token: authToken}, window.location.origin);",
+				"window.postMessage({token: authToken}, '*');",
+			),
+			invalidCase("const iframe = document.querySelector('iframe');\niframe.contentWindow.postMessage(data);", "file.js", 2, 38, 2, 39,
+				"const iframe = document.querySelector('iframe');\niframe.contentWindow.postMessage(data, self.location.origin);",
+				"const iframe = document.querySelector('iframe');\niframe.contentWindow.postMessage(data, '*');",
+			),
+		})
+}

--- a/packages/rslint-test-tools/rstack.config.mts
+++ b/packages/rslint-test-tools/rstack.config.mts
@@ -762,6 +762,7 @@ define.test({
     './tests/eslint-plugin-unicorn/rules/prefer-ternary.test.ts',
     './tests/eslint-plugin-unicorn/rules/require-array-join-separator.test.ts',
     './tests/eslint-plugin-unicorn/rules/require-number-to-fixed-digits-argument.test.ts',
+    './tests/eslint-plugin-unicorn/rules/require-post-message-target-origin.test.ts',
     './tests/eslint-plugin-unicorn/rules/throw-new-error.test.ts',
 
     './tests/eslint/rules/no-shadow-restricted-names.test.ts',

--- a/packages/rslint-test-tools/tests/cli/js-config/presets.test.ts
+++ b/packages/rslint-test-tools/tests/cli/js-config/presets.test.ts
@@ -210,7 +210,10 @@ describe('defineConfig and config presets', () => {
     // Check a positive control and that an explicit setting after the preset
     // can still enable the rule.
     for (const config of [[enabled], [preset, enabled]]) {
-      const result = await lint({ ...options, config });
+      const result = await lint({
+        ...options,
+        config: normalizeConfig(config),
+      });
       expect(result.fileCount).toBe(1);
       expect(result.diagnostics).toHaveLength(1);
       expect(result.diagnostics[0]).toMatchObject({
@@ -219,7 +222,10 @@ describe('defineConfig and config presets', () => {
       });
     }
 
-    const result = await lint({ ...options, config: [enabled, preset] });
+    const result = await lint({
+      ...options,
+      config: normalizeConfig([enabled, preset]),
+    });
     expect(result.fileCount).toBe(1);
     expect(result.diagnostics).toEqual([]);
   });

--- a/packages/rslint-test-tools/tests/cli/js-config/presets.test.ts
+++ b/packages/rslint-test-tools/tests/cli/js-config/presets.test.ts
@@ -1,6 +1,9 @@
+import path from 'node:path';
 import { describe, test, expect } from 'rstack/test';
 import { normalizeConfig } from '@rslint/core/config-loader';
+import { lint } from '@rslint/core/internal';
 import {
+  type RslintConfigEntry,
   defineConfig,
   globals,
   ts,
@@ -182,5 +185,42 @@ describe('defineConfig and config presets', () => {
     expect(rec.rules?.['unicorn/no-exports-in-scripts']).toBe('error');
     expect(rec.rules?.['unicorn/no-await-expression-member']).toBe('error');
     expect(rec.rules?.['unicorn/prefer-date-now']).toBe('error');
+    expect(rec.rules?.['unicorn/require-post-message-target-origin']).toBe(
+      'off',
+    );
+  });
+
+  test('unicornPlugin.configs.recommended disables an earlier require-post-message-target-origin setting', async () => {
+    const ruleName = 'unicorn/require-post-message-target-origin';
+    const enabled: RslintConfigEntry = {
+      plugins: ['unicorn'],
+      rules: { [ruleName]: 'error' },
+    };
+    const preset = unicornPlugin.configs.recommended;
+    const directory = import.meta.dirname;
+    const options = {
+      configDirectory: directory,
+      workingDirectory: directory,
+      fileContents: {
+        [path.join(directory, 'post-message-preset.js')]:
+          'window.postMessage(message);',
+      },
+    };
+
+    // Check a positive control and that an explicit setting after the preset
+    // can still enable the rule.
+    for (const config of [[enabled], [preset, enabled]]) {
+      const result = await lint({ ...options, config });
+      expect(result.fileCount).toBe(1);
+      expect(result.diagnostics).toHaveLength(1);
+      expect(result.diagnostics[0]).toMatchObject({
+        ruleName,
+        messageId: 'error',
+      });
+    }
+
+    const result = await lint({ ...options, config: [enabled, preset] });
+    expect(result.fileCount).toBe(1);
+    expect(result.diagnostics).toEqual([]);
   });
 });

--- a/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/require-post-message-target-origin.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/require-post-message-target-origin.test.ts
@@ -31,11 +31,13 @@ const cases = {
         {
           messageId: 'suggestion',
           message: 'Use `window.location.origin`.',
+          data: { code: 'window.location.origin' },
           output: 'window.postMessage(message, window.location.origin)',
         },
         {
           messageId: 'suggestion',
           message: "Use `'*'`.",
+          data: { code: "'*'" },
           output: "window.postMessage(message, '*')",
         },
       ],
@@ -50,11 +52,13 @@ const cases = {
         {
           messageId: 'suggestion',
           message: 'Use `self.location.origin`.',
+          data: { code: 'self.location.origin' },
           output: 'self.postMessage(message, self.location.origin)',
         },
         {
           messageId: 'suggestion',
           message: "Use `'*'`.",
+          data: { code: "'*'" },
           output: "self.postMessage(message, '*')",
         },
       ],
@@ -69,11 +73,13 @@ const cases = {
         {
           messageId: 'suggestion',
           message: 'Use `globalThis.location.origin`.',
+          data: { code: 'globalThis.location.origin' },
           output: 'globalThis.postMessage(message, globalThis.location.origin)',
         },
         {
           messageId: 'suggestion',
           message: "Use `'*'`.",
+          data: { code: "'*'" },
           output: "globalThis.postMessage(message, '*')",
         },
       ],
@@ -88,16 +94,19 @@ const cases = {
         {
           messageId: 'suggestion',
           message: 'Use `foo.location.origin`.',
+          data: { code: 'foo.location.origin' },
           output: 'foo.postMessage(message , foo.location.origin)',
         },
         {
           messageId: 'suggestion',
           message: 'Use `self.location.origin`.',
+          data: { code: 'self.location.origin' },
           output: 'foo.postMessage(message , self.location.origin)',
         },
         {
           messageId: 'suggestion',
           message: "Use `'*'`.",
+          data: { code: "'*'" },
           output: "foo.postMessage(message , '*')",
         },
       ],
@@ -112,16 +121,19 @@ const cases = {
         {
           messageId: 'suggestion',
           message: 'Use `foo.location.origin`.',
+          data: { code: 'foo.location.origin' },
           output: 'foo?.postMessage(message , foo.location.origin)',
         },
         {
           messageId: 'suggestion',
           message: 'Use `self.location.origin`.',
+          data: { code: 'self.location.origin' },
           output: 'foo?.postMessage(message , self.location.origin)',
         },
         {
           messageId: 'suggestion',
           message: "Use `'*'`.",
+          data: { code: "'*'" },
           output: "foo?.postMessage(message , '*')",
         },
       ],
@@ -136,16 +148,19 @@ const cases = {
         {
           messageId: 'suggestion',
           message: 'Use `foo.location.origin`.',
+          data: { code: 'foo.location.origin' },
           output: 'foo.postMessage( ((message)) , foo.location.origin)',
         },
         {
           messageId: 'suggestion',
           message: 'Use `self.location.origin`.',
+          data: { code: 'self.location.origin' },
           output: 'foo.postMessage( ((message)) , self.location.origin)',
         },
         {
           messageId: 'suggestion',
           message: "Use `'*'`.",
+          data: { code: "'*'" },
           output: "foo.postMessage( ((message)) , '*')",
         },
       ],
@@ -160,16 +175,19 @@ const cases = {
         {
           messageId: 'suggestion',
           message: 'Use `foo.location.origin`.',
+          data: { code: 'foo.location.origin' },
           output: 'foo.postMessage(message, foo.location.origin,)',
         },
         {
           messageId: 'suggestion',
           message: 'Use `self.location.origin`.',
+          data: { code: 'self.location.origin' },
           output: 'foo.postMessage(message, self.location.origin,)',
         },
         {
           messageId: 'suggestion',
           message: "Use `'*'`.",
+          data: { code: "'*'" },
           output: "foo.postMessage(message, '*',)",
         },
       ],
@@ -184,16 +202,19 @@ const cases = {
         {
           messageId: 'suggestion',
           message: 'Use `foo.location.origin`.',
+          data: { code: 'foo.location.origin' },
           output: 'foo.postMessage(message ,  foo.location.origin,)',
         },
         {
           messageId: 'suggestion',
           message: 'Use `self.location.origin`.',
+          data: { code: 'self.location.origin' },
           output: 'foo.postMessage(message ,  self.location.origin,)',
         },
         {
           messageId: 'suggestion',
           message: "Use `'*'`.",
+          data: { code: "'*'" },
           output: "foo.postMessage(message ,  '*',)",
         },
       ],
@@ -208,11 +229,13 @@ const cases = {
         {
           messageId: 'suggestion',
           message: 'Use `self.location.origin`.',
+          data: { code: 'self.location.origin' },
           output: 'foo.window.postMessage(message, self.location.origin)',
         },
         {
           messageId: 'suggestion',
           message: "Use `'*'`.",
+          data: { code: "'*'" },
           output: "foo.window.postMessage(message, '*')",
         },
       ],
@@ -227,12 +250,14 @@ const cases = {
         {
           messageId: 'suggestion',
           message: 'Use `self.location.origin`.',
+          data: { code: 'self.location.origin' },
           output:
             'document.defaultView.postMessage(message, self.location.origin)',
         },
         {
           messageId: 'suggestion',
           message: "Use `'*'`.",
+          data: { code: "'*'" },
           output: "document.defaultView.postMessage(message, '*')",
         },
       ],
@@ -247,11 +272,13 @@ const cases = {
         {
           messageId: 'suggestion',
           message: 'Use `self.location.origin`.',
+          data: { code: 'self.location.origin' },
           output: 'getWindow().postMessage(message, self.location.origin)',
         },
         {
           messageId: 'suggestion',
           message: "Use `'*'`.",
+          data: { code: "'*'" },
           output: "getWindow().postMessage(message, '*')",
         },
       ],
@@ -266,11 +293,13 @@ const cases = {
         {
           messageId: 'suggestion',
           message: 'Use `window.location.origin`.',
+          data: { code: 'window.location.origin' },
           output: 'window.postMessage(sensitiveData, window.location.origin);',
         },
         {
           messageId: 'suggestion',
           message: "Use `'*'`.",
+          data: { code: "'*'" },
           output: "window.postMessage(sensitiveData, '*');",
         },
       ],
@@ -285,12 +314,14 @@ const cases = {
         {
           messageId: 'suggestion',
           message: 'Use `window.location.origin`.',
+          data: { code: 'window.location.origin' },
           output:
             'window.postMessage({token: authToken}, window.location.origin);',
         },
         {
           messageId: 'suggestion',
           message: "Use `'*'`.",
+          data: { code: "'*'" },
           output: "window.postMessage({token: authToken}, '*');",
         },
       ],
@@ -305,12 +336,14 @@ const cases = {
         {
           messageId: 'suggestion',
           message: 'Use `self.location.origin`.',
+          data: { code: 'self.location.origin' },
           output:
             "const iframe = document.querySelector('iframe');\niframe.contentWindow.postMessage(data, self.location.origin);",
         },
         {
           messageId: 'suggestion',
           message: "Use `'*'`.",
+          data: { code: "'*'" },
           output:
             "const iframe = document.querySelector('iframe');\niframe.contentWindow.postMessage(data, '*');",
         },
@@ -362,6 +395,7 @@ describe(ruleName, () => {
         const suggestion = suggestions[index];
         expect(suggestion.messageId).toBe(expected.messageId);
         expect(suggestion.message).toBe(expected.message);
+        expect(suggestion.data).toEqual(expected.data);
         expect(suggestion.fixes).toHaveLength(1);
         const [edit] = suggestion.fixes ?? [];
         const output =

--- a/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/require-post-message-target-origin.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/require-post-message-target-origin.test.ts
@@ -1,0 +1,376 @@
+// Upstream tests and documentation from eslint-plugin-unicorn v74.0.0 (MIT).
+// https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/test/require-post-message-target-origin.js
+import path from 'node:path';
+import { lint } from '@rslint/core/internal';
+
+const cases = {
+  valid: [
+    'window.postMessage(message, targetOrigin)',
+    'postMessage(message)',
+    'window.postMessage',
+    'window.postMessage()',
+    'window.postMessage(message, targetOrigin, transfer)',
+    'window.postMessage(...message)',
+    'window[postMessage](message)',
+    'window["postMessage"](message)',
+    'window.notPostMessage(message)',
+    'window.postMessage?.(message)',
+    "window.postMessage(sensitiveData, 'https://trusted-domain.com');",
+    "window.postMessage({token: authToken}, 'https://api.example.com');",
+    "window.postMessage({publicData: 'hello'}, '*');",
+    "iframe.contentWindow.postMessage(data, 'https://expected-iframe-origin.com');",
+  ],
+  invalid: [
+    {
+      code: 'window.postMessage(message)',
+      column: 27,
+      line: 1,
+      endLine: 1,
+      endColumn: 28,
+      suggestions: [
+        {
+          messageId: 'suggestion',
+          message: 'Use `window.location.origin`.',
+          output: 'window.postMessage(message, window.location.origin)',
+        },
+        {
+          messageId: 'suggestion',
+          message: "Use `'*'`.",
+          output: "window.postMessage(message, '*')",
+        },
+      ],
+    },
+    {
+      code: 'self.postMessage(message)',
+      column: 25,
+      line: 1,
+      endLine: 1,
+      endColumn: 26,
+      suggestions: [
+        {
+          messageId: 'suggestion',
+          message: 'Use `self.location.origin`.',
+          output: 'self.postMessage(message, self.location.origin)',
+        },
+        {
+          messageId: 'suggestion',
+          message: "Use `'*'`.",
+          output: "self.postMessage(message, '*')",
+        },
+      ],
+    },
+    {
+      code: 'globalThis.postMessage(message)',
+      column: 31,
+      line: 1,
+      endLine: 1,
+      endColumn: 32,
+      suggestions: [
+        {
+          messageId: 'suggestion',
+          message: 'Use `globalThis.location.origin`.',
+          output: 'globalThis.postMessage(message, globalThis.location.origin)',
+        },
+        {
+          messageId: 'suggestion',
+          message: "Use `'*'`.",
+          output: "globalThis.postMessage(message, '*')",
+        },
+      ],
+    },
+    {
+      code: 'foo.postMessage(message )',
+      column: 24,
+      line: 1,
+      endLine: 1,
+      endColumn: 26,
+      suggestions: [
+        {
+          messageId: 'suggestion',
+          message: 'Use `foo.location.origin`.',
+          output: 'foo.postMessage(message , foo.location.origin)',
+        },
+        {
+          messageId: 'suggestion',
+          message: 'Use `self.location.origin`.',
+          output: 'foo.postMessage(message , self.location.origin)',
+        },
+        {
+          messageId: 'suggestion',
+          message: "Use `'*'`.",
+          output: "foo.postMessage(message , '*')",
+        },
+      ],
+    },
+    {
+      code: 'foo?.postMessage(message )',
+      column: 25,
+      line: 1,
+      endLine: 1,
+      endColumn: 27,
+      suggestions: [
+        {
+          messageId: 'suggestion',
+          message: 'Use `foo.location.origin`.',
+          output: 'foo?.postMessage(message , foo.location.origin)',
+        },
+        {
+          messageId: 'suggestion',
+          message: 'Use `self.location.origin`.',
+          output: 'foo?.postMessage(message , self.location.origin)',
+        },
+        {
+          messageId: 'suggestion',
+          message: "Use `'*'`.",
+          output: "foo?.postMessage(message , '*')",
+        },
+      ],
+    },
+    {
+      code: 'foo.postMessage( ((message)) )',
+      column: 29,
+      line: 1,
+      endLine: 1,
+      endColumn: 31,
+      suggestions: [
+        {
+          messageId: 'suggestion',
+          message: 'Use `foo.location.origin`.',
+          output: 'foo.postMessage( ((message)) , foo.location.origin)',
+        },
+        {
+          messageId: 'suggestion',
+          message: 'Use `self.location.origin`.',
+          output: 'foo.postMessage( ((message)) , self.location.origin)',
+        },
+        {
+          messageId: 'suggestion',
+          message: "Use `'*'`.",
+          output: "foo.postMessage( ((message)) , '*')",
+        },
+      ],
+    },
+    {
+      code: 'foo.postMessage(message,)',
+      column: 25,
+      line: 1,
+      endLine: 1,
+      endColumn: 26,
+      suggestions: [
+        {
+          messageId: 'suggestion',
+          message: 'Use `foo.location.origin`.',
+          output: 'foo.postMessage(message, foo.location.origin,)',
+        },
+        {
+          messageId: 'suggestion',
+          message: 'Use `self.location.origin`.',
+          output: 'foo.postMessage(message, self.location.origin,)',
+        },
+        {
+          messageId: 'suggestion',
+          message: "Use `'*'`.",
+          output: "foo.postMessage(message, '*',)",
+        },
+      ],
+    },
+    {
+      code: 'foo.postMessage(message , )',
+      column: 26,
+      line: 1,
+      endLine: 1,
+      endColumn: 28,
+      suggestions: [
+        {
+          messageId: 'suggestion',
+          message: 'Use `foo.location.origin`.',
+          output: 'foo.postMessage(message ,  foo.location.origin,)',
+        },
+        {
+          messageId: 'suggestion',
+          message: 'Use `self.location.origin`.',
+          output: 'foo.postMessage(message ,  self.location.origin,)',
+        },
+        {
+          messageId: 'suggestion',
+          message: "Use `'*'`.",
+          output: "foo.postMessage(message ,  '*',)",
+        },
+      ],
+    },
+    {
+      code: 'foo.window.postMessage(message)',
+      column: 31,
+      line: 1,
+      endLine: 1,
+      endColumn: 32,
+      suggestions: [
+        {
+          messageId: 'suggestion',
+          message: 'Use `self.location.origin`.',
+          output: 'foo.window.postMessage(message, self.location.origin)',
+        },
+        {
+          messageId: 'suggestion',
+          message: "Use `'*'`.",
+          output: "foo.window.postMessage(message, '*')",
+        },
+      ],
+    },
+    {
+      code: 'document.defaultView.postMessage(message)',
+      column: 41,
+      line: 1,
+      endLine: 1,
+      endColumn: 42,
+      suggestions: [
+        {
+          messageId: 'suggestion',
+          message: 'Use `self.location.origin`.',
+          output:
+            'document.defaultView.postMessage(message, self.location.origin)',
+        },
+        {
+          messageId: 'suggestion',
+          message: "Use `'*'`.",
+          output: "document.defaultView.postMessage(message, '*')",
+        },
+      ],
+    },
+    {
+      code: 'getWindow().postMessage(message)',
+      column: 32,
+      line: 1,
+      endLine: 1,
+      endColumn: 33,
+      suggestions: [
+        {
+          messageId: 'suggestion',
+          message: 'Use `self.location.origin`.',
+          output: 'getWindow().postMessage(message, self.location.origin)',
+        },
+        {
+          messageId: 'suggestion',
+          message: "Use `'*'`.",
+          output: "getWindow().postMessage(message, '*')",
+        },
+      ],
+    },
+    {
+      code: 'window.postMessage(sensitiveData);',
+      column: 33,
+      line: 1,
+      endLine: 1,
+      endColumn: 34,
+      suggestions: [
+        {
+          messageId: 'suggestion',
+          message: 'Use `window.location.origin`.',
+          output: 'window.postMessage(sensitiveData, window.location.origin);',
+        },
+        {
+          messageId: 'suggestion',
+          message: "Use `'*'`.",
+          output: "window.postMessage(sensitiveData, '*');",
+        },
+      ],
+    },
+    {
+      code: 'window.postMessage({token: authToken});',
+      column: 38,
+      line: 1,
+      endLine: 1,
+      endColumn: 39,
+      suggestions: [
+        {
+          messageId: 'suggestion',
+          message: 'Use `window.location.origin`.',
+          output:
+            'window.postMessage({token: authToken}, window.location.origin);',
+        },
+        {
+          messageId: 'suggestion',
+          message: "Use `'*'`.",
+          output: "window.postMessage({token: authToken}, '*');",
+        },
+      ],
+    },
+    {
+      code: "const iframe = document.querySelector('iframe');\niframe.contentWindow.postMessage(data);",
+      column: 38,
+      line: 2,
+      endLine: 2,
+      endColumn: 39,
+      suggestions: [
+        {
+          messageId: 'suggestion',
+          message: 'Use `self.location.origin`.',
+          output:
+            "const iframe = document.querySelector('iframe');\niframe.contentWindow.postMessage(data, self.location.origin);",
+        },
+        {
+          messageId: 'suggestion',
+          message: "Use `'*'`.",
+          output:
+            "const iframe = document.querySelector('iframe');\niframe.contentWindow.postMessage(data, '*');",
+        },
+      ],
+    },
+  ],
+};
+
+const directory = path.resolve(import.meta.dirname, '..');
+const filename = path.join(directory, 'src/virtual.js');
+const ruleName = 'unicorn/require-post-message-target-origin';
+const run = (code: string, fix = false) =>
+  lint({
+    config: [{ plugins: ['unicorn'], rules: { [ruleName]: 'error' } }],
+    configDirectory: directory,
+    workingDirectory: directory,
+    fileContents: { [filename]: code },
+    fix,
+  });
+
+describe(ruleName, () => {
+  test('upstream valid cases and documentation', async () => {
+    for (const code of cases.valid) {
+      const result = await run(code);
+      expect(result.fileCount).toBe(1);
+      expect(result.diagnostics).toEqual([]);
+    }
+  });
+  test('upstream diagnostics and suggestions', async () => {
+    for (const item of cases.invalid) {
+      const result = await run(item.code);
+      expect(result.fileCount).toBe(1);
+      expect(result.diagnostics).toHaveLength(1);
+      const [diagnostic] = result.diagnostics;
+      expect(diagnostic.ruleName).toBe(ruleName);
+      expect(diagnostic.messageId).toBe('error');
+      expect(diagnostic.message).toBe('Missing the `targetOrigin` argument.');
+      expect(diagnostic.range).toEqual({
+        start: { line: item.line, column: item.column },
+        end: { line: item.endLine, column: item.endColumn },
+      });
+      expect(diagnostic.fixes ?? []).toEqual([]);
+      const autofix = await run(item.code, true);
+      expect(autofix.output ?? {}).toEqual({});
+      expect(autofix.fixableErrorCount).toBe(0);
+      const suggestions = diagnostic.suggestions ?? [];
+      expect(suggestions).toHaveLength(item.suggestions.length);
+      for (const [index, expected] of item.suggestions.entries()) {
+        const suggestion = suggestions[index];
+        expect(suggestion.messageId).toBe(expected.messageId);
+        expect(suggestion.message).toBe(expected.message);
+        expect(suggestion.fixes).toHaveLength(1);
+        const [edit] = suggestion.fixes ?? [];
+        const output =
+          item.code.slice(0, edit.startPos) +
+          edit.text +
+          item.code.slice(edit.endPos);
+        expect(output).toBe(expected.output);
+        expect((await run(output)).diagnostics).toEqual([]);
+      }
+    }
+  });
+});

--- a/packages/rslint/src/config/presets/unicorn.ts
+++ b/packages/rslint/src/config/presets/unicorn.ts
@@ -344,7 +344,7 @@ const recommended: RslintConfigEntry = {
     // 'unicorn/require-module-specifiers': 'error', // not implemented
     'unicorn/require-number-to-fixed-digits-argument': 'error',
     // 'unicorn/require-passive-events': 'error', // not implemented
-    // 'unicorn/require-post-message-target-origin': 'off', // not implemented
+    'unicorn/require-post-message-target-origin': 'off',
     // 'unicorn/require-proxy-trap-boolean-return': 'error', // not implemented
     // 'unicorn/single-line-block-comment-style': 'error', // not implemented
     // 'unicorn/string-content': 'off', // not implemented


### PR DESCRIPTION
## Summary

Port `unicorn/require-post-message-target-origin` from eslint-plugin-unicorn v74.0.0.

The rule reports `.postMessage()` calls missing a `targetOrigin` argument and provides editor suggestions without automatic fixes.

- Preserve upstream matching behavior, diagnostic ranges, structured suggestion data, and suggestion order.
- Preserve comments, parentheses, and trailing commas when inserting suggested arguments.
- Register the rule in the native Unicorn catalog and explicitly disable it in the recommended preset, matching upstream.
- Migrate the complete upstream test suite and documentation examples.
- Add Go coverage for TypeScript, JSX, optional chains, Unicode, and edit-demand modes.
- Add JS integration tests that verify diagnostic ranges, suggestion data, messages and outputs, and the absence of automatic fixes.

Like upstream, the rule cannot distinguish window messaging from other APIs such as `Worker#postMessage()`. This limitation is documented. The rule has no options. Place explicit rule configuration after the recommended preset to enable it.

## Related Links

- Tracking issue: #1309
- [Upstream documentation](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/docs/rules/require-post-message-target-origin.md)
- [Upstream source](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/rules/require-post-message-target-origin.js)
- [Upstream tests](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/test/require-post-message-target-origin.js)

## Validation

- Go upstream, edge-case, edit-demand, and rule catalog tests passed.
- JS rule integration and targeted Unicorn preset tests passed.
- Core native and JS builds passed, including schema and public rule-option type generation.
- Scoped formatting and spelling checks, repository `pnpm run format:check`, and `git diff --check` passed.

Verification used reduced concurrency. No full-repository or whole-plugin test suites were run.

## Checklist

- [x] Tests updated.
- [x] Documentation updated.
