### PR TITLE
feat(react): add iframe-missing-sandbox rule

### DIFF
--- a/internal/plugins/react/all.go
+++ b/internal/plugins/react/all.go
@@ -14,6 +14,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/forward_ref_uses_ref"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/function_component_definition"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/hook_use_state"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/iframe_missing_sandbox"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_boolean_value"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_closing_bracket_location"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_closing_tag_location"
@@ -109,6 +110,7 @@ func GetAllRules() []rule.Rule {
 		forward_ref_uses_ref.ForwardRefUsesRefRule,
 		function_component_definition.FunctionComponentDefinitionRule,
 		hook_use_state.HookUseStateRule,
+		iframe_missing_sandbox.IframeMissingSandboxRule,
 		jsx_boolean_value.JsxBooleanValueRule,
 		jsx_closing_bracket_location.JsxClosingBracketLocationRule,
 		jsx_closing_tag_location.JsxClosingTagLocationRule,

--- a/internal/plugins/react/reactutil/jsx.go
+++ b/internal/plugins/react/reactutil/jsx.go
@@ -1,6 +1,34 @@
 package reactutil
 
-import "github.com/microsoft/TypeScript/tsc/shim/ast"
+import (
+	"github.com/microsoft/TypeScript/tsc/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/utils"
+	"github.com/web-infra-dev/rslint/internal/utils/ecmascript"
+)
+
+// GetJsxStringLiteralValue returns a direct JSX attribute string literal as
+// an ESTree parser exposes it. JSX parsers decode HTML character references in
+// direct attributes, but tsgo retains them in StringLiteral.Text; reading the
+// raw token restores the ESTree value. Expressions inside `{...}` must not use
+// this helper because they are JavaScript strings, not JSX text.
+//
+// When sourceFile is unavailable, the tsgo string text is returned as a safe
+// fallback. The bool is false for every non-StringLiteral input.
+func GetJsxStringLiteralValue(sourceFile *ast.SourceFile, value *ast.Node) (string, bool) {
+	if value == nil || value.Kind != ast.KindStringLiteral {
+		return "", false
+	}
+	text := value.AsStringLiteral().Text
+	if sourceFile == nil {
+		return text, true
+	}
+	rawRange := utils.TrimNodeTextRange(sourceFile, value)
+	raw := sourceFile.Text()[rawRange.Pos():rawRange.End()]
+	if len(raw) >= 2 && ((raw[0] == '"' && raw[len(raw)-1] == '"') || (raw[0] == '\'' && raw[len(raw)-1] == '\'')) {
+		return ecmascript.DecodeJSXEntities(raw[1 : len(raw)-1]), true
+	}
+	return text, true
+}
 
 // GetJsxTagBaseIdentifier returns the leftmost Identifier of a JSX tag-name
 // node — i.e. the symbol a rule must resolve to classify the tag. Pass the

--- a/internal/plugins/react/reactutil/jsx_test.go
+++ b/internal/plugins/react/reactutil/jsx_test.go
@@ -1,0 +1,45 @@
+package reactutil
+
+import (
+	"testing"
+
+	"github.com/microsoft/TypeScript/tsc/shim/ast"
+	"github.com/microsoft/TypeScript/tsc/shim/core"
+	"github.com/microsoft/TypeScript/tsc/shim/parser"
+)
+
+func TestGetJsxStringLiteralValue(t *testing.T) {
+	t.Parallel()
+	for _, testCase := range []struct {
+		name, code, want string
+	}{
+		{name: "entity forms token", code: `<iframe sandbox="allow&#x2D;forms" />`, want: "allow-forms"},
+		{name: "entity forms delimiter", code: `<iframe sandbox="allow-forms&#x20;allow-modals" />`, want: "allow-forms allow-modals"},
+		{name: "plain string", code: `<iframe sandbox="allow-popups" />`, want: "allow-popups"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			sourceFile := parser.ParseSourceFile(
+				ast.SourceFileParseOptions{FileName: "/component.tsx", Path: "/component.tsx"},
+				testCase.code,
+				core.ScriptKindTSX,
+			)
+			var initializer *ast.Node
+			var visit func(*ast.Node) bool
+			visit = func(node *ast.Node) bool {
+				if node.Kind == ast.KindJsxAttribute && GetJsxPropName(node) == "sandbox" {
+					initializer = node.AsJsxAttribute().Initializer
+					return true
+				}
+				node.ForEachChild(visit)
+				return false
+			}
+			visit(sourceFile.AsNode())
+
+			got, ok := GetJsxStringLiteralValue(sourceFile, initializer)
+			if !ok || got != testCase.want {
+				t.Fatalf("GetJsxStringLiteralValue() = %q, %v; want %q, true", got, ok, testCase.want)
+			}
+		})
+	}
+}

--- a/internal/plugins/react/rules/iframe_missing_sandbox/iframe_missing_sandbox.go
+++ b/internal/plugins/react/rules/iframe_missing_sandbox/iframe_missing_sandbox.go
@@ -1,0 +1,186 @@
+package iframe_missing_sandbox
+
+import (
+	"strings"
+
+	"github.com/microsoft/TypeScript/tsc/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils/ecmascript"
+)
+
+const (
+	msgAttributeMissing   = "An iframe element is missing a sandbox attribute"
+	msgInvalidValue       = "An iframe element defines a sandbox attribute with invalid value \"{{ value }}\""
+	msgInvalidCombination = "An iframe element defines a sandbox attribute with both allow-scripts and allow-same-origin which is invalid"
+)
+
+// allowedValues is the sandbox token list used by eslint-plugin-react v7.37.5.
+// Empty tokens are intentional: splitting a string literal on a space produces
+// them for leading, trailing, and repeated spaces, and upstream accepts them.
+var allowedValues = map[string]struct{}{
+	"": {},
+	"allow-downloads-without-user-activation": {},
+	"allow-downloads":                         {},
+	"allow-forms":                             {},
+	"allow-modals":                            {},
+	"allow-orientation-lock":                  {},
+	"allow-pointer-lock":                      {},
+	"allow-popups":                            {},
+	"allow-popups-to-escape-sandbox":          {},
+	"allow-presentation":                      {},
+	"allow-same-origin":                       {},
+	"allow-scripts":                           {},
+	"allow-storage-access-by-user-activation": {},
+	"allow-top-navigation":                    {},
+	"allow-top-navigation-by-user-activation": {},
+}
+
+func message(id, description string) rule.RuleMessage {
+	return rule.RuleMessage{Id: id, Description: description}
+}
+
+// validateSandboxValue mirrors upstream's string-literal-only validation.
+// In particular, JSX expression containers and non-string object values are
+// dynamic and therefore accepted without attempting static evaluation.
+func validateSandboxValue(ctx rule.RuleContext, node *ast.Node, value string) {
+	allowScripts := false
+	allowSameOrigin := false
+	for _, token := range strings.Split(value, " ") {
+		token = ecmascript.StringTrim(token)
+		if _, ok := allowedValues[token]; !ok {
+			ctx.ReportNode(node, rule.RuleMessage{
+				Id:          "invalidValue",
+				Description: strings.ReplaceAll(msgInvalidValue, "{{ value }}", token),
+				Data:        map[string]string{"value": token},
+			})
+		}
+		if token == "allow-scripts" {
+			allowScripts = true
+		}
+		if token == "allow-same-origin" {
+			allowSameOrigin = true
+		}
+	}
+	if allowScripts && allowSameOrigin {
+		ctx.ReportNode(node, message("invalidCombination", msgInvalidCombination))
+	}
+}
+
+// objectSandboxProperty returns the first object member that upstream sees as
+// `x.type === 'Property' && x.key.name === 'sandbox'`. Identifier keys and
+// computed identifier keys have a `name` in ESTree; quoted keys do not.
+func objectSandboxProperty(member *ast.Node) (value *ast.Node, found bool) {
+	if member == nil {
+		return nil, false
+	}
+	var name *ast.Node
+	switch member.Kind {
+	case ast.KindPropertyAssignment:
+		property := member.AsPropertyAssignment()
+		name = property.Name()
+		if !sandboxName(name) {
+			return nil, false
+		}
+		return property.Initializer, true
+	case ast.KindShorthandPropertyAssignment:
+		name = member.AsShorthandPropertyAssignment().Name()
+	case ast.KindMethodDeclaration:
+		name = member.AsMethodDeclaration().Name()
+	case ast.KindGetAccessor:
+		name = member.AsGetAccessorDeclaration().Name()
+	case ast.KindSetAccessor:
+		name = member.AsSetAccessorDeclaration().Name()
+	default:
+		return nil, false
+	}
+	if !sandboxName(name) {
+		return nil, false
+	}
+	// Shorthand properties and function-like members are never Literal values
+	// in ESTree, so they mark the prop as found without value validation.
+	return nil, true
+}
+
+func sandboxName(name *ast.Node) bool {
+	if name == nil {
+		return false
+	}
+	if name.Kind == ast.KindIdentifier {
+		return name.AsIdentifier().Text == "sandbox"
+	}
+	if name.Kind != ast.KindComputedPropertyName {
+		return false
+	}
+	expression := name.AsComputedPropertyName().Expression
+	return expression != nil && expression.Kind == ast.KindIdentifier && expression.AsIdentifier().Text == "sandbox"
+}
+
+var IframeMissingSandboxRule = rule.Rule{
+	Name:   "react/iframe-missing-sandbox",
+	Schema: rule.EmptyArraySchema,
+	Run: func(ctx rule.RuleContext, _ []any) rule.RuleListeners {
+		checkJSX := func(node *ast.Node) {
+			if reactutil.GetJsxElementTypeString(node) != "iframe" {
+				return
+			}
+			found := false
+			for _, attribute := range reactutil.GetJsxElementAttributes(node) {
+				if attribute.Kind != ast.KindJsxAttribute || reactutil.GetJsxPropName(attribute) != "sandbox" {
+					continue
+				}
+				found = true
+				initializer := attribute.AsJsxAttribute().Initializer
+				if initializer != nil && initializer.Kind == ast.KindStringLiteral {
+					value, ok := reactutil.GetJsxStringLiteralValue(ctx.SourceFile, initializer)
+					if ok && value != "" {
+						validateSandboxValue(ctx, node, value)
+					}
+				}
+			}
+			if !found {
+				ctx.ReportNode(node, message("attributeMissing", msgAttributeMissing))
+			}
+		}
+
+		isCreateElement := reactutil.NewCreateElementCallMatcher(ctx)
+		return rule.RuleListeners{
+			ast.KindJsxOpeningElement:     checkJSX,
+			ast.KindJsxSelfClosingElement: checkJSX,
+			ast.KindCallExpression: func(node *ast.Node) {
+				call := node.AsCallExpression()
+				if !isCreateElement(call.Expression) || call.Arguments == nil || len(call.Arguments.Nodes) == 0 {
+					return
+				}
+				tag := ast.SkipParentheses(call.Arguments.Nodes[0])
+				if tag == nil || tag.Kind != ast.KindStringLiteral || tag.AsStringLiteral().Text != "iframe" {
+					return
+				}
+				found := false
+				if len(call.Arguments.Nodes) > 1 {
+					props := ast.SkipParentheses(call.Arguments.Nodes[1])
+					if props != nil && props.Kind == ast.KindObjectLiteralExpression {
+						for _, member := range props.AsObjectLiteralExpression().Properties.Nodes {
+							value, hasSandbox := objectSandboxProperty(member)
+							if !hasSandbox {
+								continue
+							}
+							found = true
+							value = ast.SkipParentheses(value)
+							if value != nil && value.Kind == ast.KindStringLiteral {
+								text := value.AsStringLiteral().Text
+								if text != "" {
+									validateSandboxValue(ctx, node, text)
+								}
+							}
+							break
+						}
+					}
+				}
+				if !found {
+					ctx.ReportNode(node, message("attributeMissing", msgAttributeMissing))
+				}
+			},
+		}
+	},
+}

--- a/internal/plugins/react/rules/iframe_missing_sandbox/iframe_missing_sandbox.md
+++ b/internal/plugins/react/rules/iframe_missing_sandbox/iframe_missing_sandbox.md
@@ -1,0 +1,37 @@
+# iframe-missing-sandbox
+
+Require a `sandbox` attribute on `iframe` elements.
+
+The `sandbox` attribute adds restrictions to the document inside an iframe. This rule also validates statically known sandbox tokens and rejects the unsafe combination of `allow-scripts` and `allow-same-origin`, which permits the embedded document to remove its sandbox.
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+<iframe />
+<iframe sandbox="not-a-sandbox-token" />
+<iframe sandbox="allow-scripts allow-same-origin" />
+React.createElement('iframe')
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+<iframe sandbox="allow-popups" />
+React.createElement('iframe', { sandbox: 'allow-forms' })
+```
+
+Dynamic sandbox values are permitted because they cannot be evaluated statically:
+
+```jsx
+<iframe sandbox={sandboxValue} />
+React.createElement('iframe', { sandbox: sandboxValue })
+```
+
+## Rule Options
+
+This rule has no options.
+
+## Original Documentation
+
+- [eslint-plugin-react: iframe-missing-sandbox](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/iframe-missing-sandbox.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/iframe-missing-sandbox.js)

--- a/internal/plugins/react/rules/iframe_missing_sandbox/iframe_missing_sandbox_extras_test.go
+++ b/internal/plugins/react/rules/iframe_missing_sandbox/iframe_missing_sandbox_extras_test.go
@@ -1,0 +1,57 @@
+package iframe_missing_sandbox
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestIframeMissingSandboxExtras(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &IframeMissingSandboxRule, []rule_tester.ValidTestCase{
+		// Tokens supported upstream but not exercised by its v7.37.5 suite.
+		{Code: `<iframe sandbox="allow-downloads allow-downloads-without-user-activation allow-storage-access-by-user-activation" />`, Tsx: true},
+		// Direct JSX attributes decode HTML entities before the rule sees their
+		// ESTree Literal value; entities can form both a token and a delimiter.
+		{Code: `<iframe sandbox="allow&#x2D;forms" />`, Tsx: true},
+		{Code: `<iframe sandbox="allow-forms&#x20;allow-modals" />`, Tsx: true},
+		// Upstream validates only direct Literal values; expressions remain dynamic.
+		{Code: `<iframe sandbox={"__unknown__"} />`, Tsx: true},
+		{Code: `React.createElement("iframe", {sandbox: value})`, Tsx: true},
+		// The first matching property wins, matching Array.prototype.find upstream.
+		{Code: `React.createElement("iframe", {sandbox: "allow-forms", sandbox: "__unknown__"})`, Tsx: true},
+		// A destructured React factory is supported by upstream's isCreateElement.
+		{Code: `import { createElement } from "react"; createElement("iframe", {sandbox: "allow-forms"})`, Tsx: true},
+		// Upstream reads MemberExpression.property.name, so an identifier in a
+		// computed access is still recognized as createElement.
+		{Code: `React[createElement]("iframe", {sandbox: "allow-forms"})`, Tsx: true},
+		{Code: `React?.[createElement]("iframe", {sandbox: "allow-forms"})`, Tsx: true},
+		// Configured pragma support comes from the shared upstream-equivalent matcher.
+		{Code: `h.createElement("iframe", {sandbox: "allow-forms"})`, Tsx: true, Settings: map[string]interface{}{"react": map[string]interface{}{"pragma": "h"}}},
+	}, []rule_tester.InvalidTestCase{
+		{
+			Code: `React.createElement("iframe", {"sandbox": "allow-forms"})`, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "attributeMissing", Message: msgAttributeMissing, Line: 1, Column: 1, EndLine: 1, EndColumn: 58}},
+		},
+		{
+			Code: `React.createElement("iframe", {[sandbox]: "__unknown__"})`, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidValue", Message: `An iframe element defines a sandbox attribute with invalid value "__unknown__"`, Line: 1, Column: 1, EndLine: 1, EndColumn: 58}},
+		},
+		{
+			Code: `import { createElement } from "react"; createElement("iframe")`, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "attributeMissing", Message: msgAttributeMissing, Line: 1, Column: 40, EndLine: 1, EndColumn: 63}},
+		},
+		{
+			Code: `React[createElement]("iframe")`, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "attributeMissing", Message: msgAttributeMissing, Line: 1, Column: 1, EndLine: 1, EndColumn: 31}},
+		},
+		{
+			Code: `React?.[createElement]("iframe")`, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "attributeMissing", Message: msgAttributeMissing, Line: 1, Column: 1, EndLine: 1, EndColumn: 33}},
+		},
+		{
+			Code: `h.createElement("iframe")`, Tsx: true, Settings: map[string]interface{}{"react": map[string]interface{}{"pragma": "h"}},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "attributeMissing", Message: msgAttributeMissing, Line: 1, Column: 1, EndLine: 1, EndColumn: 26}},
+		},
+	})
+}

--- a/internal/plugins/react/rules/iframe_missing_sandbox/iframe_missing_sandbox_upstream_test.go
+++ b/internal/plugins/react/rules/iframe_missing_sandbox/iframe_missing_sandbox_upstream_test.go
@@ -1,0 +1,119 @@
+// TestIframeMissingSandboxUpstream migrates every valid and invalid case from
+// eslint-plugin-react v7.37.5's tests/lib/rules/iframe-missing-sandbox.js.
+// The documentation examples are also retained below. tsgo-specific coverage
+// lives in iframe_missing_sandbox_extras_test.go.
+package iframe_missing_sandbox
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestIframeMissingSandboxUpstream(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &IframeMissingSandboxRule, []rule_tester.ValidTestCase{
+		{Code: `<div sandbox="__unknown__" />;`, Tsx: true},
+
+		{Code: `<iframe sandbox="" />;`, Tsx: true},
+		{Code: `<iframe sandbox={""} />`, Tsx: true},
+		{Code: `React.createElement("iframe", { sandbox: "" });`, Tsx: true},
+
+		{Code: `<iframe src="foo.htm" sandbox></iframe>`, Tsx: true},
+		{Code: `React.createElement("iframe", { src: "foo.htm", sandbox: true })`, Tsx: true},
+
+		{Code: `<iframe src="foo.htm" sandbox sandbox></iframe>`, Tsx: true},
+
+		{Code: `<iframe sandbox="allow-forms"></iframe>`, Tsx: true},
+		{Code: `<iframe sandbox="allow-modals"></iframe>`, Tsx: true},
+		{Code: `<iframe sandbox="allow-orientation-lock"></iframe>`, Tsx: true},
+		{Code: `<iframe sandbox="allow-pointer-lock"></iframe>`, Tsx: true},
+		{Code: `<iframe sandbox="allow-popups"></iframe>`, Tsx: true},
+		{Code: `<iframe sandbox="allow-popups-to-escape-sandbox"></iframe>`, Tsx: true},
+		{Code: `<iframe sandbox="allow-presentation"></iframe>`, Tsx: true},
+		{Code: `<iframe sandbox="allow-same-origin"></iframe>`, Tsx: true},
+		{Code: `<iframe sandbox="allow-scripts"></iframe>`, Tsx: true},
+		{Code: `<iframe sandbox="allow-top-navigation"></iframe>`, Tsx: true},
+		{Code: `<iframe sandbox="allow-top-navigation-by-user-activation"></iframe>`, Tsx: true},
+		{Code: `<iframe sandbox="allow-forms allow-modals"></iframe>`, Tsx: true},
+		{Code: `<iframe sandbox="allow-popups allow-popups-to-escape-sandbox allow-pointer-lock allow-same-origin allow-top-navigation"></iframe>`, Tsx: true},
+		{Code: `React.createElement("iframe", { sandbox: "allow-forms" })`, Tsx: true},
+		{Code: `React.createElement("iframe", { sandbox: "allow-modals" })`, Tsx: true},
+		{Code: `React.createElement("iframe", { sandbox: "allow-orientation-lock" })`, Tsx: true},
+		{Code: `React.createElement("iframe", { sandbox: "allow-pointer-lock" })`, Tsx: true},
+		{Code: `React.createElement("iframe", { sandbox: "allow-popups" })`, Tsx: true},
+		{Code: `React.createElement("iframe", { sandbox: "allow-popups-to-escape-sandbox" })`, Tsx: true},
+		{Code: `React.createElement("iframe", { sandbox: "allow-presentation" })`, Tsx: true},
+		{Code: `React.createElement("iframe", { sandbox: "allow-same-origin" })`, Tsx: true},
+		{Code: `React.createElement("iframe", { sandbox: "allow-scripts" })`, Tsx: true},
+		{Code: `React.createElement("iframe", { sandbox: "allow-top-navigation" })`, Tsx: true},
+		{Code: `React.createElement("iframe", { sandbox: "allow-top-navigation-by-user-activation" })`, Tsx: true},
+		{Code: `React.createElement("iframe", { sandbox: "allow-forms allow-modals" })`, Tsx: true},
+		{Code: `React.createElement("iframe", { sandbox: "allow-popups allow-popups-to-escape-sandbox allow-pointer-lock allow-same-origin allow-top-navigation" })`, Tsx: true},
+
+		// Documentation's non-warning examples.
+		{Code: `var React = require('react'); var Frame = <iframe sandbox="allow-popups"/>;`, Tsx: true},
+		{Code: `var React = require('react'); var Frame = () => (<div><iframe sandbox="allow-popups"></iframe>{React.createElement('iframe', { sandbox: "allow-popups" })}</div>);`, Tsx: true},
+	}, []rule_tester.InvalidTestCase{
+		{
+			Code: `<iframe></iframe>;`, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "attributeMissing", Message: msgAttributeMissing, Line: 1, Column: 1, EndLine: 1, EndColumn: 9}},
+		},
+		{
+			Code: `<iframe/>;`, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "attributeMissing", Message: msgAttributeMissing, Line: 1, Column: 1, EndLine: 1, EndColumn: 10}},
+		},
+		{
+			Code: `React.createElement("iframe");`, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "attributeMissing", Message: msgAttributeMissing, Line: 1, Column: 1, EndLine: 1, EndColumn: 30}},
+		},
+		{
+			Code: `React.createElement("iframe", {});`, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "attributeMissing", Message: msgAttributeMissing, Line: 1, Column: 1, EndLine: 1, EndColumn: 34}},
+		},
+		{
+			Code: `React.createElement("iframe", null);`, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "attributeMissing", Message: msgAttributeMissing, Line: 1, Column: 1, EndLine: 1, EndColumn: 36}},
+		},
+
+		// Documentation's warning examples.
+		{
+			Code: `var React = require('react'); var Frame = () => (<div><iframe></iframe>{React.createElement('iframe')}</div>);`, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "attributeMissing", Message: msgAttributeMissing, Line: 1, Column: 55, EndLine: 1, EndColumn: 63},
+				{MessageId: "attributeMissing", Message: msgAttributeMissing, Line: 1, Column: 73, EndLine: 1, EndColumn: 102},
+			},
+		},
+		{
+			Code: `<iframe sandbox="__unknown__"></iframe>`, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidValue", Message: `An iframe element defines a sandbox attribute with invalid value "__unknown__"`, Line: 1, Column: 1, EndLine: 1, EndColumn: 31}},
+		},
+		{
+			Code: `React.createElement("iframe", { sandbox: "__unknown__" })`, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidValue", Message: `An iframe element defines a sandbox attribute with invalid value "__unknown__"`, Line: 1, Column: 1, EndLine: 1, EndColumn: 58}},
+		},
+		{
+			Code: `<iframe sandbox="allow-popups __unknown__"/>`, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidValue", Message: `An iframe element defines a sandbox attribute with invalid value "__unknown__"`, Line: 1, Column: 1, EndLine: 1, EndColumn: 45}},
+		},
+		{
+			Code: `<iframe sandbox="__unknown__ allow-popups"/>`, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidValue", Message: `An iframe element defines a sandbox attribute with invalid value "__unknown__"`, Line: 1, Column: 1, EndLine: 1, EndColumn: 45}},
+		},
+		{
+			Code: `<iframe sandbox=" allow-forms __unknown__ allow-popups __unknown__  "/>`, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "invalidValue", Message: `An iframe element defines a sandbox attribute with invalid value "__unknown__"`, Line: 1, Column: 1, EndLine: 1, EndColumn: 72},
+				{MessageId: "invalidValue", Message: `An iframe element defines a sandbox attribute with invalid value "__unknown__"`, Line: 1, Column: 1, EndLine: 1, EndColumn: 72},
+			},
+		},
+		{
+			Code: `<iframe sandbox="allow-scripts allow-same-origin"></iframe>;`, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidCombination", Message: msgInvalidCombination, Line: 1, Column: 1, EndLine: 1, EndColumn: 51}},
+		},
+		{
+			Code: `<iframe sandbox="allow-same-origin allow-scripts"/>;`, Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "invalidCombination", Message: msgInvalidCombination, Line: 1, Column: 1, EndLine: 1, EndColumn: 52}},
+		},
+	})
+}

--- a/internal/plugins/react/rules/no_invalid_html_attribute/no_invalid_html_attribute.go
+++ b/internal/plugins/react/rules/no_invalid_html_attribute/no_invalid_html_attribute.go
@@ -139,18 +139,6 @@ func literalString(node *ast.Node) (string, bool) {
 	return "", false
 }
 
-func jsxLiteralString(ctx rule.RuleContext, node *ast.Node) (string, bool) {
-	value, ok := literalString(node)
-	if !ok {
-		return "", false
-	}
-	raw := sourceText(ctx, node)
-	if len(raw) >= 2 && ((raw[0] == '"' && raw[len(raw)-1] == '"') || (raw[0] == '\'' && raw[len(raw)-1] == '\'')) {
-		return ecmascript.DecodeJSXEntities(raw[1 : len(raw)-1]), true
-	}
-	return value, true
-}
-
 func isCreateElementCall(callee *ast.Node) bool {
 	if reactutil.IsCreateElementCall(callee, reactutil.DefaultReactPragma) {
 		return true
@@ -295,7 +283,7 @@ var NoInvalidHtmlAttributeRule = rule.Rule{
 		reportLiteral := func(valueNode, nonStringRemoveNode, emptyRemoveNode *ast.Node, element string, decodeJSX bool) {
 			value, isString := literalString(valueNode)
 			if decodeJSX {
-				value, isString = jsxLiteralString(ctx, valueNode)
+				value, isString = reactutil.GetJsxStringLiteralValue(ctx.SourceFile, valueNode)
 			}
 			if !isString {
 				ctx.ReportNodeWithDeferredSuggestions(valueNode, message("onlyStrings", "“rel” attribute only supports strings."), func() []rule.RuleSuggestion {

--- a/packages/rslint-test-tools/rstack.config.mts
+++ b/packages/rslint-test-tools/rstack.config.mts
@@ -203,6 +203,7 @@ define.test({
     './tests/eslint-plugin-react/rules/forward-ref-uses-ref.test.ts',
     './tests/eslint-plugin-react/rules/function-component-definition.test.ts',
     './tests/eslint-plugin-react/rules/hook-use-state.test.ts',
+    './tests/eslint-plugin-react/rules/iframe-missing-sandbox.test.ts',
     './tests/eslint-plugin-react/rules/jsx-child-element-spacing.test.ts',
     './tests/eslint-plugin-react/rules/no-adjacent-inline-elements.test.ts',
     './tests/eslint-plugin-react/rules/self-closing-comp.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-react/rules/iframe-missing-sandbox.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react/rules/iframe-missing-sandbox.test.ts
@@ -1,0 +1,111 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('iframe-missing-sandbox', {} as never, {
+  valid: [
+    { code: `<div sandbox="__unknown__" />;` },
+    { code: `<iframe sandbox="" />;` },
+    { code: `<iframe sandbox={""} />` },
+    { code: `React.createElement("iframe", { sandbox: "" });` },
+    { code: `<iframe src="foo.htm" sandbox></iframe>` },
+    {
+      code: `React.createElement("iframe", { src: "foo.htm", sandbox: true })`,
+    },
+    { code: `<iframe src="foo.htm" sandbox sandbox></iframe>` },
+    { code: `<iframe sandbox="allow-forms"></iframe>` },
+    { code: `<iframe sandbox="allow-modals"></iframe>` },
+    { code: `<iframe sandbox="allow-orientation-lock"></iframe>` },
+    { code: `<iframe sandbox="allow-pointer-lock"></iframe>` },
+    { code: `<iframe sandbox="allow-popups"></iframe>` },
+    { code: `<iframe sandbox="allow-popups-to-escape-sandbox"></iframe>` },
+    { code: `<iframe sandbox="allow-presentation"></iframe>` },
+    { code: `<iframe sandbox="allow-same-origin"></iframe>` },
+    { code: `<iframe sandbox="allow-scripts"></iframe>` },
+    { code: `<iframe sandbox="allow-top-navigation"></iframe>` },
+    {
+      code: `<iframe sandbox="allow-top-navigation-by-user-activation"></iframe>`,
+    },
+    { code: `<iframe sandbox="allow-forms allow-modals"></iframe>` },
+    {
+      code: `<iframe sandbox="allow-popups allow-popups-to-escape-sandbox allow-pointer-lock allow-same-origin allow-top-navigation"></iframe>`,
+    },
+    { code: `React.createElement("iframe", { sandbox: "allow-forms" })` },
+    { code: `React.createElement("iframe", { sandbox: "allow-modals" })` },
+    {
+      code: `React.createElement("iframe", { sandbox: "allow-orientation-lock" })`,
+    },
+    {
+      code: `React.createElement("iframe", { sandbox: "allow-pointer-lock" })`,
+    },
+    { code: `React.createElement("iframe", { sandbox: "allow-popups" })` },
+    {
+      code: `React.createElement("iframe", { sandbox: "allow-popups-to-escape-sandbox" })`,
+    },
+    {
+      code: `React.createElement("iframe", { sandbox: "allow-presentation" })`,
+    },
+    {
+      code: `React.createElement("iframe", { sandbox: "allow-same-origin" })`,
+    },
+    {
+      code: `React.createElement("iframe", { sandbox: "allow-scripts" })`,
+    },
+    {
+      code: `React.createElement("iframe", { sandbox: "allow-top-navigation" })`,
+    },
+    {
+      code: `React.createElement("iframe", { sandbox: "allow-top-navigation-by-user-activation" })`,
+    },
+    {
+      code: `React.createElement("iframe", { sandbox: "allow-forms allow-modals" })`,
+    },
+    {
+      code: `React.createElement("iframe", { sandbox: "allow-popups allow-popups-to-escape-sandbox allow-pointer-lock allow-same-origin allow-top-navigation" })`,
+    },
+  ],
+  invalid: [
+    { code: `<iframe></iframe>;`, errors: [{ messageId: 'attributeMissing' }] },
+    { code: `<iframe/>;`, errors: [{ messageId: 'attributeMissing' }] },
+    {
+      code: `React.createElement("iframe");`,
+      errors: [{ messageId: 'attributeMissing' }],
+    },
+    {
+      code: `React.createElement("iframe", {});`,
+      errors: [{ messageId: 'attributeMissing' }],
+    },
+    {
+      code: `React.createElement("iframe", null);`,
+      errors: [{ messageId: 'attributeMissing' }],
+    },
+    {
+      code: `<iframe sandbox="__unknown__"></iframe>`,
+      errors: [{ messageId: 'invalidValue' }],
+    },
+    {
+      code: `React.createElement("iframe", { sandbox: "__unknown__" })`,
+      errors: [{ messageId: 'invalidValue' }],
+    },
+    {
+      code: `<iframe sandbox="allow-popups __unknown__"/>`,
+      errors: [{ messageId: 'invalidValue' }],
+    },
+    {
+      code: `<iframe sandbox="__unknown__ allow-popups"/>`,
+      errors: [{ messageId: 'invalidValue' }],
+    },
+    {
+      code: `<iframe sandbox=" allow-forms __unknown__ allow-popups __unknown__  "/>`,
+      errors: [{ messageId: 'invalidValue' }, { messageId: 'invalidValue' }],
+    },
+    {
+      code: `<iframe sandbox="allow-scripts allow-same-origin"></iframe>;`,
+      errors: [{ messageId: 'invalidCombination' }],
+    },
+    {
+      code: `<iframe sandbox="allow-same-origin allow-scripts"/>;`,
+      errors: [{ messageId: 'invalidCombination' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Motivation

Add parity for eslint-plugin-react’s iframe sandbox security rule. It catches iframe elements without a sandbox attribute, invalid sandbox tokens, and the unsafe allow-scripts + allow-same-origin combination.

## Changes

- Port `react/iframe-missing-sandbox` from eslint-plugin-react v7.37.5, including documentation, registration, and Go/JS test coverage.
- Preserve upstream React createElement recognition, including computed identifiers and destructured React imports.
- Extract direct JSX string-attribute entity decoding into reactutil and reuse it from react/no-invalid-html-attribute.
- Add regressions for entity-decoded sandbox tokens and delimiters.