### PR TITLE
feat: port rule unicorn/number-literal-case

### DIFF
--- a/internal/plugins/unicorn/all.go
+++ b/internal/plugins/unicorn/all.go
@@ -33,6 +33,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_unsafe_string_replacement"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_useless_switch_case"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/no_xor_as_exponentiation"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/number_literal_case"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_add_event_listener_options"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_array_flat"
 	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/prefer_array_flat_map"
@@ -85,6 +86,7 @@ func GetAllRules() []rule.Rule {
 		no_unsafe_string_replacement.NoUnsafeStringReplacementRule,
 		no_useless_switch_case.NoUselessSwitchCaseRule,
 		no_xor_as_exponentiation.NoXorAsExponentiationRule,
+		number_literal_case.NumberLiteralCaseRule,
 		prefer_add_event_listener_options.PreferAddEventListenerOptionsRule,
 		prefer_array_flat.PreferArrayFlatRule,
 		prefer_array_flat_map.PreferArrayFlatMapRule,

--- a/internal/plugins/unicorn/rules/number_literal_case/number_literal_case.go
+++ b/internal/plugins/unicorn/rules/number_literal_case/number_literal_case.go
@@ -1,0 +1,61 @@
+package number_literal_case
+
+import (
+	_ "embed"
+	"strings"
+
+	"github.com/microsoft/TypeScript/tsc/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+	"github.com/web-infra-dev/rslint/internal/utils/ecmascript"
+)
+
+//go:embed number_literal_case.schema.json
+var schemaJSON []byte
+
+var message = rule.RuleMessage{
+	Id:          "number-literal-case",
+	Description: "Invalid number literal casing.",
+}
+
+// https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/rules/number-literal-case.js
+var NumberLiteralCaseRule = rule.Rule{
+	Name:   "unicorn/number-literal-case",
+	Schema: rule.NewSchema(schemaJSON),
+	Run: func(ctx rule.RuleContext, options []any) rule.RuleListeners {
+		lowercaseHexadecimal := false
+		if len(options) > 0 {
+			if object, ok := options[0].(map[string]any); ok {
+				lowercaseHexadecimal = object["hexadecimalValue"] == "lowercase"
+			}
+		}
+
+		checkLiteral := func(node *ast.Node) {
+			// NumericLiteral.Text is normalized by tsgo; casing and separators
+			// must come from the original token instead.
+			raw := utils.TrimmedNodeText(ctx.SourceFile, node)
+			value := raw
+			if node.Kind == ast.KindBigIntLiteral {
+				value = strings.TrimSuffix(value, "n")
+			}
+			fixed := ecmascript.StringToLowerCase(value)
+			if strings.HasPrefix(fixed, "0x") && !lowercaseHexadecimal {
+				fixed = "0x" + ecmascript.StringToUpperCase(fixed[2:])
+			}
+			if node.Kind == ast.KindBigIntLiteral {
+				fixed += "n"
+			}
+			if raw == fixed {
+				return
+			}
+
+			ctx.ReportNodeWithDeferredFixes(node, message, func() []rule.RuleFix {
+				return []rule.RuleFix{rule.RuleFixReplace(ctx.SourceFile, node, fixed)}
+			})
+		}
+		return rule.RuleListeners{
+			ast.KindNumericLiteral: checkLiteral,
+			ast.KindBigIntLiteral:  checkLiteral,
+		}
+	},
+}

--- a/internal/plugins/unicorn/rules/number_literal_case/number_literal_case.md
+++ b/internal/plugins/unicorn/rules/number_literal_case/number_literal_case.md
@@ -1,0 +1,62 @@
+# number-literal-case
+
+## Rule Details
+
+Enforce lowercase radix prefixes (`0x`, `0o`, and `0b`) and a lowercase `e`
+in exponential notation. Hexadecimal digits use uppercase by default.
+The rule checks both numbers and BigInts and provides an automatic fix.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+const mask = 0xff;
+const flags = 0B1010n;
+const permissions = 0O755;
+const timeout = 1E3;
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+const mask = 0xFF;
+const flags = 0b1010n;
+const permissions = 0o755;
+const timeout = 1e3;
+```
+
+Numeric separators and the lowercase BigInt suffix `n` are preserved.
+Strings containing numeric-looking text are not checked.
+
+## Options
+
+### `hexadecimalValue`
+
+Type: `"uppercase" | "lowercase"`
+
+Default: `"uppercase"`
+
+Choose the case of hexadecimal digits. The `0x` prefix is always lowercase.
+
+```javascript
+{
+  'unicorn/number-literal-case': ['error', { hexadecimalValue: 'lowercase' }]
+}
+```
+
+With `hexadecimalValue: "lowercase"`, use `0xff` and `0xffn` instead of
+`0xFF` and `0xFFn`.
+
+## Differences from upstream
+
+Vue single-file components and template expressions are not supported by
+rslint's parser. For example, this rule does not check `{{ 1.2E3 }}` inside
+a Vue template.
+
+The TypeScript parser rejects legacy numeric spellings such as `0777` and
+`0888` before lint rules run, even in scripts. Upstream accepts these in
+sloppy-mode JavaScript and leaves them unchanged.
+
+## Original Documentation
+
+- [eslint-plugin-unicorn: number-literal-case](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/docs/rules/number-literal-case.md)
+- [Source code](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/rules/number-literal-case.js)

--- a/internal/plugins/unicorn/rules/number_literal_case/number_literal_case.schema.json
+++ b/internal/plugins/unicorn/rules/number_literal_case/number_literal_case.schema.json
@@ -1,0 +1,16 @@
+{
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "hexadecimalValue": {
+          "enum": ["uppercase", "lowercase"]
+        }
+      }
+    }
+  ],
+  "minItems": 0,
+  "maxItems": 1
+}

--- a/internal/plugins/unicorn/rules/number_literal_case/number_literal_case_extras_test.go
+++ b/internal/plugins/unicorn/rules/number_literal_case/number_literal_case_extras_test.go
@@ -1,0 +1,126 @@
+package number_literal_case_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/microsoft/TypeScript/tsc/shim/ast"
+	"github.com/microsoft/TypeScript/tsc/shim/core"
+	"github.com/microsoft/TypeScript/tsc/shim/parser"
+	"github.com/web-infra-dev/rslint/internal/linter"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/number_literal_case"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNumberLiteralCaseExtras(t *testing.T) {
+	valid := []rule_tester.ValidTestCase{
+		{Code: `const mask = 0xAB_CD;`, Options: map[string]any{}},
+		{Code: `const mask = 0xAB_CDn;`, Options: map[string]any{"hexadecimalValue": "uppercase"}},
+		{Code: `const values = [0xff, 0xab_cdn, 0b10, 0o76, 1e3];`, Options: map[string]any{"hexadecimalValue": "lowercase"}},
+		// Non-numeric tokens, including JSX text, must not be rewritten.
+		{Code: "const values = ['0Xff', /0Xff/, `0Xff`, true, false, null];"},
+		{Code: `const node = <div title="0Xff">0Xff</div>;`, Tsx: true},
+	}
+	invalid := []rule_tester.InvalidTestCase{
+		invalidLiteral(t, `const mask = 0xff;`, `const mask = 0xFF;`, "0xff", map[string]any{}),
+		invalidLiteral(t, `const mask = 0xabn;`, `const mask = 0xABn;`, "0xabn", map[string]any{"hexadecimalValue": "uppercase"}),
+		// Lowercase digits do not exempt radix prefixes or decimal exponents.
+		invalidLiteral(t, `const value = 0B1n;`, `const value = 0b1n;`, "0B1n", map[string]any{"hexadecimalValue": "lowercase"}),
+		invalidLiteral(t, `const value = 1E2;`, `const value = 1e2;`, "1E2", map[string]any{"hexadecimalValue": "lowercase"}),
+		// Source spans preserve parentheses, comments, signs and UTF-16 columns.
+		invalidLiteral(t, `const value = - /* sign */ ( /* before */ 0Xab /* after */ );`, `const value = - /* sign */ ( /* before */ 0xAB /* after */ );`, "0Xab", nil),
+		invalidLiteral(t, "const 文 = '😀';\n/*😀*/ const value = 0Xabn;", "const 文 = '😀';\n/*😀*/ const value = 0xABn;", "0Xabn", nil),
+		invalidLiteral(t, `const value = .5E+2;`, `const value = .5e+2;`, ".5E+2", nil),
+		invalidLiteral(t, `const value = 1_000E-1_0;`, `const value = 1_000e-1_0;`, "1_000E-1_0", nil),
+		// Numeric property names and computed/optional access are literals too.
+		invalidLiteral(t, `const object = {0Xab: true};`, `const object = {0xAB: true};`, "0Xab", nil),
+		invalidLiteral(t, `object?.[0Xab]`, `object?.[0xAB]`, "0Xab", nil),
+		invalidLiteral(t, `class C { #value = 0Xab; }`, `class C { #value = 0xAB; }`, "0Xab", nil),
+	}
+	for _, pair := range [][3]string{
+		{`type Mask = -0Xab;`, `type Mask = -0xAB;`, "0Xab"},
+		{`type Mask = 0Xabn;`, `type Mask = 0xABn;`, "0Xabn"},
+		{`enum Mask { All = 0Xab }`, `enum Mask { All = 0xAB }`, "0Xab"},
+		{`const value = (0Xab as number)!;`, `const value = (0xAB as number)!;`, "0Xab"},
+		{`const value = 0Xab satisfies number;`, `const value = 0xAB satisfies number;`, "0Xab"},
+	} {
+		item := invalidLiteral(t, pair[0], pair[1], pair[2], nil)
+		item.FileName = "file.ts"
+		invalid = append(invalid, item)
+	}
+	jsx := invalidLiteral(t, `const node = <div value={0Xab} />;`, `const node = <div value={0xAB} />;`, "0Xab", nil)
+	jsx.FileName = "file.tsx"
+	jsx.Tsx = true
+	invalid = append(invalid, jsx)
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &number_literal_case.NumberLiteralCaseRule, valid, invalid)
+}
+
+func TestNumberLiteralCaseSchema(t *testing.T) {
+	t.Parallel()
+	for _, options := range [][]any{
+		{}, {map[string]any{}},
+		{map[string]any{"hexadecimalValue": "uppercase"}},
+		{map[string]any{"hexadecimalValue": "lowercase"}},
+	} {
+		if err := number_literal_case.NumberLiteralCaseRule.Schema.Validate(options); err != nil {
+			t.Errorf("valid options %#v: %v", options, err)
+		}
+	}
+	for _, options := range [][]any{
+		{"lowercase"}, {nil},
+		{map[string]any{"hexadecimalValue": "mixed"}},
+		{map[string]any{"hexadecimalValue": false}},
+		{map[string]any{"unknown": true}},
+		{map[string]any{}, map[string]any{}},
+	} {
+		if err := number_literal_case.NumberLiteralCaseRule.Schema.Validate(options); err == nil {
+			t.Errorf("invalid options accepted: %#v", options)
+		}
+	}
+}
+
+func TestNumberLiteralCaseEditDemand(t *testing.T) {
+	t.Parallel()
+	const source = `const values = [0Xab, 0Xabn];`
+	const fixedSource = `const values = [0xAB, 0xABn];`
+	sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+		FileName: "/edit-demand.ts", Path: "/edit-demand.ts",
+	}, source, core.ScriptKindTS)
+
+	run := func(demand rule.EditDemand) []rule.RuleDiagnostic {
+		t.Helper()
+		diagnostics := lintLiteralSource(t, sourceFile, demand)
+		if len(diagnostics) != 2 {
+			t.Fatalf("demand %d: got %d diagnostics, want 2", demand, len(diagnostics))
+		}
+		return diagnostics
+	}
+
+	all := run(rule.EditDemandAll)
+	for _, demand := range []rule.EditDemand{rule.EditDemandNone, rule.EditDemandAutofix, rule.EditDemandSuggestion, rule.EditDemandAll} {
+		for index, diagnostic := range run(demand) {
+			if diagnostic.Suggestions != nil {
+				t.Errorf("demand %d: unexpected suggestions", demand)
+			}
+			if demand == rule.EditDemandAutofix || demand == rule.EditDemandAll {
+				if diagnostic.FixesPtr == nil || !reflect.DeepEqual(diagnostic.FixesPtr, all[index].FixesPtr) {
+					t.Errorf("demand %d: fixes differ from all-edits result", demand)
+				}
+			} else if diagnostic.FixesPtr != nil {
+				t.Errorf("demand %d: unexpected fixes", demand)
+			}
+			want := all[index]
+			want.FixesPtr = nil
+			diagnostic.FixesPtr = nil
+			if !reflect.DeepEqual(diagnostic, want) {
+				t.Errorf("demand %d changed diagnostic metadata", demand)
+			}
+		}
+	}
+	output, unapplied, fixed := linter.ApplyRuleFixes(source, all)
+	if !fixed || len(unapplied) != 0 || output != fixedSource {
+		t.Fatalf("fix result = %q, unapplied = %d, fixed = %v; want %q", output, len(unapplied), fixed, fixedSource)
+	}
+}

--- a/internal/plugins/unicorn/rules/number_literal_case/number_literal_case_upstream_test.go
+++ b/internal/plugins/unicorn/rules/number_literal_case/number_literal_case_upstream_test.go
@@ -1,0 +1,165 @@
+package number_literal_case_test
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf16"
+
+	"github.com/microsoft/TypeScript/tsc/shim/ast"
+	"github.com/microsoft/TypeScript/tsc/shim/core"
+	"github.com/microsoft/TypeScript/tsc/shim/parser"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/number_literal_case"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/test/number-literal-case.js
+func TestNumberLiteralCaseUpstream(t *testing.T) {
+	var valid []rule_tester.ValidTestCase
+	for _, value := range []string{
+		// Number and BigInt.
+		"1234", "0b10", "0o1234567", "0xABCDEF",
+		"1234n", "0b10n", "0o1234567n", "0xABCDEFn",
+		// Symbolic values and exponential notation.
+		"NaN", "+Infinity", "-Infinity", "1.2e3", "1.2e-3", "1.2e+3",
+		// Not numbers.
+		"'0Xff'", "'0Xffn'",
+		// Numeric separators.
+		"123_456", "0b10_10", "0o1_234_567", "0xDEED_BEEF",
+		"123_456n", "0b10_10n", "0o1_234_567n", "0xDEED_BEEFn",
+		// Negative numbers.
+		"-1234", "-0b10", "-0o1234567", "-0xABCDEF",
+	} {
+		valid = append(valid, rule_tester.ValidTestCase{Code: "const foo = " + value, FileName: "file.js"})
+	}
+
+	var invalid []rule_tester.InvalidTestCase
+	for _, pair := range [][2]string{
+		// Number and BigInt.
+		{"0B10", "0b10"}, {"0O1234567", "0o1234567"}, {"0XaBcDeF", "0xABCDEF"},
+		{"0B10n", "0b10n"}, {"0O1234567n", "0o1234567n"}, {"0XaBcDeFn", "0xABCDEFn"},
+		// BigInt zero.
+		{"0B0n", "0b0n"}, {"0O0n", "0o0n"}, {"0X0n", "0x0n"},
+		// Exponential notation, including integer mantissas.
+		{"1.2E3", "1.2e3"}, {"5E3", "5e3"}, {"5E+3", "5e+3"},
+		{"1.2E-3", "1.2e-3"}, {"1.2E+3", "1.2e+3"},
+		// Numeric separators and negative numbers.
+		{"0XdeEd_Beefn", "0xDEED_BEEFn"},
+		{"-0B10", "-0b10"}, {"-0O1234567", "-0o1234567"},
+		{"-0XaBcDeF", "-0xABCDEF"}, {"-0XaBcn", "-0xABCn"},
+	} {
+		invalid = append(invalid, invalidLiteral(t, "const foo = "+pair[0], "const foo = "+pair[1], strings.TrimPrefix(pair[0], "-"), nil))
+	}
+	const multiline = "const foo = 255;\n\nif (foo === 0xff) {\n\tconsole.log('invalid');\n}"
+	invalid = append(invalid, invalidLiteral(t, multiline, strings.Replace(multiline, "0xff", "0xFF", 1), "0xff", nil))
+	for _, pair := range [][2]string{
+		{"0XaBcDeF", "0xabcdef"}, {"0xaBcDeF", "0xabcdef"},
+		{"0XaBcDeFn", "0xabcdefn"}, {"0XdeEd_Beefn", "0xdeed_beefn"},
+	} {
+		invalid = append(invalid, invalidLiteral(t, "const foo = "+pair[0], "const foo = "+pair[1], pair[0], map[string]any{"hexadecimalValue": "lowercase"}))
+	}
+
+	// Upstream's Vue parser service is unavailable in rslint. Keep every Vue
+	// case visible rather than treating template text as JavaScript.
+	for _, code := range []string{
+		`<template><input value="0XdeEd_Beef"></div></template>`,
+		`<template><div v-if="0xDEED_BEEF > 0"></div></template>`,
+	} {
+		valid = append(valid, rule_tester.ValidTestCase{Code: code, Skip: true})
+	}
+	for _, code := range []string{
+		`<template><div v-if="0XdeEd_Beef > 0"></div></template>`,
+		`<template><div v-if="0XdeEd_Beefn > 0n"></div></template>`,
+		`<template><div>{{1.2E3}}</div></template>`,
+		`<template><div>{{0B1n}}</div></template>`,
+		`<script>export default {data() {return {n: 0XdeEd_Beefn}}}</script>`,
+	} {
+		invalid = append(invalid, rule_tester.InvalidTestCase{Code: code, Skip: true})
+	}
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &number_literal_case.NumberLiteralCaseRule, valid, invalid)
+}
+
+func TestNumberLiteralCaseUpstreamLegacyOctal(t *testing.T) {
+	t.Parallel()
+	// tsgo emits parse diagnostics for these sloppy-mode literals, which the
+	// Go RuleTester rejects. Check the rule on the parsed literals directly;
+	// neither legacy spelling needs a casing diagnostic or an edit.
+	for _, code := range []string{"var foo = 0777", "var foo = 0888"} {
+		sourceFile := parser.ParseSourceFile(ast.SourceFileParseOptions{
+			FileName: "/legacy.js", Path: "/legacy.js",
+		}, code, core.ScriptKindJS)
+		if diagnostics := lintLiteralSource(t, sourceFile, rule.EditDemandAll); len(diagnostics) != 0 {
+			t.Errorf("legacy literal %q: unexpected diagnostics: %#v", code, diagnostics)
+		}
+	}
+}
+
+// https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/docs/rules/number-literal-case.md
+func TestNumberLiteralCaseUpstreamDocumentation(t *testing.T) {
+	var valid []rule_tester.ValidTestCase
+	var invalid []rule_tester.InvalidTestCase
+	for _, pair := range [][2]string{
+		{"0XFF", "0xFF"}, {"0xff", "0xFF"}, {"0Xff", "0xFF"},
+		{"0Xffn", "0xFFn"}, {"0B10", "0b10"}, {"0B10n", "0b10n"},
+		{"0O76", "0o76"}, {"0O76n", "0o76n"},
+		{"2E-5", "2e-5"}, {"2E+5", "2e+5"}, {"2E5", "2e5"},
+	} {
+		invalid = append(invalid, invalidLiteral(t, "const foo = "+pair[0]+";", "const foo = "+pair[1]+";", pair[0], nil))
+		valid = append(valid, rule_tester.ValidTestCase{Code: "const foo = " + pair[1] + ";", FileName: "file.js"})
+	}
+	lowercase := map[string]any{"hexadecimalValue": "lowercase"}
+	for _, pair := range [][2]string{
+		{"0XFF", "0xff"}, {"0xFF", "0xff"}, {"0XFFn", "0xffn"}, {"0xFFn", "0xffn"},
+	} {
+		invalid = append(invalid, invalidLiteral(t, "const foo = "+pair[0]+";", "const foo = "+pair[1]+";", pair[0], lowercase))
+		valid = append(valid, rule_tester.ValidTestCase{Code: "const foo = " + pair[1] + ";", FileName: "file.js", Options: lowercase})
+	}
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &number_literal_case.NumberLiteralCaseRule, valid, invalid)
+}
+
+func invalidLiteral(t testing.TB, code, output, literal string, options any) rule_tester.InvalidTestCase {
+	t.Helper()
+	start := strings.Index(code, literal)
+	if literal == "" || start < 0 || strings.Count(code, literal) != 1 {
+		t.Fatalf("expected exactly one occurrence of %q in %q", literal, code)
+	}
+	line := strings.Count(code[:start], "\n") + 1
+	lineStart := strings.LastIndex(code[:start], "\n") + 1
+	column := len(utf16.Encode([]rune(code[lineStart:start]))) + 1
+	return rule_tester.InvalidTestCase{
+		Code: code, FileName: "file.js", Options: options, Output: []string{output},
+		Errors: []rule_tester.InvalidTestCaseError{{
+			MessageId: "number-literal-case", Message: "Invalid number literal casing.",
+			Line: line, Column: column, EndLine: line, EndColumn: column + len(literal),
+		}},
+	}
+}
+
+func lintLiteralSource(t testing.TB, sourceFile *ast.SourceFile, demand rule.EditDemand) []rule.RuleDiagnostic {
+	t.Helper()
+	var diagnostics []rule.RuleDiagnostic
+	comments := rule.NewCommentStore(sourceFile)
+	ctx := rule.RuleContext{
+		SourceFile: sourceFile, Comments: comments,
+		DisableManager: rule.NewDisableManager(sourceFile, comments),
+	}.WithDiagnosticConsumer(number_literal_case.NumberLiteralCaseRule.Name, rule.SeverityError, rule.DiagnosticConsumer{
+		Demand: demand,
+		Report: func(diagnostic rule.RuleDiagnostic) { diagnostics = append(diagnostics, diagnostic) },
+	})
+	listeners := number_literal_case.NumberLiteralCaseRule.Run(ctx, nil)
+	literalCount := 0
+	var visit ast.Visitor
+	visit = func(node *ast.Node) bool {
+		if listener := listeners[node.Kind]; listener != nil {
+			literalCount++
+			listener(node)
+		}
+		return node.ForEachChild(visit)
+	}
+	sourceFile.AsNode().ForEachChild(visit)
+	if literalCount == 0 {
+		t.Fatal("expected at least one numeric or BigInt literal")
+	}
+	return diagnostics
+}

--- a/packages/rslint-test-tools/rstack.config.mts
+++ b/packages/rslint-test-tools/rstack.config.mts
@@ -750,6 +750,7 @@ define.test({
     './tests/eslint-plugin-unicorn/rules/no-unsafe-string-replacement.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-useless-switch-case.test.ts',
     './tests/eslint-plugin-unicorn/rules/no-xor-as-exponentiation.test.ts',
+    './tests/eslint-plugin-unicorn/rules/number-literal-case.test.ts',
     './tests/eslint-plugin-unicorn/rules/prefer-add-event-listener-options.test.ts',
     './tests/eslint-plugin-unicorn/rules/prefer-array-flat.test.ts',
     './tests/eslint-plugin-unicorn/rules/prefer-array-flat-map.test.ts',

--- a/packages/rslint-test-tools/tests/cli/js-config/presets.test.ts
+++ b/packages/rslint-test-tools/tests/cli/js-config/presets.test.ts
@@ -182,6 +182,7 @@ describe('defineConfig and config presets', () => {
     expect(rec.rules?.['unicorn/empty-brace-spaces']).toBe('error');
     expect(rec.rules?.['unicorn/no-exports-in-scripts']).toBe('error');
     expect(rec.rules?.['unicorn/no-await-expression-member']).toBe('error');
+    expect(rec.rules?.['unicorn/number-literal-case']).toBe('error');
     expect(rec.rules?.['unicorn/prefer-date-now']).toBe('error');
   });
 });

--- a/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/number-literal-case.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/number-literal-case.test.ts
@@ -1,0 +1,121 @@
+// https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/test/number-literal-case.js
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+const valid = (code: string) => ({ code, filename: 'file.js' });
+const invalid = (code: string, output: string) => ({
+  code,
+  output,
+  filename: 'file.js',
+  errors: [
+    {
+      messageId: 'number-literal-case',
+      message: 'Invalid number literal casing.',
+    },
+  ],
+});
+
+ruleTester.run('number-literal-case', null as never, {
+  valid: [
+    ...[
+      // Number.
+      '1234',
+      '0b10',
+      '0o1234567',
+      '0xABCDEF',
+      // BigInt.
+      '1234n',
+      '0b10n',
+      '0o1234567n',
+      '0xABCDEFn',
+      // Symbolic values.
+      'NaN',
+      '+Infinity',
+      '-Infinity',
+      // Exponential notation.
+      '1.2e3',
+      '1.2e-3',
+      '1.2e+3',
+      // Not numbers.
+      "'0Xff'",
+      "'0Xffn'",
+      // Numeric separators.
+      '123_456',
+      '0b10_10',
+      '0o1_234_567',
+      '0xDEED_BEEF',
+      '123_456n',
+      '0b10_10n',
+      '0o1_234_567n',
+      '0xDEED_BEEFn',
+      // Negative numbers.
+      '-1234',
+      '-0b10',
+      '-0o1234567',
+      '-0xABCDEF',
+    ].map((value) => valid(`const foo = ${value}`)),
+  ],
+  invalid: [
+    ...[
+      // Number.
+      ['0B10', '0b10'],
+      ['0O1234567', '0o1234567'],
+      ['0XaBcDeF', '0xABCDEF'],
+      // BigInt.
+      ['0B10n', '0b10n'],
+      ['0O1234567n', '0o1234567n'],
+      ['0XaBcDeFn', '0xABCDEFn'],
+      // BigInt zero.
+      ['0B0n', '0b0n'],
+      ['0O0n', '0o0n'],
+      ['0X0n', '0x0n'],
+      // Exponential notation, including integer mantissas.
+      ['1.2E3', '1.2e3'],
+      ['5E3', '5e3'],
+      ['5E+3', '5e+3'],
+      ['1.2E-3', '1.2e-3'],
+      ['1.2E+3', '1.2e+3'],
+      // Numeric separators.
+      ['0XdeEd_Beefn', '0xDEED_BEEFn'],
+      // Negative numbers.
+      ['-0B10', '-0b10'],
+      ['-0O1234567', '-0o1234567'],
+      ['-0XaBcDeF', '-0xABCDEF'],
+      ['-0XaBcn', '-0xABCn'],
+    ].map(([value, fixed]) =>
+      invalid(`const foo = ${value}`, `const foo = ${fixed}`),
+    ),
+    invalid(
+      "const foo = 255;\n\nif (foo === 0xff) {\n\tconsole.log('invalid');\n}",
+      "const foo = 255;\n\nif (foo === 0xFF) {\n\tconsole.log('invalid');\n}",
+    ),
+    // Lowercase hexadecimal values.
+    ...[
+      ['0XaBcDeF', '0xabcdef'],
+      ['0xaBcDeF', '0xabcdef'],
+      ['0XaBcDeFn', '0xabcdefn'],
+      ['0XdeEd_Beefn', '0xdeed_beefn'],
+    ].map(([value, fixed]) => ({
+      ...invalid(`const foo = ${value}`, `const foo = ${fixed}`),
+      options: [{ hexadecimalValue: 'lowercase' }],
+    })),
+  ],
+});
+
+// tsgo rejects these sloppy-mode literals before running rules (TS1121/TS1489).
+// The Go upstream suite checks their casing directly on the parsed literals.
+test.skip.each(['var foo = 0777', 'var foo = 0888'])(
+  'Legacy literal parser limitation: %s',
+  () => {},
+);
+
+// rslint does not provide the Vue parser service used by these upstream cases.
+test.skip.each([
+  '<template><input value="0XdeEd_Beef"></div></template>',
+  '<template><div v-if="0xDEED_BEEF > 0"></div></template>',
+  '<template><div v-if="0XdeEd_Beef > 0"></div></template>',
+  '<template><div v-if="0XdeEd_Beefn > 0n"></div></template>',
+  '<template><div>{{1.2E3}}</div></template>',
+  '<template><div>{{0B1n}}</div></template>',
+  '<script>export default {data() {return {n: 0XdeEd_Beefn}}}</script>',
+])('Vue parser service: %s', () => {});

--- a/packages/rslint/src/config/presets/unicorn.ts
+++ b/packages/rslint/src/config/presets/unicorn.ts
@@ -200,7 +200,7 @@ const recommended: RslintConfigEntry = {
     // 'unicorn/no-useless-undefined': 'error', // not implemented
     'unicorn/no-xor-as-exponentiation': 'error',
     // 'unicorn/no-zero-fractions': 'error', // not implemented
-    // 'unicorn/number-literal-case': 'error', // not implemented
+    'unicorn/number-literal-case': 'error',
     // 'unicorn/numeric-separators-style': 'error', // not implemented
     // 'unicorn/operator-assignment': 'error', // not implemented
     // 'unicorn/prefer-abort-signal-any': 'error', // not implemented


### PR DESCRIPTION
## Summary

Port `unicorn/number-literal-case` from eslint-plugin-unicorn v74.0.0.

The rule enforces lowercase radix prefixes and exponent markers for numbers and BigInts, with configurable hexadecimal digit casing and automatic fixes.

- Support `hexadecimalValue: "uppercase" | "lowercase"`, defaulting to `"uppercase"`.
- Preserve numeric separators, BigInt suffixes, comments, and surrounding syntax when fixing literals.
- Register the rule and its options schema in the native Unicorn catalog.
- Migrate upstream tests and documentation examples.
- Add Go coverage for TypeScript, JSX, UTF-16 diagnostic positions, option validation, and edit-demand modes.
- Add JS integration tests and document parser limitations.

Seven Vue cases and two legacy numeric-literal cases are explicitly skipped in JS integration because of existing parser limitations. The legacy literals are additionally checked directly against the Go rule using parsed AST nodes.

The rule is enabled at `error` severity in the Unicorn recommended preset, matching upstream.

## Related Links

- Tracking issue: #1309
- [Upstream documentation](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/docs/rules/number-literal-case.md)
- [Upstream source](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/rules/number-literal-case.js)
- [Upstream tests](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v74.0.0/test/number-literal-case.js)

## Validation

- Go upstream, edge-case, schema, and edit-demand tests passed, with 100% statement coverage for the rule package.
- Rule catalog registration check passed.
- Targeted Unicorn recommended-preset test passed with one worker.
- JS rule integration tests passed, with the parser-related skips described above.
- Core native and JS builds passed, including schema and public rule-option type generation.
- Scoped Go lint, formatting, spelling checks, repository `pnpm run format:check`, and `git diff --check` passed.

Verification used reduced concurrency. No full-repository or whole-plugin test suites were run.

## Checklist

- [x] Tests updated.
- [x] Documentation updated.
