### PR TITLE
feat(react): add jsx-curly-newline rule

### DIFF
--- a/internal/plugins/react/all.go
+++ b/internal/plugins/react/all.go
@@ -87,6 +87,7 @@ import (
 
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_child_element_spacing"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_curly_brace_presence"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_curly_newline"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_curly_spacing"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_no_comment_textnodes"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_no_leaked_render"
@@ -181,6 +182,7 @@ func GetAllRules() []rule.Rule {
 		void_dom_elements_no_children.VoidDomElementsNoChildrenRule,
 		jsx_child_element_spacing.JsxChildElementSpacingRule,
 		jsx_curly_brace_presence.JsxCurlyBracePresenceRule,
+		jsx_curly_newline.JsxCurlyNewlineRule,
 		jsx_curly_spacing.JsxCurlySpacingRule,
 		jsx_no_comment_textnodes.JsxNoCommentTextnodesRule,
 		jsx_no_leaked_render.JsxNoLeakedRenderRule,

--- a/internal/plugins/react/rules/jsx_curly_newline/jsx_curly_newline.go
+++ b/internal/plugins/react/rules/jsx_curly_newline/jsx_curly_newline.go
@@ -1,0 +1,186 @@
+package jsx_curly_newline
+
+import (
+	_ "embed"
+	"strings"
+
+	"github.com/microsoft/TypeScript/tsc/shim/ast"
+	"github.com/microsoft/TypeScript/tsc/shim/core"
+	"github.com/microsoft/TypeScript/tsc/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+	"github.com/web-infra-dev/rslint/internal/utils/ecmascript"
+)
+
+//go:embed jsx_curly_newline.schema.json
+var schemaJSON []byte
+
+const (
+	consistent = "consistent"
+	require    = "require"
+	forbid     = "forbid"
+)
+
+type options struct {
+	singleline string
+	multiline  string
+}
+
+func parseOptions(raw []any) options {
+	result := options{singleline: consistent, multiline: consistent}
+	if len(raw) == 0 {
+		return result
+	}
+	if value, ok := raw[0].(string); ok && value == "never" {
+		return options{singleline: forbid, multiline: forbid}
+	}
+	if value, ok := raw[0].(map[string]any); ok {
+		if singleline, ok := value["singleline"].(string); ok {
+			result.singleline = singleline
+		}
+		if multiline, ok := value["multiline"].(string); ok {
+			result.multiline = multiline
+		}
+	}
+	return result
+}
+
+func requiresNewlines(option options, expression *ast.Node, lineMap []core.TextPos, hasLeftNewline bool) bool {
+	multiline := false
+	if expression != nil {
+		multiline = expression.Pos() != expression.End() && scanner.ComputeLineOfPosition(lineMap, expression.Pos()) != scanner.ComputeLineOfPosition(lineMap, expression.End())
+	}
+	mode := option.singleline
+	if multiline {
+		mode = option.multiline
+	}
+	switch mode {
+	case forbid:
+		return false
+	case require:
+		return true
+	default:
+		return hasLeftNewline
+	}
+}
+
+// JsxCurlyNewlineRule enforces matching line breaks immediately within JSX
+// expression-container braces. JSX spread children are excluded because the
+// upstream listener is JSXExpressionContainer-only.
+var JsxCurlyNewlineRule = rule.Rule{
+	Name:   "react/jsx-curly-newline",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, rawOptions []any) rule.RuleListeners {
+		option := parseOptions(rawOptions)
+		text := ctx.SourceFile.Text()
+		lineMap := ctx.SourceFile.ECMALineMap()
+
+		return rule.RuleListeners{
+			ast.KindJsxExpression: func(node *ast.Node) {
+				expression := node.AsJsxExpression()
+				if expression == nil || expression.DotDotDotToken != nil {
+					return
+				}
+				trimmed := utils.TrimNodeTextRange(ctx.SourceFile, node)
+				openPos, closePos := trimmed.Pos(), trimmed.End()-1
+				if openPos < 0 || closePos <= openPos || closePos >= len(text) || text[openPos] != '{' || text[closePos] != '}' {
+					return
+				}
+
+				innerLow, innerHigh := openPos+1, closePos
+				firstToken := ecmascript.SkipLeadingWhitespace(text, innerLow, innerHigh)
+				lastTokenEnd := ecmascript.SkipTrailingWhitespace(text, innerLow, innerHigh)
+				// The upstream token APIs skip comments. scan to the first/last
+				// non-comment token so comments participate in newline detection.
+				firstCode := skipLeadingComments(text, firstToken, innerHigh)
+				lastCodeEnd := skipTrailingComments(text, lastTokenEnd, innerLow)
+				hasLeftNewline := ecmascript.ContainsLineTerminator(text, innerLow, firstCode)
+				hasRightNewline := ecmascript.ContainsLineTerminator(text, lastCodeEnd, innerHigh)
+				needsNewlines := requiresNewlines(option, expression.Expression, lineMap, hasLeftNewline)
+
+				report := func(position int, id, description string, fix *rule.RuleFix) {
+					range_ := core.NewTextRange(position, position+1)
+					message := rule.RuleMessage{Id: id, Description: description}
+					if fix == nil {
+						ctx.ReportRange(range_, message)
+					} else {
+						ctx.ReportRangeWithFixes(range_, message, *fix)
+					}
+				}
+
+				if hasLeftNewline && !needsNewlines {
+					var fix *rule.RuleFix
+					if ecmascript.StringTrim(text[innerLow:firstCode]) == "" {
+						candidate := rule.RuleFixRemoveRange(core.NewTextRange(innerLow, firstCode))
+						fix = &candidate
+					}
+					report(openPos, "unexpectedAfter", "Unexpected newline after '{'.", fix)
+				} else if !hasLeftNewline && needsNewlines {
+					fix := rule.RuleFix{Text: "\n", Range: core.NewTextRange(innerLow, innerLow)}
+					report(openPos, "expectedAfter", "Expected newline after '{'.", &fix)
+				}
+
+				if hasRightNewline && !needsNewlines {
+					var fix *rule.RuleFix
+					if ecmascript.StringTrim(text[lastCodeEnd:innerHigh]) == "" {
+						candidate := rule.RuleFixRemoveRange(core.NewTextRange(lastCodeEnd, innerHigh))
+						fix = &candidate
+					}
+					report(closePos, "unexpectedBefore", "Unexpected newline before '}'.", fix)
+				} else if !hasRightNewline && needsNewlines {
+					fix := rule.RuleFix{Text: "\n", Range: core.NewTextRange(innerHigh, innerHigh)}
+					report(closePos, "expectedBefore", "Expected newline before '}'.", &fix)
+				}
+			},
+		}
+	},
+}
+
+func skipLeadingComments(text string, position, end int) int {
+	for position+1 < end && text[position] == '/' {
+		switch text[position+1] {
+		case '*':
+			position += 2
+			for position+1 < end && (text[position] != '*' || text[position+1] != '/') {
+				position++
+			}
+			if position+1 >= end {
+				return end
+			}
+			position += 2
+		case '/':
+			position += 2
+			for position < end && text[position] != '\n' && text[position] != '\r' {
+				position++
+			}
+		default:
+			return position
+		}
+		position = ecmascript.SkipLeadingWhitespace(text, position, end)
+	}
+	return position
+}
+
+func skipTrailingComments(text string, position, start int) int {
+	for position > start {
+		lineStart := strings.LastIndexByte(text[start:position], '\n') + start + 1
+		if comment := strings.LastIndex(text[lineStart:position], "//"); comment >= 0 {
+			position = lineStart + comment
+			position = ecmascript.SkipTrailingWhitespace(text, start, position)
+			continue
+		}
+		if position-2 < start || text[position-2] != '*' || text[position-1] != '/' {
+			break
+		}
+		position -= 2
+		for position-2 >= start && (text[position-2] != '/' || text[position-1] != '*') {
+			position--
+		}
+		if position-2 < start {
+			return start
+		}
+		position -= 2
+		position = ecmascript.SkipTrailingWhitespace(text, start, position)
+	}
+	return position
+}

--- a/internal/plugins/react/rules/jsx_curly_newline/jsx_curly_newline.md
+++ b/internal/plugins/react/rules/jsx_curly_newline/jsx_curly_newline.md
@@ -1,0 +1,57 @@
+# jsx-curly-newline
+
+Enforce consistent line breaks immediately inside curly braces in JSX
+attributes and expressions.
+
+## Rule Details
+
+This rule checks both braces of every JSX expression container. It can require,
+forbid, or keep consistent the newline directly after `{` and directly before
+`}`. Comments are preserved: a diagnostic adjacent to a comment may not be
+autofixable.
+
+Examples of **incorrect** code with the default `"consistent"` option:
+
+```jsx
+<div>{ foo
+}</div>
+
+<div>{
+  foo }</div>
+```
+
+Examples of **correct** code:
+
+```jsx
+<div>{ foo }</div>
+
+<div>{
+  foo
+}</div>
+```
+
+## Rule Options
+
+The default is `"consistent"`, an alias for:
+
+```json
+{ "singleline": "consistent", "multiline": "consistent" }
+```
+
+`"never"` is an alias for `{ "singleline": "forbid", "multiline":
+"forbid" }`. Alternatively, use an object with independently configured
+`singleline` and `multiline` values: `"consistent"`, `"require"`, or
+`"forbid"`.
+
+```json
+{ "react/jsx-curly-newline": ["error", { "singleline": "require", "multiline": "forbid" }] }
+```
+
+With `"require"`, both immediate brace boundaries must have newlines. With
+`"forbid"`, neither boundary may have one. With `"consistent"`, the right
+boundary follows the existing state of the left boundary.
+
+## Original Documentation
+
+- [eslint-plugin-react: jsx-curly-newline](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/jsx-curly-newline.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/lib/rules/jsx-curly-newline.js)

--- a/internal/plugins/react/rules/jsx_curly_newline/jsx_curly_newline.schema.json
+++ b/internal/plugins/react/rules/jsx_curly_newline/jsx_curly_newline.schema.json
@@ -1,0 +1,20 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "anyOf": [
+        { "enum": ["consistent", "never"] },
+        {
+          "type": "object",
+          "properties": {
+            "singleline": { "enum": ["consistent", "require", "forbid"] },
+            "multiline": { "enum": ["consistent", "require", "forbid"] }
+          },
+          "additionalProperties": false
+        }
+      ]
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/react/rules/jsx_curly_newline/jsx_curly_newline_extras_test.go
+++ b/internal/plugins/react/rules/jsx_curly_newline/jsx_curly_newline_extras_test.go
@@ -1,0 +1,66 @@
+package jsx_curly_newline
+
+import (
+	"testing"
+
+	"github.com/microsoft/TypeScript/tsc/shim/ast"
+	"github.com/microsoft/TypeScript/tsc/shim/core"
+	"github.com/microsoft/TypeScript/tsc/shim/parser"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+	"gotest.tools/v3/assert"
+)
+
+func TestJsxCurlyNewlineExtras(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &JsxCurlyNewlineRule, []rule_tester.ValidTestCase{
+		// JSX spread children are represented as JsxExpression by tsgo but are
+		// not JSXExpressionContainers in ESTree, so upstream does not inspect them.
+		{Code: "<App>{...items}</App>", Tsx: true, Options: []any{"never"}},
+		// A TypeScript wrapper may span lines, so multiline selection follows the
+		// expression range rather than just the first and last inner tokens.
+		{Code: "<App>{\n(value as string)\n}</App>", Tsx: true, Options: []any{map[string]any{"multiline": "require"}}},
+	}, []rule_tester.InvalidTestCase{
+		{Code: "<App>{value}</App>", Tsx: true, Options: []any{map[string]any{"singleline": "require"}}, Output: []string{"<App>{\nvalue\n}</App>"}, Errors: []rule_tester.InvalidTestCaseError{
+			errorAt("expectedAfter", "Expected newline after '{'.", 1, 6),
+			errorAt("expectedBefore", "Expected newline before '}'.", 1, 12),
+		}},
+		// Line comments are skipped by ESLint's token APIs but deliberately keep
+		// newline-removal diagnostics non-fixable.
+		{Code: "<App>{// comment\nvalue}</App>", Tsx: true, Options: []any{"never"}, Errors: []rule_tester.InvalidTestCaseError{
+			errorAt("unexpectedAfter", "Unexpected newline after '{'.", 1, 6),
+		}},
+		{Code: "<App>{value // comment\n}</App>", Tsx: true, Options: []any{"never"}, Errors: []rule_tester.InvalidTestCaseError{
+			errorAt("unexpectedBefore", "Unexpected newline before '}'.", 2, 1),
+		}},
+	})
+}
+
+func TestJsxCurlyNewlineEditDemand(t *testing.T) {
+	for _, demand := range []rule.EditDemand{rule.EditDemandNone, rule.EditDemandAutofix, rule.EditDemandSuggestion, rule.EditDemandAll} {
+		sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{FileName: "/demand.tsx", Path: "/demand.tsx"}, "<App>{value}</App>", core.ScriptKindTSX)
+		comments := rule.NewCommentStore(sourceFile)
+		var diagnostics []rule.RuleDiagnostic
+		ctx := rule.RuleContext{SourceFile: sourceFile, Comments: comments, DisableManager: rule.NewDisableManager(sourceFile, comments)}.WithDiagnosticConsumer("react/jsx-curly-newline", rule.SeverityError, rule.DiagnosticConsumer{
+			Demand: demand,
+			Report: func(diagnostic rule.RuleDiagnostic) { diagnostics = append(diagnostics, diagnostic) },
+		})
+		root := sourceFile.Statements.Nodes[0].AsExpressionStatement().Expression
+		child := reactutil.GetJsxChildren(root)[0]
+		listeners := JsxCurlyNewlineRule.Run(ctx, []any{map[string]any{"singleline": "require"}})
+		listeners[ast.KindJsxExpression](child)
+
+		assert.Equal(t, len(diagnostics), 2)
+		for index, expected := range []struct {
+			id     string
+			range_ core.TextRange
+		}{{"expectedAfter", core.NewTextRange(5, 6)}, {"expectedBefore", core.NewTextRange(11, 12)}} {
+			diagnostic := diagnostics[index]
+			assert.Equal(t, diagnostic.Message.Id, expected.id)
+			assert.Equal(t, diagnostic.Range, expected.range_)
+			assert.Equal(t, len(diagnostic.Fixes()) > 0, demand&rule.EditDemandAutofix != 0)
+			assert.Assert(t, diagnostic.Suggestions == nil)
+		}
+	}
+}

--- a/internal/plugins/react/rules/jsx_curly_newline/jsx_curly_newline_upstream_test.go
+++ b/internal/plugins/react/rules/jsx_curly_newline/jsx_curly_newline_upstream_test.go
@@ -1,0 +1,175 @@
+// TestJsxCurlyNewlineUpstream ports eslint-plugin-react v7.37.5's complete
+// jsx-curly-newline suite, plus the rule documentation's examples.
+package jsx_curly_newline
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func errorAt(id, message string, line, column int) rule_tester.InvalidTestCaseError {
+	return rule_tester.InvalidTestCaseError{MessageId: id, Message: message, Line: line, Column: column, EndLine: line, EndColumn: column + 1}
+}
+
+func TestJsxCurlyNewlineUpstream(t *testing.T) {
+	consistentOption := []any{"consistent"}
+	neverOption := []any{"never"}
+	requireMultiline := []any{map[string]any{"singleline": "consistent", "multiline": "require"}}
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &JsxCurlyNewlineRule, []rule_tester.ValidTestCase{
+		{Code: `<div>{foo}</div>`, Tsx: true, Options: consistentOption},
+		{Code: `
+        <div>
+          {
+            foo
+          }
+        </div>
+      `, Tsx: true, Options: consistentOption},
+		{Code: `
+        <div>
+          { foo &&
+            foo.bar }
+        </div>
+      `, Tsx: true, Options: consistentOption},
+		{Code: `
+        <div>
+          {
+            foo &&
+            foo.bar
+          }
+        </div>
+      `, Tsx: true, Options: consistentOption},
+		{Code: `
+        <div foo={
+          bar
+        } />
+      `, Tsx: true, Options: consistentOption},
+		{Code: `<div>{foo}</div>`, Tsx: true, Options: requireMultiline},
+		{Code: `<div foo={bar} />`, Tsx: true, Options: requireMultiline},
+		{Code: `
+        <div>
+          {
+            foo &&
+            foo.bar
+          }
+        </div>
+      `, Tsx: true, Options: requireMultiline},
+		{Code: `
+        <div>
+          {
+            foo
+          }
+        </div>
+      `, Tsx: true, Options: requireMultiline},
+		{Code: `<div>{foo}</div>`, Tsx: true, Options: neverOption},
+		{Code: `<div foo={bar} />`, Tsx: true, Options: neverOption},
+		{Code: `
+        <div>
+          { foo &&
+            foo.bar }
+        </div>
+      `, Tsx: true, Options: neverOption},
+		// Documentation examples.
+		{Code: `<div>{ foo }</div>`, Tsx: true},
+		{Code: "<div>{\n  foo\n}</div>", Tsx: true},
+		{Code: "<div>{ foo &&\n  foo.bar }</div>", Tsx: true, Options: neverOption},
+	}, []rule_tester.InvalidTestCase{
+		{Code: "\n        <div>\n          { foo \n}\n        </div>\n      ", Tsx: true, Output: []string{`
+        <div>
+          { foo}
+        </div>
+      `}, Options: consistentOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpectedBefore"}}},
+		{Code: "\n        <div>\n          { foo &&\n            foo.bar \n}\n        </div>\n      ", Tsx: true, Output: []string{`
+        <div>
+          { foo &&
+            foo.bar}
+        </div>
+      `}, Options: consistentOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpectedBefore"}}},
+		{Code: `
+        <div>
+          { foo &&
+            bar
+          }
+        </div>
+      `, Tsx: true, Output: []string{`
+        <div>
+          { foo &&
+            bar}
+        </div>
+      `}, Options: consistentOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpectedBefore"}}},
+		{Code: `<div>{foo
+}</div>`, Tsx: true, Output: []string{`<div>{foo}</div>`}, Options: requireMultiline, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpectedBefore"}}},
+		{Code: `<div>{
+foo}</div>`, Tsx: true, Output: []string{`<div>{
+foo
+}</div>`}, Options: requireMultiline, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "expectedBefore"}}},
+		{Code: `
+        <div>
+          { foo &&
+            bar }
+        </div>
+      `, Tsx: true, Output: []string{"\n        <div>\n          {\n foo &&\n            bar \n}\n        </div>\n      "}, Options: requireMultiline, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "expectedAfter"}, {MessageId: "expectedBefore"}}},
+		{Code: `
+        <div style={foo &&
+          foo.bar
+        } />
+      `, Tsx: true, Output: []string{`
+        <div style={
+foo &&
+          foo.bar
+        } />
+      `}, Options: requireMultiline, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "expectedAfter"}}},
+		{Code: `
+        <div>
+          {
+foo
+}
+        </div>
+      `, Tsx: true, Output: []string{`
+        <div>
+          {foo}
+        </div>
+      `}, Options: neverOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpectedAfter"}, {MessageId: "unexpectedBefore"}}},
+		{Code: `
+        <div>
+          {
+            foo &&
+            foo.bar
+          }
+        </div>
+      `, Tsx: true, Output: []string{`
+        <div>
+          {foo &&
+            foo.bar}
+        </div>
+      `}, Options: neverOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpectedAfter"}, {MessageId: "unexpectedBefore"}}},
+		{Code: `
+        <div>
+          { foo &&
+            foo.bar
+          }
+        </div>
+      `, Tsx: true, Output: []string{`
+        <div>
+          { foo &&
+            foo.bar}
+        </div>
+      `}, Options: neverOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpectedBefore"}}},
+		{Code: `
+        <div>
+          { /* not fixed due to comment */
+            foo }
+        </div>
+      `, Tsx: true, Options: neverOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpectedAfter"}}},
+		{Code: `
+        <div>
+          { foo
+            /* not fixed due to comment */}
+        </div>
+      `, Tsx: true, Options: neverOption, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpectedBefore"}}},
+		// Documentation examples.
+		{Code: "<div>{ foo\n}</div>", Tsx: true, Output: []string{"<div>{ foo}</div>"}, Errors: []rule_tester.InvalidTestCaseError{errorAt("unexpectedBefore", "Unexpected newline before '}'.", 2, 1)}},
+		{Code: "<div>{\n  foo }</div>", Tsx: true, Output: []string{"<div>{\n  foo \n}</div>"}, Errors: []rule_tester.InvalidTestCaseError{errorAt("expectedBefore", "Expected newline before '}'.", 2, 7)}},
+	})
+}

--- a/packages/rslint-test-tools/rstack.config.mts
+++ b/packages/rslint-test-tools/rstack.config.mts
@@ -238,6 +238,7 @@ define.test({
     './tests/eslint-plugin-react/rules/jsx-closing-bracket-location.test.ts',
     './tests/eslint-plugin-react/rules/jsx-closing-tag-location.test.ts',
     './tests/eslint-plugin-react/rules/jsx-curly-brace-presence.test.ts',
+    './tests/eslint-plugin-react/rules/jsx-curly-newline.test.ts',
     './tests/eslint-plugin-react/rules/jsx-curly-spacing.test.ts',
     './tests/eslint-plugin-react/rules/jsx-wrap-multilines.test.ts',
     './tests/eslint-plugin-react/rules/no-access-state-in-setstate.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-react/rules/jsx-curly-newline.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react/rules/jsx-curly-newline.test.ts
@@ -1,0 +1,43 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+const multilineRequire = [{ singleline: 'consistent', multiline: 'require' }];
+
+ruleTester.run('jsx-curly-newline', {} as never, {
+  valid: [
+    { code: '<div>{foo}</div>', options: ['consistent'] },
+    { code: '<div>{\nfoo\n}</div>', options: ['consistent'] },
+    { code: '<div>{ foo &&\nfoo.bar }</div>', options: ['never'] },
+    { code: '<div>{\nfoo\n}</div>', options: multilineRequire },
+    { code: '<div foo={bar} />', options: multilineRequire },
+  ],
+  invalid: [
+    {
+      code: '<div>{ foo\n}</div>',
+      options: ['consistent'],
+      output: '<div>{ foo}</div>',
+      errors: [{ messageId: 'unexpectedBefore' }],
+    },
+    {
+      code: '<div>{\nfoo}</div>',
+      options: multilineRequire,
+      output: '<div>{\nfoo\n}</div>',
+      errors: [{ messageId: 'expectedBefore' }],
+    },
+    {
+      code: '<div>{\nfoo\n}</div>',
+      options: ['never'],
+      output: '<div>{foo}</div>',
+      errors: [
+        { messageId: 'unexpectedAfter' },
+        { messageId: 'unexpectedBefore' },
+      ],
+    },
+    {
+      code: '<div>{ foo &&\nbar }</div>',
+      options: multilineRequire,
+      output: '<div>{\n foo &&\nbar \n}</div>',
+      errors: [{ messageId: 'expectedAfter' }, { messageId: 'expectedBefore' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary
- add the `react/jsx-curly-newline` rule, schema, documentation, and React catalog registration
- migrate every eslint-plugin-react v7.37.5 upstream case (excluding Flow syntax) with exact runtime source and fixer output
- add tsgo edge-case, edit-demand, and JS integration coverage

## Verification
- `go test ./internal/plugins/react/rules/jsx_curly_newline`
- `golangci-lint run --new-from-merge-base=origin/main ./internal/plugins/react/rules/jsx_curly_newline ./internal/plugins/react`
- `pnpm run check-spell <changed files>`
- `pnpm run format:check`

## Remaining
- The JS integration test could not be rerun with a rebuilt native CLI: `pnpm --filter @rslint/core build:bin` failed because the environment hit its `/tmp` build disk quota.